### PR TITLE
Fjerne warning om non-string props

### DIFF
--- a/src/frontend/Sider/Behandling/Fanemeny/Fane.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/Fane.tsx
@@ -57,8 +57,6 @@ const Lenke = styled(NavLink)`
     height: 100%;
 `;
 
-const Tekst = styled(BodyShort)<{ deaktivert?: boolean }>``;
-
 interface Props {
     fane: FanerMedRouter;
     behandlingId: string;
@@ -72,16 +70,16 @@ const Fane: React.FC<Props> = ({ fane, behandlingId, index, deaktivert, erAktivF
         <>
             {deaktivert ? (
                 <Container>
-                    <Tekst size="small" deaktivert>
+                    <BodyShort size="small">
                         {index + 1}. {fane.navn}
-                    </Tekst>
+                    </BodyShort>
                 </Container>
             ) : (
                 <Lenke key={fane.navn} to={`/behandling/${behandlingId}/${fane.path}`}>
                     <ContainerAktivert className={erAktivFane ? 'active' : ''}>
-                        <Tekst size="small">
+                        <BodyShort size="small">
                             {index + 1}. {fane.navn}
-                        </Tekst>
+                        </BodyShort>
                     </ContainerAktivert>
                 </Lenke>
             )}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi fikk warning om at vi prøvde å sende en bolsk verdi når man forventet en ikke-bolsk verdi i styled component. Dette kan unngås ved å bruke `$` foran navnet slik at props som er ment for styled components ikke rendres til DOM elementet, les [HER](https://styled-components.com/docs/api#transient-props).

Nå kunne hele variabelen slettes fordi det var en styled component uten noe styling 😎 