### PR TITLE
🚧  Preview av Tekst i valgfelt

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Delmal.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Delmal.tsx
@@ -1,15 +1,15 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { PortableText } from '@portabletext/react';
 import styled from 'styled-components';
 
-import { ExpansionCard, Label, Switch } from '@navikt/ds-react';
+import { ExpansionCard, Label } from '@navikt/ds-react';
 import { ABlue50 } from '@navikt/ds-tokens/dist/tokens';
 
-import Fritekst from './Fritekst';
+import { DelmalMeny } from './DelmalMeny';
 import { FritekstSerializer } from './Sanity/FritekstSerializer';
-import { Delmal as DelmalType, Fritekst as FritekstType, Valgfelt as ValgfeltType } from './typer';
-import Valgfelt from './Valgfelt';
+import { ValgfeltSerializer } from './Sanity/ValgfeltSerializer';
+import { Delmal as DelmalType, Valg } from './typer';
 
 const Background = styled.div`
     --ac-expansioncard-bg: ${ABlue50};
@@ -26,13 +26,6 @@ const Innhold = styled.div`
     padding: 1rem;
 `;
 
-const FlexColumn = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-    min-width: 640px;
-`;
-
 const DelmalPreview = styled.div`
     display: flex;
     flex-direction: column;
@@ -45,34 +38,20 @@ interface Props {
     delmal: DelmalType;
 }
 
-const DelmalMeny: React.FC<{ delmal: DelmalType }> = ({ delmal }) => {
-    return (
-        <FlexColumn>
-            <Switch>Inkluder seksjon i brev</Switch>
-            {delmal.blocks
-                .filter(
-                    (val): val is ValgfeltType | FritekstType =>
-                        val._type === 'valgfelt' || val._type == 'fritekst'
-                )
-                .map((val) =>
-                    val._type === 'valgfelt' ? <Valgfelt valgfelt={val} /> : <Fritekst />
-                )}
-        </FlexColumn>
-    );
-};
-
 // TODO: Denne, og komponentene den bruker er ikke ferdig
-const CustomComponets = {
+const CustomComponets = (valgfelt: Record<string, Valg>) => ({
     types: {
         fritekst: () => FritekstSerializer({}),
-        valgfelt: () => <div>Valgfelt</div>,
+        valgfelt: ValgfeltSerializer(valgfelt),
     },
     marks: {
         variabel: () => <span>Variabel</span>,
     },
-};
+});
 
 const Delmal: React.FC<Props> = ({ delmal }) => {
+    const [valgfelt, settValgfelt] = useState<Record<string, Valg>>({});
+
     return (
         <Background>
             <ExpansionCard aria-label={'Delmal'}>
@@ -81,11 +60,18 @@ const Delmal: React.FC<Props> = ({ delmal }) => {
                 </ExpansionCard.Header>
                 <ExpansionCard.Content>
                     <Container>
-                        <DelmalMeny delmal={delmal} />
+                        <DelmalMeny
+                            delmal={delmal}
+                            valgfelt={valgfelt}
+                            settValgfelt={settValgfelt}
+                        />
                         <DelmalPreview>
                             <Label>Generert brevtekst</Label>
                             <Innhold>
-                                <PortableText value={delmal.blocks} components={CustomComponets} />
+                                <PortableText
+                                    value={delmal.blocks}
+                                    components={CustomComponets(valgfelt)}
+                                />
                             </Innhold>
                         </DelmalPreview>
                     </Container>

--- a/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
+++ b/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
@@ -1,0 +1,47 @@
+import React, { SetStateAction } from 'react';
+
+import styled from 'styled-components';
+
+import { Switch } from '@navikt/ds-react';
+
+import Fritekst from './Fritekst';
+import {
+    Delmal as DelmalType,
+    Fritekst as FritekstType,
+    Valg,
+    Valgfelt as ValgfeltType,
+} from './typer';
+import Valgfelt from './Valgfelt';
+
+interface Props {
+    delmal: DelmalType;
+    valgfelt: Record<string, Valg>;
+    settValgfelt: React.Dispatch<SetStateAction<Record<string, Valg>>>;
+}
+
+const FlexColumn = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    min-width: 640px;
+`;
+
+export const DelmalMeny: React.FC<Props> = ({ delmal, settValgfelt }) => {
+    return (
+        <FlexColumn>
+            <Switch>Inkluder seksjon i brev</Switch>
+            {delmal.blocks
+                .filter(
+                    (val): val is ValgfeltType | FritekstType =>
+                        val._type === 'valgfelt' || val._type == 'fritekst'
+                )
+                .map((val, index) =>
+                    val._type === 'valgfelt' ? (
+                        <Valgfelt valgfelt={val} settValgfelt={settValgfelt} key={index} />
+                    ) : (
+                        <Fritekst key={index} />
+                    )
+                )}
+        </FlexColumn>
+    );
+};

