### PR TITLE
✨  Behandlingscontext

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingContainer.tsx
@@ -1,13 +1,35 @@
-import React from 'react';
+import React, { useCallback, useState } from 'react';
 
 import { useParams } from 'react-router-dom';
 
 import BehandlingInnhold from './BehandlingInnhold';
+import { useApp } from '../../context/AppContext';
+import { useRerunnableEffect } from '../../hooks/useRerunnableEffect';
+import DataViewer from '../../komponenter/DataViewer';
+import { Behandling } from '../../typer/behandling/behandling';
+import { byggTomRessurs, Ressurs } from '../../typer/ressurs';
 
 const BehandlingContainer = () => {
-    const behandlingId = useParams<{ fagsakPersonId: string }>().fagsakPersonId as string;
+    const { request } = useApp();
+    const [behandling, settBehandling] = useState<Ressurs<Behandling>>(byggTomRessurs());
 
-    return <BehandlingInnhold behandlingId={behandlingId} />;
+    const behandlingId = useParams<{
+        behandlingId: string;
+    }>().behandlingId as string;
+
+    const hentBehandlingCallback = useCallback(() => {
+        request<Behandling, null>(`/api/sak/behandling/${behandlingId}`).then(settBehandling);
+    }, [request, behandlingId]);
+
+    const hentBehandling = useRerunnableEffect(hentBehandlingCallback, [behandlingId]);
+
+    return (
+        <DataViewer response={{ behandling }}>
+            {({ behandling }) => (
+                <BehandlingInnhold behandling={behandling} hentBehandling={hentBehandling} />
+            )}
+        </DataViewer>
+    );
 };
 
 export default BehandlingContainer;

--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -5,25 +5,32 @@ import styled from 'styled-components';
 
 import Fanemeny from './Fanemeny/Fanemeny';
 import { behandlingFaner } from './Fanemeny/faner';
+import { BehandlingProvider } from '../../context/BehandlingContext';
+import { RerrunnableEffect } from '../../hooks/useRerunnableEffect';
+import { Behandling } from '../../typer/behandling/behandling';
 
 const InnholdWrapper = styled.div`
     padding: 1rem;
 `;
 
-const BehandlingInnhold: React.FC<{ behandlingId: string }> = ({ behandlingId }) => {
+const BehandlingInnhold: React.FC<{
+    behandling: Behandling;
+    hentBehandling: RerrunnableEffect;
+}> = ({ behandling, hentBehandling }) => {
     const paths = useLocation().pathname.split('/').slice(-1);
+
     const path = paths.length ? paths[paths.length - 1] : '';
 
     return (
-        <>
-            <Fanemeny behandlingId={behandlingId} aktivFane={path} />
+        <BehandlingProvider behandling={behandling} hentBehandling={hentBehandling}>
+            <Fanemeny behandlingId={behandling.id} aktivFane={path} />
             <InnholdWrapper>
                 <Routes>
                     {behandlingFaner.map((tab) => (
                         <Route
                             key={tab.path}
                             path={`/${tab.path}`}
-                            element={tab.komponent(behandlingId)}
+                            element={tab.komponent(behandling.id)}
                         />
                     ))}
                     <Route
@@ -32,7 +39,7 @@ const BehandlingInnhold: React.FC<{ behandlingId: string }> = ({ behandlingId })
                     />
                 </Routes>
             </InnholdWrapper>
-        </>
+        </BehandlingProvider>
     );
 };
 

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -1,0 +1,8 @@
+import constate from 'constate';
+
+import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
+import { Behandling } from '../typer/behandling/behandling';
+
+export const [BehandlingProvider, useBehandling] = constate(
+    (props: { behandling: Behandling; hentBehandling: RerrunnableEffect }) => props
+);

--- a/src/frontend/hooks/useRerunnableEffect.ts
+++ b/src/frontend/hooks/useRerunnableEffect.ts
@@ -1,0 +1,21 @@
+import { DependencyList, EffectCallback, useEffect, useMemo, useState } from 'react';
+
+export interface RerrunnableEffect {
+    rerun: () => void;
+}
+
+export function useRerunnableEffect(
+    effect: EffectCallback,
+    deps?: DependencyList
+): RerrunnableEffect {
+    const [rerun, setRerun] = useState<number>(0);
+    const allDeps = useMemo(() => [rerun, ...(deps ?? [])], [rerun, deps]);
+    // eslint-disable-next-line
+    useEffect(effect, allDeps);
+    return useMemo(
+        () => ({
+            rerun: () => setRerun((prev) => prev + 1),
+        }),
+        [setRerun]
+    );
+}

--- a/src/frontend/utils/fetch.ts
+++ b/src/frontend/utils/fetch.ts
@@ -5,7 +5,7 @@ import { RessursFeilet, RessursStatus, RessursSuksess } from '../typer/ressurs';
 export const fetchFn = <ResponseData, RequestData>(
     url: string,
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'UPDATE' = 'GET',
-    data: RequestData
+    data?: RequestData
 ): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
     const requestId = uuidv4().replaceAll('-', '');
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi ønsker å ha `behandling` tilgjengelig i context for å slippe å sende den som props. 

Litt usikker på hvordan vi vil gjøre dette, men la det opp litt annerledes enn i ef-sak.

Forskjellen på denne og ef-saks hook:
- Denne returnerer `Behandling`
- ef-sak returnerer `Ressurs<Behandling>`

Det betyr at hele behandlingscontaineren re-rendres hver gang man kjører `hentBehandling.rerun()` Fordelen er at komponentene i containeren kan bruke `behandling` direkte, uten å forholde seg til ressurs. Hva tenker dere om det @sarahjelle @blommish ?
