### PR TITLE
Beregning utgifter

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/AktivitetSelect.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/AktivitetSelect.tsx
@@ -3,16 +3,12 @@ import React from 'react';
 import Select from '../../../../../../komponenter/Skjema/Select';
 import {
     UtgiftsperiodeAktivitet,
-    UtgiftsperiodeProperty,
     utgiftsperiodeAktivitetTilTekst,
 } from '../../../../../../typer/vedtak';
 
 interface Props {
     aktivitet: UtgiftsperiodeAktivitet | '' | undefined;
-    oppdaterUtgiftsperiodeElement: (
-        property: UtgiftsperiodeProperty,
-        value: string | undefined
-    ) => void;
+    oppdaterUtgiftsperiodeElement: (value: string | undefined) => void;
     erLesevisning: boolean;
     feil?: string;
 }
@@ -37,10 +33,7 @@ const AktivitetSelect: React.FC<Props> = ({
             value={aktivitet}
             error={feil}
             onChange={(e) => {
-                oppdaterUtgiftsperiodeElement(
-                    UtgiftsperiodeProperty.aktivitetstype,
-                    e.target.value
-                );
+                oppdaterUtgiftsperiodeElement(e.target.value);
             }}
             erLesevisning={erLesevisning}
             lesevisningVerdi={utledLesevisningVerdi()}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/AntallDagerSelect.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/AntallDagerSelect.tsx
@@ -2,11 +2,12 @@ import React from 'react';
 
 import Select from '../../../../../../komponenter/Skjema/Select';
 import { UtgiftsperiodeProperty } from '../../../../../../typer/vedtak';
+import { harTallverdi } from '../../../../../../utils/tall';
 
 interface Props {
     erLesevisning: boolean;
     feil?: string;
-    oppdaterUtgiftsperiodeElement: (value: string | undefined) => void;
+    oppdaterUtgiftsperiodeElement: (value: number | undefined) => void;
     property: UtgiftsperiodeProperty;
     value: number | undefined;
 }
@@ -27,7 +28,9 @@ const AntallDagerSelect: React.FC<Props> = ({
             value={value}
             error={feil}
             onChange={(e) => {
-                oppdaterUtgiftsperiodeElement(e.target.value);
+                oppdaterUtgiftsperiodeElement(
+                    harTallverdi(e.target.value) ? parseInt(e.target.value) : undefined
+                );
             }}
             erLesevisning={erLesevisning}
             lesevisningVerdi={value ? value.toString() : ''}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/PeriodetypeSelect.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/PeriodetypeSelect.tsx
@@ -1,20 +1,13 @@
 import React, { FC } from 'react';
 
 import Select from '../../../../../../komponenter/Skjema/Select';
-import {
-    UtgiftsperiodeProperty,
-    Utgiftsperiodetype,
-    utgiftsperiodetypeTilTekst,
-} from '../../../../../../typer/vedtak';
+import { Utgiftsperiodetype, utgiftsperiodetypeTilTekst } from '../../../../../../typer/vedtak';
 
 interface Props {
     className?: string;
     feil?: string;
     erLesevisning: boolean;
-    oppdaterUtgiftsperiodeElement: (
-        property: UtgiftsperiodeProperty,
-        value: string | undefined
-    ) => void;
+    oppdaterUtgiftsperiodeElement: (value: string | undefined) => void;
     periodetype: Utgiftsperiodetype | '' | undefined;
 }
 
@@ -36,7 +29,7 @@ const PeriodetypeSelect: FC<Props> = ({
             label="Periodetype"
             lesevisningVerdi={periodetype && utgiftsperiodetypeTilTekst[periodetype]}
             onChange={(e) => {
-                oppdaterUtgiftsperiodeElement(UtgiftsperiodeProperty.periodetype, e.target.value);
+                oppdaterUtgiftsperiodeElement(e.target.value);
             }}
             value={periodetype}
         >

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
@@ -42,16 +42,16 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
     const { behandlingErRedigerbar } = useBehandling();
 
     const oppdaterUtgiftsperiode = (
-        index: number,
+        indeks: number,
         property: UtgiftsperiodeProperty,
         value: string | string[] | number | boolean | undefined
     ) => {
         utgiftsperioderState.update(
             {
-                ...utgiftsperioderState.value[index],
+                ...utgiftsperioderState.value[indeks],
                 [property]: value,
             },
-            index
+            indeks
         );
     };
 
@@ -75,13 +75,13 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                 <Label>Velg barn</Label>
                 <Label>Utgifter</Label>
                 <Label>Dager med tilsyn</Label>
-                {utgiftsperioderState.value.map((utgiftsperiode, index) => (
-                    <React.Fragment key={index}>
+                {utgiftsperioderState.value.map((utgiftsperiode, indeks) => (
+                    <React.Fragment key={indeks}>
                         <PeriodetypeSelect
                             className={'ny-rad'}
                             periodetype={utgiftsperiode.periodetype}
                             oppdaterUtgiftsperiodeElement={(property, value) =>
-                                oppdaterUtgiftsperiode(index, property, value)
+                                oppdaterUtgiftsperiode(indeks, property, value)
                             }
                             erLesevisning={!behandlingErRedigerbar}
                         />
@@ -91,7 +91,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                             erLesevisning={!behandlingErRedigerbar}
                             value={utgiftsperiode.fra}
                             onChange={(dato?: Date) =>
-                                oppdaterDatofelter(index, UtgiftsperiodeProperty.fra, dato)
+                                oppdaterDatofelter(indeks, UtgiftsperiodeProperty.fra, dato)
                             }
                         />
                         <DateInput
@@ -100,7 +100,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                             erLesevisning={!behandlingErRedigerbar}
                             value={utgiftsperiode.til}
                             onChange={(dato?: Date) =>
-                                oppdaterDatofelter(index, UtgiftsperiodeProperty.til, dato)
+                                oppdaterDatofelter(indeks, UtgiftsperiodeProperty.til, dato)
                             }
                         />
 
@@ -108,7 +108,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                         <AktivitetSelect
                             aktivitet={utgiftsperiode.aktivitetstype}
                             oppdaterUtgiftsperiodeElement={(property, value) =>
-                                oppdaterUtgiftsperiode(index, property, value)
+                                oppdaterUtgiftsperiode(indeks, property, value)
                             }
                             erLesevisning={!behandlingErRedigerbar}
                         />
@@ -118,7 +118,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                             value={utgiftsperiode.antallAktivitetsdager}
                             oppdaterUtgiftsperiodeElement={(value) =>
                                 oppdaterUtgiftsperiode(
-                                    index,
+                                    indeks,
                                     UtgiftsperiodeProperty.antallAktivitetsdager,
                                     value
                                 )
@@ -131,7 +131,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                                 { barnId: 'id2', registergrunnlag: { navn: 'Espen Askeladden' } },
                             ]}
                             oppdaterUtgiftsperiodeElement={(value) =>
-                                oppdaterUtgiftsperiode(index, UtgiftsperiodeProperty.barn, value)
+                                oppdaterUtgiftsperiode(indeks, UtgiftsperiodeProperty.barn, value)
                             }
                         />
 
@@ -144,7 +144,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                             }
                             onChange={(e) =>
                                 oppdaterUtgiftsperiode(
-                                    index,
+                                    indeks,
                                     UtgiftsperiodeProperty.utgifter,
                                     tilTallverdi(e.target.value)
                                 )
@@ -157,7 +157,7 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                             value={utgiftsperiode.dagerMedTilsyn}
                             oppdaterUtgiftsperiodeElement={(value) =>
                                 oppdaterUtgiftsperiode(
-                                    index,
+                                    indeks,
                                     UtgiftsperiodeProperty.dagerMedTilsyn,
                                     value
                                 )

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
@@ -8,6 +8,7 @@ import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 import AktivitetSelect from './AktivitetSelect';
 import AntallDagerSelect from './AntallDagerSelect';
 import PeriodetypeSelect from './PeriodetypeSelect';
+import VelgBarn from './VelgBarn';
 import { useBehandling } from '../../../../../../context/BehandlingContext';
 import { ListState } from '../../../../../../hooks/felles/useListState';
 import DateInput from '../../../../../../komponenter/Skjema/DateInput';
@@ -121,6 +122,16 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                                     UtgiftsperiodeProperty.antallAktivitetsdager,
                                     value
                                 )
+                            }
+                        />
+
+                        <VelgBarn
+                            barn={[
+                                { barnId: 'id1', registergrunnlag: { navn: 'Ronja Røverdatter' } },
+                                { barnId: 'id2', registergrunnlag: { navn: 'Espen Askeladden' } },
+                            ]}
+                            oppdaterUtgiftsperiodeElement={(value) =>
+                                oppdaterUtgiftsperiode(index, UtgiftsperiodeProperty.barn, value)
                             }
                         />
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
@@ -11,7 +11,9 @@ import PeriodetypeSelect from './PeriodetypeSelect';
 import { useBehandling } from '../../../../../../context/BehandlingContext';
 import { ListState } from '../../../../../../hooks/felles/useListState';
 import DateInput from '../../../../../../komponenter/Skjema/DateInput';
+import TextField from '../../../../../../komponenter/Skjema/TextField';
 import { Utgiftsperiode, UtgiftsperiodeProperty } from '../../../../../../typer/vedtak';
+import { harTallverdi, tilTallverdi } from '../../../../../../utils/tall';
 
 const Container = styled.div`
     padding: 1rem;
@@ -121,8 +123,22 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                                 )
                             }
                         />
-                        <p>Barn</p>
-                        <p>Utgifter</p>
+
+                        <TextField
+                            erLesevisning={!behandlingErRedigerbar}
+                            label="Utgifter"
+                            hideLabel
+                            value={
+                                harTallverdi(utgiftsperiode.utgifter) ? utgiftsperiode.utgifter : ''
+                            }
+                            onChange={(e) =>
+                                oppdaterUtgiftsperiode(
+                                    index,
+                                    UtgiftsperiodeProperty.utgifter,
+                                    tilTallverdi(e.target.value)
+                                )
+                            }
+                        />
 
                         <AntallDagerSelect
                             erLesevisning={!behandlingErRedigerbar}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/UtgiftsperiodeValg.tsx
@@ -80,8 +80,12 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                         <PeriodetypeSelect
                             className={'ny-rad'}
                             periodetype={utgiftsperiode.periodetype}
-                            oppdaterUtgiftsperiodeElement={(property, value) =>
-                                oppdaterUtgiftsperiode(indeks, property, value)
+                            oppdaterUtgiftsperiodeElement={(value) =>
+                                oppdaterUtgiftsperiode(
+                                    indeks,
+                                    UtgiftsperiodeProperty.periodetype,
+                                    value
+                                )
                             }
                             erLesevisning={!behandlingErRedigerbar}
                         />
@@ -107,8 +111,12 @@ const UtgiftsperiodeValg: React.FC<Props> = ({ utgiftsperioderState }) => {
                         {/* TODO: Håndtere tilfeller hvor aktivitet ikke skal velges (f.eks. opp) */}
                         <AktivitetSelect
                             aktivitet={utgiftsperiode.aktivitetstype}
-                            oppdaterUtgiftsperiodeElement={(property, value) =>
-                                oppdaterUtgiftsperiode(indeks, property, value)
+                            oppdaterUtgiftsperiodeElement={(value) =>
+                                oppdaterUtgiftsperiode(
+                                    indeks,
+                                    UtgiftsperiodeProperty.aktivitetstype,
+                                    value
+                                )
                             }
                             erLesevisning={!behandlingErRedigerbar}
                         />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/VelgBarn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgiftsperiode/VelgBarn.tsx
@@ -1,0 +1,30 @@
+import React, { FC } from 'react';
+
+import { Checkbox, CheckboxGroup } from '@navikt/ds-react';
+
+import { Barn } from '../../../../vilkår';
+
+interface Props {
+    barn: Barn[];
+    oppdaterUtgiftsperiodeElement: (value: string[]) => void;
+}
+
+const VelgBarn: FC<Props> = ({ barn, oppdaterUtgiftsperiodeElement }) => {
+    const handleChange = (avhukedeBarn: string[]) => oppdaterUtgiftsperiodeElement(avhukedeBarn);
+
+    return (
+        <CheckboxGroup
+            legend="Velg barn"
+            hideLegend
+            onChange={(val: string[]) => handleChange(val)}
+        >
+            {barn.map((barn, indeks) => (
+                <Checkbox value={barn.barnId} key={indeks}>
+                    {barn.registergrunnlag.navn}
+                </Checkbox>
+            ))}
+        </CheckboxGroup>
+    );
+};
+
+export default VelgBarn;

--- a/src/frontend/Sider/Behandling/vilkår.ts
+++ b/src/frontend/Sider/Behandling/vilkår.ts
@@ -6,3 +6,15 @@ export enum Vilkårsresultat {
     IKKE_TATT_STILLING_TIL = 'IKKE_TATT_STILLING_TIL',
     SKAL_IKKE_VURDERES = 'SKAL_IKKE_VURDERES',
 }
+
+export interface Barn {
+    barnId: string;
+    // søknadsgrunnlag: BarnSøknadsgrunnlag;
+    registergrunnlag: BarnRegistergrunnlag;
+    // barnepass?: Barnepass;
+}
+
+interface BarnRegistergrunnlag {
+    navn?: string;
+    fødselsdato?: string;
+}

--- a/src/frontend/komponenter/Skjema/TextField.tsx
+++ b/src/frontend/komponenter/Skjema/TextField.tsx
@@ -1,0 +1,44 @@
+import React, { FC } from 'react';
+
+import {
+    TextField as AkselTextField,
+    TextFieldProps as AkselTextFieldProps,
+} from '@navikt/ds-react';
+
+import Lesefelt from './Lesefelt';
+
+export interface TextFieldProps extends AkselTextFieldProps {
+    erLesevisning: boolean;
+    lesevisningVerdi?: string;
+}
+
+const TextField: FC<TextFieldProps> = ({
+    className,
+    erLesevisning = false,
+    label,
+    lesevisningVerdi,
+    value,
+    size,
+    hideLabel,
+    ...props
+}) => {
+    return erLesevisning ? (
+        <Lesefelt
+            label={!hideLabel && label}
+            verdi={lesevisningVerdi ? lesevisningVerdi : value}
+            className={className}
+            size={size}
+        />
+    ) : (
+        <AkselTextField
+            className={className}
+            label={label}
+            value={value}
+            size={size}
+            hideLabel={hideLabel}
+            {...props}
+        />
+    );
+};
+
+export default TextField;

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -8,5 +8,10 @@ export const formaterNullableIsoDatoTid = (dato?: string): string | undefined =>
     return dato && formaterIsoDatoTid(dato);
 };
 
-export const nullableTilDato = (dato: string | Date | undefined): Date | undefined =>
-    typeof dato === 'string' ? parseISO(dato) : dato;
+export const nullableTilDato = (dato: string | Date | undefined): Date | undefined => {
+    if (typeof dato === 'string') {
+        return dato !== '' ? parseISO(dato) : undefined;
+    } else {
+        return dato;
+    }
+};

--- a/src/frontend/utils/tall.ts
+++ b/src/frontend/utils/tall.ts
@@ -1,3 +1,27 @@
 export const erDesimaltall = (verdi: number) => {
     return verdi % 1 !== 0;
 };
+
+const erPågåendeDesimaltall = (verdi: string) => {
+    return (
+        (verdi.indexOf(',') > 0 && verdi.indexOf(',') == verdi.length - 1) ||
+        (verdi.indexOf('.') > 0 && verdi.indexOf('.') == verdi.length - 1)
+    );
+};
+
+export const tilTallverdi = (verdi: number | string | undefined): number | undefined | string => {
+    if (verdi === '' || verdi === undefined || verdi === null) {
+        return undefined;
+    }
+    if (typeof verdi === 'string') {
+        if (erPågåendeDesimaltall(verdi)) {
+            return verdi;
+        }
+        const formatertVerdi = Number(verdi.replace(/\s/g, '').replace(/,/g, '.'));
+        return isNaN(formatertVerdi) ? verdi : formatertVerdi;
+    }
+    return Number(verdi);
+};
+
+export const harTallverdi = (verdi: number | undefined | null | string): boolean =>
+    verdi !== undefined && verdi !== null;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legge inn resterende felter (barn og utgifter):
<img width="1302" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/69620c2d-672c-4e6f-8f07-3742716c8653">

Se commit for commit

### Valg tatt
- Frem til vi vet hvordan designet skal se ut er det gjort en enkel visning av barn med checkbokser
- Utgifter er kun et rent tekstfelt. Det gjøres om til en tallverdi dersom det er mulig. Det er lagt inn på TODO kort på trello å se på dette. 

### Andre småfix
- Må kunne håndtere en dato-streng som er tom ("")
- Gjør om antall dager med aktivitet og pass til `number`
- `index` -> `indeks`
- Sette property i `UtgiftsperiodeValg` slik at hver komponent ikke trenger å ta hensyn til hvilken property i skjema den er.