### PR TITLE
🚧 Variabler i valgfelt

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Delmal.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Delmal.tsx
@@ -51,6 +51,7 @@ const CustomComponets = (valgfelt: Record<string, Valg>) => ({
 
 const Delmal: React.FC<Props> = ({ delmal }) => {
     const [valgfelt, settValgfelt] = useState<Record<string, Valg>>({});
+    const [variabler, settVariabler] = useState<Record<string, string>>({});
 
     return (
         <Background>
@@ -64,6 +65,8 @@ const Delmal: React.FC<Props> = ({ delmal }) => {
                             delmal={delmal}
                             valgfelt={valgfelt}
                             settValgfelt={settValgfelt}
+                            variabler={variabler}
+                            settVariabler={settVariabler}
                         />
                         <DelmalPreview>
                             <Label>Generert brevtekst</Label>

--- a/src/frontend/Sider/Behandling/Brev/Delmal.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Delmal.tsx
@@ -39,10 +39,10 @@ interface Props {
 }
 
 // TODO: Denne, og komponentene den bruker er ikke ferdig
-const CustomComponets = (valgfelt: Record<string, Valg>) => ({
+const CustomComponets = (valgfelt: Record<string, Valg>, variabler: Record<string, string>) => ({
     types: {
         fritekst: () => FritekstSerializer({}),
-        valgfelt: ValgfeltSerializer(valgfelt),
+        valgfelt: ValgfeltSerializer(valgfelt, variabler),
     },
     marks: {
         variabel: () => <span>Variabel</span>,
@@ -73,7 +73,7 @@ const Delmal: React.FC<Props> = ({ delmal }) => {
                             <Innhold>
                                 <PortableText
                                     value={delmal.blocks}
-                                    components={CustomComponets(valgfelt)}
+                                    components={CustomComponets(valgfelt, variabler)}
                                 />
                             </Innhold>
                         </DelmalPreview>

--- a/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
+++ b/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
@@ -17,6 +17,8 @@ interface Props {
     delmal: DelmalType;
     valgfelt: Record<string, Valg>;
     settValgfelt: React.Dispatch<SetStateAction<Record<string, Valg>>>;
+    variabler: Record<string, string>;
+    settVariabler: React.Dispatch<SetStateAction<Record<string, string>>>;
 }
 
 const FlexColumn = styled.div`
@@ -26,7 +28,7 @@ const FlexColumn = styled.div`
     min-width: 640px;
 `;
 
-export const DelmalMeny: React.FC<Props> = ({ delmal, settValgfelt }) => {
+export const DelmalMeny: React.FC<Props> = ({ delmal, settValgfelt, variabler, settVariabler }) => {
     return (
         <FlexColumn>
             <Switch>Inkluder seksjon i brev</Switch>
@@ -37,7 +39,13 @@ export const DelmalMeny: React.FC<Props> = ({ delmal, settValgfelt }) => {
                 )
                 .map((val, index) =>
                     val._type === 'valgfelt' ? (
-                        <Valgfelt valgfelt={val} settValgfelt={settValgfelt} key={index} />
+                        <Valgfelt
+                            valgfelt={val}
+                            settValgfelt={settValgfelt}
+                            variabler={variabler}
+                            settVariabler={settVariabler}
+                            key={index}
+                        />
                     ) : (
                         <Fritekst key={index} />
                     )

--- a/src/frontend/Sider/Behandling/Brev/Sanity/ValgfeltSerializer.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/ValgfeltSerializer.tsx
@@ -6,7 +6,10 @@ import { FritekstSerializer } from './FritekstSerializer';
 import { Fritekst, Tekst, Valgfelt } from '../typer';
 
 export const ValgfeltSerializer =
-    (valgfelt: Record<string, Fritekst | Tekst>): React.FC<{ value: Valgfelt }> =>
+    (
+        valgfelt: Record<string, Fritekst | Tekst>,
+        variabler: Record<string, string>
+    ): React.FC<{ value: Valgfelt }> =>
     ({ value }) => {
         const valg = valgfelt[value._id];
 
@@ -19,7 +22,11 @@ export const ValgfeltSerializer =
                 value={valg.innhold}
                 components={{
                     marks: {
-                        variabel: (props) => <span>variabel med id: {props.value._id}</span>, // TODO: Bruke varibel fra state
+                        variabel: (props) => (
+                            <span>
+                                {variabler[props.value._id] || `[${props.value.visningsnavn}]`}
+                            </span>
+                        ),
                     },
                 }}
             />

--- a/src/frontend/Sider/Behandling/Brev/Tekst.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Tekst.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+
+import { TextField } from '@navikt/ds-react';
+
+import { Tekst } from './typer';
+
+const Tekst: React.FC<{ tekst: Tekst }> = ({ tekst }) => {
+    return (
+        <>
+            {tekst.variabler.map((variabel) => (
+                <div key={variabel._id}>
+                    <TextField label={variabel.visningsnavn} key={variabel._id} />
+                </div>
+            ))}
+        </>
+    );
+};
+
+export default Tekst;

--- a/src/frontend/Sider/Behandling/Brev/Tekst.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Tekst.tsx
@@ -1,17 +1,36 @@
-import React from 'react';
+import React, { SetStateAction } from 'react';
 
 import { TextField } from '@navikt/ds-react';
 
 import { Tekst } from './typer';
 
-const Tekst: React.FC<{ tekst: Tekst }> = ({ tekst }) => {
+interface Props {
+    tekst: Tekst;
+    variabler: Record<string, string>;
+    settVariabler: React.Dispatch<SetStateAction<Record<string, string>>>;
+}
+
+const Tekst: React.FC<Props> = ({ tekst, variabler, settVariabler }) => {
     return (
         <>
-            {tekst.variabler.map((variabel) => (
-                <div key={variabel._id}>
-                    <TextField label={variabel.visningsnavn} key={variabel._id} />
-                </div>
-            ))}
+            {tekst.variabler.map((variabel) => {
+                const håndterInput = (e: React.ChangeEvent<HTMLInputElement>) =>
+                    settVariabler((prevState) => ({
+                        ...prevState,
+                        [variabel._id]: e.target.value,
+                    }));
+
+                return (
+                    <div key={variabel._id}>
+                        <TextField
+                            label={variabel.visningsnavn}
+                            key={variabel._id}
+                            value={variabler[variabel._id] || ''}
+                            onChange={håndterInput}
+                        />
+                    </div>
+                );
+            })}
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
@@ -9,9 +9,11 @@ import { Valg, Valgfelt } from './typer';
 interface Props {
     valgfelt: Valgfelt;
     settValgfelt: React.Dispatch<SetStateAction<Record<string, Valg>>>;
+    variabler: Record<string, string>;
+    settVariabler: React.Dispatch<SetStateAction<Record<string, string>>>;
 }
 
-const Valgfelt: React.FC<Props> = ({ valgfelt, settValgfelt }) => {
+const Valgfelt: React.FC<Props> = ({ valgfelt, settValgfelt, variabler, settVariabler }) => {
     const [valgt, settValgt] = useState<string>();
 
     const finnValgtBlock = (id: string | undefined) =>
@@ -53,7 +55,11 @@ const Valgfelt: React.FC<Props> = ({ valgfelt, settValgfelt }) => {
                 )}
             </Select>
             {valgtBlock &&
-                (valgtBlock._type == 'fritekst' ? <Fritekst /> : <Tekst tekst={valgtBlock} />)}
+                (valgtBlock._type == 'fritekst' ? (
+                    <Fritekst />
+                ) : (
+                    <Tekst tekst={valgtBlock} variabler={variabler} settVariabler={settVariabler} />
+                ))}
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
@@ -1,26 +1,15 @@
 import React, { SetStateAction, useState } from 'react';
 
-import { Select, TextField } from '@navikt/ds-react';
+import { Select } from '@navikt/ds-react';
 
 import Fritekst from './Fritekst';
-import { Tekst, Valg, Valgfelt } from './typer';
+import Tekst from './Tekst';
+import { Valg, Valgfelt } from './typer';
 
 interface Props {
     valgfelt: Valgfelt;
     settValgfelt: React.Dispatch<SetStateAction<Record<string, Valg>>>;
 }
-
-const Tekst: React.FC<{ tekst: Tekst }> = ({ tekst }) => {
-    return (
-        <>
-            {tekst.variabler.map((variabel) => (
-                <div key={variabel._id}>
-                    <TextField label={variabel.visningsnavn} key={variabel._id} />
-                </div>
-            ))}
-        </>
-    );
-};
 
 const Valgfelt: React.FC<Props> = ({ valgfelt, settValgfelt }) => {
     const [valgt, settValgt] = useState<string>();


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når saksbehandler fyller ut variabler i brevmenyen skal disse komme med i den genererte brevteksten ✍️ 

Denne PRen fikser variabler i `Tekst`-komponentene. Variabler ytterst i delmalen tas i neste PR. Visualisering av hva som er gjort foreløpig:

![Skjermbilde 2023-10-05 kl  16 19 05](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/b0ee2a2f-52e3-4936-8dbf-07dd36c600ea)

### Screenshot 📸 
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/cbbbde62-aaac-4ed2-bc1a-076a3defcea8)

Ps. Ser at variablene i brevmenyen ikke nødvendigvis følger rekkefølgen de er definert i i brevmalen. Mulig vi må endre på spørringene for å fikse dette 💭 


