### PR TITLE
Redirect 401 login

### DIFF
--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -40,7 +40,7 @@ spec:
   azure:
     sidecar:
       enabled: true
-      autoLogin: true
+      autoLogin: false
     application:
       enabled: true
       claims:

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -40,7 +40,7 @@ spec:
   azure:
     sidecar:
       enabled: true
-      autoLogin: true
+      autoLogin: false
     application:
       enabled: true
       claims:

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -42,9 +42,13 @@ if (process.env.NODE_ENV === 'development') {
 app.use(bodyParser.json({ limit: '200mb' }));
 app.use(bodyParser.urlencoded({ limit: '200mb', extended: true }));
 
-app.get(/^(?!.*\/(internal|static|api|oauth2)\/).*$/, (_req, res) => {
-    res.sendFile('index.html', { root: buildPath });
-});
+app.get(
+    /^(?!.*\/(internal|static|api|oauth2|favicon\.ico)\/).*$/,
+    validateToken(true),
+    (_req, res) => {
+        res.sendFile('index.html', { root: buildPath });
+    }
+);
 
 app.use('/api/profile', addRequestInfo(), validateToken(), getProfile());
 

--- a/src/backend/server.ts
+++ b/src/backend/server.ts
@@ -42,13 +42,9 @@ if (process.env.NODE_ENV === 'development') {
 app.use(bodyParser.json({ limit: '200mb' }));
 app.use(bodyParser.urlencoded({ limit: '200mb', extended: true }));
 
-app.get(
-    /^(?!.*\/(internal|static|api|oauth2|favicon\.ico)\/).*$/,
-    validateToken(true),
-    (_req, res) => {
-        res.sendFile('index.html', { root: buildPath });
-    }
-);
+app.get(/^(?!.*\/(internal|static|api|oauth2)\/).*$/, validateToken(true), (_req, res) => {
+    res.sendFile('index.html', { root: buildPath });
+});
 
 app.use('/api/profile', addRequestInfo(), validateToken(), getProfile());
 

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -4,11 +4,33 @@ import { BrowserRouter, Route, Routes } from 'react-router-dom';
 
 import { InternalHeader, Spacer } from '@navikt/ds-react';
 
-import { AppProvider } from './context/AppContext';
+import { AppProvider, useApp } from './context/AppContext';
 import { Sticky } from './komponenter/Visningskomponenter/Sticky';
 import BehandlingContainer from './Sider/Behandling/BehandlingContainer';
 import Oppgavebenk from './Sider/Oppgavebenk/Oppgavebenk';
 import Personoversikt from './Sider/Personoversikt/Personoversikt';
+
+const AppRoutes = () => {
+    const { autentisert } = useApp();
+    return (
+        <BrowserRouter>
+            {autentisert ? (
+                <Routes>
+                    <Route path={'/'} element={<Oppgavebenk />} />
+                    <Route path={'/person/:fagsakPersonId/*'} element={<Personoversikt />} />
+                    <Route path={'/behandling/:behandlingId/*'} element={<BehandlingContainer />} />
+                </Routes>
+            ) : (
+                <Routes>
+                    <Route
+                        path={'*'}
+                        element={<div>Sesjonen har utløpt. Prøv å last inn siden på nytt.</div>}
+                    />
+                </Routes>
+            )}
+        </BrowserRouter>
+    );
+};
 
 const App: React.FC = () => {
     return (
@@ -20,13 +42,7 @@ const App: React.FC = () => {
                     <InternalHeader.User name="Ola Normann" />
                 </InternalHeader>
             </Sticky>
-            <BrowserRouter>
-                <Routes>
-                    <Route path={'/'} element={<Oppgavebenk />} />
-                    <Route path={'/person/:fagsakPersonId/*'} element={<Personoversikt />} />
-                    <Route path={'/behandling/:behandlingId/*'} element={<BehandlingContainer />} />
-                </Routes>
-            </BrowserRouter>
+            <AppRoutes />
         </AppProvider>
     );
 };

--- a/src/frontend/context/AppContext.ts
+++ b/src/frontend/context/AppContext.ts
@@ -1,14 +1,20 @@
-import { useCallback } from 'react';
+import { useCallback, useState } from 'react';
 
 import constate from 'constate';
 
-import { fetchFn } from '../utils/fetch';
+import { fetchFn, Method } from '../utils/fetch';
 
 const [AppProvider, useApp] = constate(() => {
-    const request = useCallback(fetchFn, []); // Saksbehandler skal inn som dep etter hvert
+    const [autentisert, settAutentisert] = useState(true);
+    const request = useCallback(
+        <RES, REQ>(url: string, method: Method = 'GET', data?: REQ) =>
+            fetchFn<RES, REQ>(url, method, () => settAutentisert(false), data),
+        []
+    ); // Saksbehandler skal inn som dep etter hvert
 
     return {
         request,
+        autentisert,
     };
 });
 

--- a/src/frontend/utils/fetch.ts
+++ b/src/frontend/utils/fetch.ts
@@ -7,7 +7,7 @@ export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'UPDATE';
 export const fetchFn = <ResponseData, RequestData>(
     url: string,
     method: Method,
-    settAutentisert: () => void,
+    settIkkeAutentisert: () => void,
     data?: RequestData
 ): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
     const requestId = uuidv4().replaceAll('-', '');
@@ -25,7 +25,7 @@ export const fetchFn = <ResponseData, RequestData>(
                 return håndterSuksess<ResponseData>(res);
             } else {
                 if (res.status === 401) {
-                    settAutentisert();
+                    settIkkeAutentisert();
                 }
                 return håndterFeil(res, res.headers);
             }

--- a/src/frontend/utils/fetch.ts
+++ b/src/frontend/utils/fetch.ts
@@ -2,9 +2,12 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../typer/ressurs';
 
+export type Method = 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'UPDATE';
+
 export const fetchFn = <ResponseData, RequestData>(
     url: string,
-    method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' | 'UPDATE' = 'GET',
+    method: Method,
+    settAutentisert: () => void,
     data?: RequestData
 ): Promise<RessursSuksess<ResponseData> | RessursFeilet> => {
     const requestId = uuidv4().replaceAll('-', '');
@@ -21,6 +24,9 @@ export const fetchFn = <ResponseData, RequestData>(
             if (res.ok) {
                 return håndterSuksess<ResponseData>(res);
             } else {
+                if (res.status === 401) {
+                    settAutentisert();
+                }
                 return håndterFeil(res, res.headers);
             }
         })


### PR DESCRIPTION
…ikke har gyldig token

Frontend viser info om at man må laste om siden hvis et kall returnerer 401

### Hvorfor er denne endringen nødvendig? ✨
For å enklere kunne få en oppdatert sesjon ved utdatert token.
Dette skjer oftere i frontend då vi ikke håndterer refreshtokens lokalt, men i dev/prod håndterer wonderwall refreshtoken

Kan testes med:
* Logg inn
* Opprett en behandling
* Fjern cookie for sessjonen, `tilleggsstonad-local` lokalt og `io.nais.wonderwall.session` i dev
* Velg fane `Vilkår for aktivitet`
* Gå tilbake til første fanen