--- a/src/frontend/Sider/Behandling/Brev/Sanity/ValgfeltSerializer.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/ValgfeltSerializer.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+
+import { PortableText } from '@portabletext/react';
+
+import { FritekstSerializer } from './FritekstSerializer';
+import { Fritekst, Tekst, Valgfelt } from '../typer';
+
+export const ValgfeltSerializer =
+    (valgfelt: Record<string, Fritekst | Tekst>): React.FC<{ value: Valgfelt }> =>
+    ({ value }) => {
+        const valg = valgfelt[value._id];
+
+        if (!valg) {
+            return null;
+        }
+
+        return valg._type === 'tekst' ? (
+            <PortableText
+                value={valg.innhold}
+                components={{
+                    marks: {
+                        variabel: (props) => <span>variabel med id: {props.value._id}</span>, // TODO: Bruke varibel fra state
+                    },
+                }}
+            />
+        ) : (
+            <FritekstSerializer />
+        );
+    };

--- a/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
@@ -16,7 +16,11 @@ export const malQuery = (id: string, målform: 'bokmål' = 'bokmål') => groq`*[
                     _type == "reference" => @->{
                         ...,
                         "innhold": nb[]{
-                            ...
+                            ...,
+                            "markDefs": markDefs[]{
+                                ..., 
+                                _type == "reference" => @->{...}
+                             }
                         },
                         "variabler": nb[].markDefs[]->
                     }

--- a/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
@@ -1,19 +1,20 @@
-import React, { useState } from 'react';
+import React, { SetStateAction, useState } from 'react';
 
 import { Select, TextField } from '@navikt/ds-react';
 
 import Fritekst from './Fritekst';
-import { Tekst, Valgfelt } from './typer';
+import { Tekst, Valg, Valgfelt } from './typer';
 
 interface Props {
     valgfelt: Valgfelt;
+    settValgfelt: React.Dispatch<SetStateAction<Record<string, Valg>>>;
 }
 
 const Tekst: React.FC<{ tekst: Tekst }> = ({ tekst }) => {
     return (
         <>
             {tekst.variabler.map((variabel) => (
-                <div>
+                <div key={variabel._id}>
                     <TextField label={variabel.visningsnavn} key={variabel._id} />
                 </div>
             ))}
@@ -21,21 +22,33 @@ const Tekst: React.FC<{ tekst: Tekst }> = ({ tekst }) => {
     );
 };
 
-const Valgfelt: React.FC<Props> = ({ valgfelt }) => {
+const Valgfelt: React.FC<Props> = ({ valgfelt, settValgfelt }) => {
     const [valgt, settValgt] = useState<string>();
 
-    const valgtBlock = valgfelt.valg.find(
-        (valg) =>
-            (valg._type === 'tekst' && valg._id === valgt) ||
-            (valg._type === 'fritekst' && valgt === 'fritekst')
-    );
+    const finnValgtBlock = (id: string | undefined) =>
+        valgfelt.valg.find(
+            (valg) =>
+                (valg._type === 'tekst' && valg._id === id) ||
+                (valg._type === 'fritekst' && id === 'fritekst')
+        );
+
+    const valgtBlock = finnValgtBlock(valgt);
 
     return (
         <>
             <Select
                 label={valgfelt.visningsnavn}
                 value={valgt || ''}
-                onChange={(e) => settValgt(e.target.value)}
+                onChange={(e) => {
+                    settValgt(e.target.value);
+                    settValgfelt((prevState) => {
+                        const valgtBlock = finnValgtBlock(e.target.value);
+
+                        return valgtBlock
+                            ? { ...prevState, [valgfelt._id]: valgtBlock }
+                            : prevState;
+                    });
+                }}
             >
                 <option value={''}>Velg</option>
                 {valgfelt.valg.map((valg, index) =>

--- a/src/frontend/Sider/Behandling/Brev/typer.ts
+++ b/src/frontend/Sider/Behandling/Brev/typer.ts
@@ -28,10 +28,12 @@ export interface Fritekst {
     _type: 'fritekst';
 }
 
+export type Valg = Fritekst | Tekst;
+
 export interface Valgfelt {
     _type: 'valgfelt';
     _id: string;
-    valg: (Fritekst | Tekst)[];
+    valg: Valg[];
     visningsnavn: string;
 }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når man velger et valgfelt skal endringen komme med i den genererte brevteksten.

Denne PRen fikser delvis generering av valgtfelt. Når saksbehandler tar et valg skal dette reflekteres i den genererte brevteksten. 

**Hva funker?**
✅ Valgfelt som bare har `Tekst` uten variabler

**Hva mangler?**
🚫 Variabler i `Tekst`
🚫 Fritekstvalg


**Før valg:**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/580db364-7766-4097-9f60-469b00d36925)
**Etter valg:**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/60849a32-0404-41f7-ae61-321ea53cd9bf)

