### PR TITLE
✨  AppContext og fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,17 +23,20 @@
     "@navikt/ds-react": "^5.5.0",
     "@navikt/ds-react-internal": "^3.4.3",
     "@navikt/ds-tokens": "^5.3.4",
+    "constate": "^3.3.2",
     "data-fns": "^1.1.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.16.0",
-    "styled-components": "^6.0.7"
+    "styled-components": "^6.0.7",
+    "uuid": "^9.0.1"
   },
   "devDependencies": {
     "@babel/core": "^7.22.15",
     "@babel/preset-env": "^7.22.15",
     "@types/react": "^18.2.21",
     "@types/react-dom": "^18.2.7",
+    "@types/uuid": "^9.0.4",
     "@types/webpack-hot-middleware": "^2.25.6",
     "@typescript-eslint/eslint-plugin": "^6.7.0",
     "@typescript-eslint/parser": "^6.7.0",

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -4,13 +4,14 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import { InternalHeader, Spacer } from '@navikt/ds-react';
 
+import { AppProvider } from './context/AppContext';
 import { Sticky } from './komponenter/Visningskomponenter/Sticky';
 import BehandlingContainer from './Sider/Behandling/BehandlingContainer';
 import Personoversikt from './Sider/Personoversikt/Personoversikt';
 
 const App: React.FC = () => {
     return (
-        <>
+        <AppProvider>
             <Sticky>
                 <InternalHeader>
                     <InternalHeader.Title as="h1">Tilleggsstønader</InternalHeader.Title>
@@ -24,7 +25,7 @@ const App: React.FC = () => {
                     <Route path={'/behandling/:behandlingId/*'} element={<BehandlingContainer />} />
                 </Routes>
             </BrowserRouter>
-        </>
+        </AppProvider>
     );
 };
 

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -1,0 +1,51 @@
+import { useCallback } from 'react';
+
+import constate from 'constate';
+import { v4 as uuidv4 } from 'uuid';
+
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../typer/ressurs';
+import { feilmeldingMedCallId, håndterFeil, håndterSuksess } from '../utils/fetch';
+
+const [AppProvider, useApp] = constate(() => {
+    const request = useCallback(
+        <ResponseData, RequestData>(
+            url: string,
+            method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'UPDATE' = 'GET',
+            data: RequestData
+        ): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
+            const requestId = uuidv4().replaceAll('-', '');
+
+            return fetch(url, {
+                body: JSON.stringify(data),
+                method: method,
+                headers: {
+                    'Content-Type': 'application/json',
+                    'x-request-id': requestId,
+                },
+            })
+                .then((res): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
+                    if (res.ok) {
+                        return håndterSuksess<ResponseData>(res).then((suksess) => suksess);
+                    } else {
+                        return håndterFeil(res, res.headers).then((feil) => feil);
+                    }
+                })
+                .catch((error) => {
+                    // TODO: sjekk for 401
+
+                    return {
+                        status: RessursStatus.FEILET,
+                        frontendFeilmelding: feilmeldingMedCallId(error.detail, error.headers),
+                        melding: error.detail,
+                    };
+                });
+        },
+        []
+    );
+
+    return {
+        request,
+    };
+});
+
+export { AppProvider, useApp };

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -1,47 +1,11 @@
 import { useCallback } from 'react';
 
 import constate from 'constate';
-import { v4 as uuidv4 } from 'uuid';
 
