### PR TITLE
Vedtak beregning - velg resultat for behandling

### DIFF
--- a/src/frontend/Sider/Behandling/Fanemeny/faner.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/faner.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import Brev from '../Brev/Brev';
 import Inngangsvilkår from '../Inngangsvilkår/Inngangsvilkår';
+import VedtakOgBeregningBarnetilsyn from '../VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn';
 
 export type FanerMedRouter = {
     navn: FaneNavn;
@@ -32,7 +33,7 @@ export const behandlingFaner: FanerMedRouter[] = [
     {
         navn: FaneNavn.VEDTAK_OG_BEREGNING,
         path: 'vedtak-og-beregning',
-        komponent: () => <p>Vedtak og beregning</p>,
+        komponent: () => <VedtakOgBeregningBarnetilsyn />,
     },
     {
         navn: FaneNavn.SIMULERING,

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -1,0 +1,19 @@
+import React, { FC, useState } from 'react';
+
+import { BehandlingResultat } from '../../../../typer/behandling/behandlingResultat';
+import SelectVedtaksresultat from '../Felles/SelectVedtaksresultat';
+
+const VedtakOgBeregningBarnetilsyn: FC = () => {
+    const [resultatType, settResultatType] = useState<BehandlingResultat | undefined>();
+
+    return (
+        <>
+            <SelectVedtaksresultat
+                resultatType={resultatType}
+                settResultatType={settResultatType}
+            />
+        </>
+    );
+};
+
+export default VedtakOgBeregningBarnetilsyn;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -6,12 +6,26 @@ import SelectVedtaksresultat from '../Felles/SelectVedtaksresultat';
 const VedtakOgBeregningBarnetilsyn: FC = () => {
     const [resultatType, settResultatType] = useState<BehandlingResultat | undefined>();
 
+    const test = () => {
+        switch (resultatType) {
+            case BehandlingResultat.INNVILGET:
+                return <p>Innvilge</p>;
+
+            case undefined:
+                break;
+
+            default:
+                return <p>Ikke implementert</p>;
+        }
+    };
+
     return (
         <>
             <SelectVedtaksresultat
                 resultatType={resultatType}
                 settResultatType={settResultatType}
             />
+            {test()}
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -6,7 +6,7 @@ import SelectVedtaksresultat from '../Felles/SelectVedtaksresultat';
 const VedtakOgBeregningBarnetilsyn: FC = () => {
     const [resultatType, settResultatType] = useState<BehandlingResultat | undefined>();
 
-    const test = () => {
+    const utledVedtakForm = () => {
         switch (resultatType) {
             case BehandlingResultat.INNVILGET:
                 return <p>Innvilge</p>;
@@ -25,7 +25,7 @@ const VedtakOgBeregningBarnetilsyn: FC = () => {
                 resultatType={resultatType}
                 settResultatType={settResultatType}
             />
-            {test()}
+            {utledVedtakForm()}
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -1,0 +1,46 @@
+import React, { FC } from 'react';
+
+import { Heading } from '@navikt/ds-react';
+
+import { useBehandling } from '../../../../context/BehandlingContext';
+import Select from '../../../../komponenter/Skjema/Select';
+import {
+    BehandlingResultat,
+    behandlingResultatTilTekst,
+} from '../../../../typer/behandling/behandlingResultat';
+
+interface Props {
+    resultatType?: BehandlingResultat;
+    settResultatType: (val: BehandlingResultat | undefined) => void;
+}
+
+const SelectVedtaksresultat: FC<Props> = ({ resultatType, settResultatType }) => {
+    const { behandlingErRedigerbar } = useBehandling();
+    // const { settIkkePersistertKomponent } = useApp();
+
+    return (
+        <div>
+            <Heading spacing size="small">
+                Vedtaksresultat
+            </Heading>
+            <Select
+                erLesevisning={!behandlingErRedigerbar}
+                label={'Vedtaksresultat'}
+                hideLabel
+                value={resultatType || ''}
+                onChange={(e) => {
+                    const vedtaksresultat =
+                        e.target.value === '' ? undefined : (e.target.value as BehandlingResultat);
+                    settResultatType(vedtaksresultat);
+                    // settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
+                }}
+                lesevisningVerdi={resultatType && behandlingResultatTilTekst[resultatType]}
+            >
+                <option value="">Velg</option>
+                <option value={BehandlingResultat.INNVILGET}>Innvilge</option>
+            </Select>
+        </div>
+    );
+};
+
+export default SelectVedtaksresultat;

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -3,6 +3,19 @@ import constate from 'constate';
 import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
 import { Behandling } from '../typer/behandling/behandling';
 
+interface Props {
+    behandling: Behandling;
+    hentBehandling: RerrunnableEffect;
+}
+
 export const [BehandlingProvider, useBehandling] = constate(
-    (props: { behandling: Behandling; hentBehandling: RerrunnableEffect }) => props
+    ({ behandling, hentBehandling }: Props) => {
+        const behandlingErRedigerbar = true;
+
+        return {
+            behandling,
+            behandlingErRedigerbar,
+            hentBehandling,
+        };
+    }
 );

--- a/src/frontend/komponenter/Skjema/Lesefelt.tsx
+++ b/src/frontend/komponenter/Skjema/Lesefelt.tsx
@@ -1,0 +1,21 @@
+import React, { FC } from 'react';
+
+import { BodyShort, Label, LabelProps } from '@navikt/ds-react';
+
+interface Props {
+    className?: string;
+    label?: React.ReactNode;
+    verdi?: string | readonly string[] | number;
+    size?: LabelProps['size'];
+}
+
+const Lesefelt: FC<Props> = ({ className, label, verdi, size }) => {
+    return (
+        <div className={className}>
+            {label !== undefined && <Label size={size}>{label}</Label>}
+            <BodyShort size={size}>{verdi}</BodyShort>
+        </div>
+    );
+};
+
+export default Lesefelt;

--- a/src/frontend/komponenter/Skjema/Select.tsx
+++ b/src/frontend/komponenter/Skjema/Select.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react';
+
+import { Select as AkselSelect, SelectProps } from '@navikt/ds-react';
+
+import Lesefelt from './Lesefelt';
+
+interface Props extends SelectProps {
+    erLesevisning: boolean;
+    lesevisningVerdi?: string;
+}
+
+const Select: FC<Props> = ({
+    children,
+    className,
+    erLesevisning = false,
+    label,
+    lesevisningVerdi,
+    value,
+    size,
+    hideLabel,
+    ...props
+}) => {
+    return erLesevisning ? (
+        <Lesefelt
+            label={!hideLabel && label}
+            verdi={lesevisningVerdi ? lesevisningVerdi : value}
+            className={className}
+            size={size}
+        />
+    ) : (
+        <AkselSelect
+            className={className}
+            label={label}
+            value={value}
+            size={size}
+            hideLabel={hideLabel}
+            {...props}
+        >
+            {children}
+        </AkselSelect>
+    );
+};
+
+export default Select;

--- a/src/frontend/typer/behandling/behandlingResultat.ts
+++ b/src/frontend/typer/behandling/behandlingResultat.ts
@@ -5,3 +5,11 @@ export enum BehandlingResultat {
     AVSLÅTT = 'AVSLÅTT',
     OPPHØRT = 'OPPHØRT',
 }
+
+export const behandlingResultatTilTekst: Record<BehandlingResultat, string> = {
+    INNVILGET: 'Innvilget',
+    IKKE_SATT: 'Ikke satt',
+    AVSLÅTT: 'Avslått',
+    HENLAGT: 'Henlagt',
+    OPPHØRT: 'Opphørt',
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Start på vedtak og beregning. 
Skal være mulig å velge ønsket resultat og rendre innhold basert på valg. 

OBS: mest sannsynlig forsvinner funksjonen med switch dersom vi får inn en dataviewer

### Bilder 🎨 
<img width="1090" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/dfa1e4ba-f12c-49dd-9876-5412fbecf87c">
