### PR TITLE
🧑‍💻 start:dev-preprod skal kunne kjøres fra rotmappa

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "build": "webpack --config ./webpack/webpack.production.js",
     "build:dev": "cd src/backend && yarn build",
     "start:dev": "cd src/backend && yarn start:dev",
+    "start:dev-preprod": "cd src/backend && yarn start:dev-preprod",
     "prepare": "husky install"
   },
   "lint-staged": {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å slippe å hoppe mellom rot og `./backend`