-import { RessursFeilet, RessursStatus, RessursSuksess } from '../typer/ressurs';
-import { feilmeldingMedCallId, håndterFeil, håndterSuksess } from '../utils/fetch';
+import { fetchFn } from '../utils/fetch';
 
 const [AppProvider, useApp] = constate(() => {
-    const request = useCallback(
-        <ResponseData, RequestData>(
-            url: string,
-            method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'UPDATE' = 'GET',
-            data: RequestData
-        ): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
-            const requestId = uuidv4().replaceAll('-', '');
-
-            return fetch(url, {
-                body: JSON.stringify(data),
-                method: method,
-                headers: {
-                    'Content-Type': 'application/json',
-                    'x-request-id': requestId,
-                },
-            })
-                .then((res): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
-                    if (res.ok) {
-                        return håndterSuksess<ResponseData>(res);
-                    } else {
-                        return håndterFeil(res, res.headers);
-                    }
-                })
-                .catch((error) => {
-                    // TODO: sjekk for 401
-
-                    return {
-                        status: RessursStatus.FEILET,
-                        frontendFeilmelding: feilmeldingMedCallId(error.detail, error.headers),
-                        melding: error.detail,
-                    };
-                });
-        },
-        []
-    );
+    const request = useCallback(fetchFn, []); // Saksbehandler skal inn som dep etter hvert
 
     return {
         request,

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -25,9 +25,9 @@ const [AppProvider, useApp] = constate(() => {
             })
                 .then((res): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
                     if (res.ok) {
-                        return håndterSuksess<ResponseData>(res).then((suksess) => suksess);
+                        return håndterSuksess<ResponseData>(res);
                     } else {
-                        return håndterFeil(res, res.headers).then((feil) => feil);
+                        return håndterFeil(res, res.headers);
                     }
                 })
                 .catch((error) => {

--- a/src/frontend/komponenter/DataViewer.tsx
+++ b/src/frontend/komponenter/DataViewer.tsx
@@ -1,6 +1,8 @@
 import React, { ReactElement, ReactNode } from 'react';
 
-import { Ressurs, RessursStatus, RessursSuksess } from '../typer/ressurs';
+import { Alert } from '@navikt/ds-react';
+
+import { erFeilressurs, Ressurs, RessursStatus, RessursSuksess } from '../typer/ressurs';
 
 /**
  * Input: { behandling: Ressurss<Behandling>, personopslyninger: Ressurss<IPersonopplysninger> }
@@ -32,7 +34,18 @@ function DataViewer<T extends Record<string, unknown>>(
 ): JSX.Element | null {
     const { response, children } = props;
     const responses = Object.values(response);
-    if (responses.every((response) => response.status === RessursStatus.SUKSESS)) {
+
+    if (responses.some(erFeilressurs)) {
+        return (
+            <>
+                {responses.filter(erFeilressurs).map((feilet, index) => (
+                    <Alert key={index} variant={'error'}>
+                        {feilet.frontendFeilmelding}
+                    </Alert>
+                ))}
+            </>
+        );
+    } else if (responses.every((response) => response.status === RessursStatus.SUKSESS)) {
         return renderChildren(children, response);
     } else {
         return null;

--- a/src/frontend/typer/ressurs.ts
+++ b/src/frontend/typer/ressurs.ts
@@ -23,7 +23,7 @@ type FeilMelding = {
     frontendFeilmeldingUtenFeilkode?: string;
 };
 
-type RessursFeilet =
+export type RessursFeilet =
     | (FeilMelding & { status: RessursStatus.IKKE_TILGANG })
     | (FeilMelding & { status: RessursStatus.FEILET })
     | (FeilMelding & { status: RessursStatus.FUNKSJONELL_FEIL });
@@ -39,9 +39,13 @@ export const byggTomRessurs = <T>(): Ressurs<T> => {
         status: RessursStatus.IKKE_HENTET,
     };
 };
-
 export const harNoenRessursMedStatus = (
     // eslint-disable-next-line
     ressurser: Ressurs<any>[],
     ...status: RessursStatus[]
 ): boolean => ressurser.some((ressurs) => status.includes(ressurs.status));
+
+export const erFeilressurs = <T>(response: Ressurs<T>): response is RessursFeilet =>
+    response.status === RessursStatus.FEILET ||
+    response.status === RessursStatus.FUNKSJONELL_FEIL ||
+    response.status === RessursStatus.IKKE_TILGANG;

--- a/src/frontend/utils/fetch.ts
+++ b/src/frontend/utils/fetch.ts
@@ -7,6 +7,7 @@ export const håndterSuksess = <ResponseData>(
         data: data as ResponseData,
         status: RessursStatus.SUKSESS,
     }));
+
 export const håndterFeil = (res: Response, headers: Headers): Promise<RessursFeilet> =>
     res.json().then((res) => {
         return {
@@ -15,6 +16,7 @@ export const håndterFeil = (res: Response, headers: Headers): Promise<RessursFe
             melding: res.detail,
         };
     });
+
 export const feilmeldingMedCallId = (feilmelding: string, headers?: Headers): string => {
     const callId = headers?.get('Nav-Call-id');
     return `${feilmelding}. Feilkode: ${callId}`;

--- a/src/frontend/utils/fetch.ts
+++ b/src/frontend/utils/fetch.ts
@@ -1,0 +1,21 @@
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../typer/ressurs';
+
+export const håndterSuksess = <ResponseData>(
+    res: Response
+): Promise<RessursSuksess<ResponseData>> =>
+    res.json().then((data) => ({
+        data: data as ResponseData,
+        status: RessursStatus.SUKSESS,
+    }));
+export const håndterFeil = (res: Response, headers: Headers): Promise<RessursFeilet> =>
+    res.json().then((res) => {
+        return {
+            status: RessursStatus.FEILET,
+            frontendFeilmelding: feilmeldingMedCallId(res.detail, headers),
+            melding: res.detail,
+        };
+    });
+export const feilmeldingMedCallId = (feilmelding: string, headers?: Headers): string => {
+    const callId = headers?.get('Nav-Call-id');
+    return `${feilmelding}. Feilkode: ${callId}`;
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,11 @@
     "forceConsistentCasingInFileNames": true,
     "noFallthroughCasesInSwitch": true,
     "sourceMap": true,
-    "jsx": "react"
+    "jsx": "react",
+    "lib": [
+      "ESNext",
+      "dom"
+    ]
   },
   "exclude": [
     "node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1545,6 +1545,11 @@
   resolved "https://registry.yarnpkg.com/@types/stylis/-/stylis-4.2.0.tgz#199a3f473f0c3a6f6e4e1b17cdbc967f274bdc6b"
   integrity sha512-n4sx2bqL0mW1tvDf/loQ+aMX7GQD3lc3fkCMC55VFNDu/vBOabO+LTIeXKM14xK0ppk5TUGcWRjiSpIlUpghKw==
 
+"@types/uuid@^9.0.4":
+  version "9.0.4"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-9.0.4.tgz#e884a59338da907bda8d2ed03e01c5c49d036f1c"
+  integrity sha512-zAuJWQflfx6dYJM62vna+Sn5aeSWhh3OB+wfUEACNcqUSc0AGc5JKl+ycL1vrH7frGTXhJchYjE1Hak8L819dA==
+
 "@types/webpack-hot-middleware@^2.25.6":
   version "2.25.6"
   resolved "https://registry.yarnpkg.com/@types/webpack-hot-middleware/-/webpack-hot-middleware-2.25.6.tgz#4336abd668dc73284a777907cfd00147e794354a"
@@ -2284,6 +2289,11 @@ concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
   integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
+
+constate@^3.3.2:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/constate/-/constate-3.3.2.tgz#a6cd2f3c203da2cb863f47d22a330b833936c449"
+  integrity sha512-ZnEWiwU6QUTil41D5EGpA7pbqAPGvnR9kBjko8DzVIxpC60mdNKrP568tT5WLJPAxAOtJqJw60+h79ot/Uz1+Q==
 
 convert-source-map@^1.1.0, convert-source-map@^1.7.0:
   version "1.9.0"
@@ -5038,6 +5048,11 @@ utila@~0.4:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/utila/-/utila-0.4.0.tgz#8a16a05d445657a3aea5eecc5b12a4fa5379772c"
   integrity sha512-Z0DbgELS9/L/75wZbro8xAnT50pBVFQZ+hUEueGDU5FN51YSCYM+jdxsfCiHjwNP/4LCDD0i/graKpeBnOXKRA==
+
+uuid@^9.0.1:
+  version "9.0.1"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-9.0.1.tgz#e188d4c8853cc722220392c424cd637f32293f30"
+  integrity sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==
 
 warning@^4.0.3:
   version "4.0.3"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi ønsker å bruke Ressurs i frontend for å kunne bruke dataviewer-komponenten og for å få typede responser.


Eksempel på bruk:
```js
const { request } = useApp();
const [nyBehandlingRessurs, settNyBehandlingRessurs] = useState<Ressurs<string>>(byggTomRessurs());

const opprettBehandling = () => {
    request<string, { personIdent: string }>(`/api/sak/test/opprett-behandling`, 'POST', {
        personIdent: personIdent,
    }).then(settNyBehandlingRessurs);
};
```

Denne kan utvides med mer funksjonalitet, men dette er en start for å kunne gjøre enkle fetch kall 🤠 

**Hva mangler?**
* Håndtering av 401
* Håndtering av IKKE_TILGANG
* Logging ved feil
