### PR TITLE
🚧 Lage felter for stønadsperiode

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { Button } from '@navikt/ds-react';
 
+import StønadsperiodeValg from './Stønadsperiode/StønadsperiodeValg';
 import UtgiftsperiodeValg from './Utgiftsperiode/UtgiftsperiodeValg';
 import { validerInnvilgetVedtakForm } from './vedtaksvalidering';
 import { useBehandling } from '../../../../../context/BehandlingContext';
@@ -12,12 +13,14 @@ import { ListState } from '../../../../../hooks/felles/useListState';
 import { BehandlingResultat } from '../../../../../typer/behandling/behandlingResultat';
 import {
     InnvilgeVedtakForBarnetilsyn,
+    Stønadsperiode,
     Utgiftsperiode,
     VedtakType,
 } from '../../../../../typer/vedtak';
-import { tomUtgiftsperiodeRad } from '../utils';
+import { tomStønadsperiodeRad, tomUtgiftsperiodeRad } from '../utils';
 
 export type InnvilgeVedtakForm = {
+    stønadsperioder: Stønadsperiode[];
     utgiftsperioder: Utgiftsperiode[];
     begrunnelse?: string;
 };
@@ -28,10 +31,14 @@ const Form = styled.form`
     gap: 1rem;
 `;
 
+const initStønadsperioder = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) =>
+    vedtak ? vedtak.stønadsperioder : [tomStønadsperiodeRad()];
+
 const initUtgiftsperioder = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) =>
     vedtak ? vedtak.perioder : [tomUtgiftsperiodeRad()];
 
 const initFormState = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) => ({
+    stønadsperioder: initStønadsperioder(vedtak),
     utgiftsperioder: initUtgiftsperioder(vedtak),
     begrunnelse: vedtak?.begrunnelse || '',
 });
@@ -52,6 +59,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
         validerInnvilgetVedtakForm
     );
 
+    const stønadsperioderState = formState.getProps('stønadsperioder') as ListState<Stønadsperiode>;
     const utgiftsperiodeState = formState.getProps('utgiftsperioder') as ListState<Utgiftsperiode>;
 
     useEffect(() => {
@@ -74,6 +82,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
 
     const handleSubmit = (form: FormState<InnvilgeVedtakForm>) => {
         const vedtaksRequest: InnvilgeVedtakForBarnetilsyn = {
+            stønadsperioder: form.stønadsperioder,
             perioder: form.utgiftsperioder,
             // begrunnelse: form.begrunnelse,
             _type: VedtakType.InnvilgelseBarnetilsyn,
@@ -85,6 +94,10 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
 
     return (
         <Form onSubmit={formState.onSubmit(handleSubmit)}>
+            <StønadsperiodeValg
+                stønadsperioderState={stønadsperioderState}
+                errorState={formState.errors.stønadsperioder}
+            />
             <UtgiftsperiodeValg
                 utgiftsperioderState={utgiftsperiodeState}
                 errorState={formState.errors}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -1,0 +1,87 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Heading, Label } from '@navikt/ds-react';
+import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
+
+import { useBehandling } from '../../../../../../context/BehandlingContext';
+import { FormErrors } from '../../../../../../hooks/felles/useFormState';
+import { ListState } from '../../../../../../hooks/felles/useListState';
+import DateInput from '../../../../../../komponenter/Skjema/DateInput';
+import { Stønadsperiode, StønadsperiodeProperty } from '../../../../../../typer/vedtak';
+
+const Container = styled.div`
+    padding: 1rem;
+    background-color: ${AGray50};
+`;
+
+const Grid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(2, max-content);
+    grid-gap: 0.5rem 1rem;
+    align-items: start;
+`;
+
+interface Props {
+    errorState: FormErrors<Stønadsperiode[]>;
+    stønadsperioderState: ListState<Stønadsperiode>;
+}
+
+const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorState }) => {
+    const { behandlingErRedigerbar } = useBehandling();
+
+    const oppdaterUtgiftsperiode = (
+        indeks: number,
+        property: StønadsperiodeProperty,
+        value: string | string[] | number | boolean | undefined
+    ) => {
+        stønadsperioderState.update(
+            {
+                ...stønadsperioderState.value[indeks],
+                [property]: value,
+            },
+            indeks
+        );
+    };
+
+    return (
+        <Container>
+            <Heading spacing size="small" level="5">
+                Perioder for stønad
+            </Heading>
+            <Grid>
+                <Label>Fra</Label>
+                <Label>Til</Label>
+                {stønadsperioderState.value.map((stønadsperiode, indeks) => (
+                    <React.Fragment key={indeks}>
+                        <DateInput
+                            label="Fra"
+                            hideLabel
+                            erLesevisning={!behandlingErRedigerbar}
+                            value={stønadsperiode.fra}
+                            onChange={(dato?: string) =>
+                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.fra, dato)
+                            }
+                            size="small"
+                            feil={errorState[indeks].fra}
+                        />
+                        <DateInput
+                            label="Til"
+                            hideLabel
+                            erLesevisning={!behandlingErRedigerbar}
+                            value={stønadsperiode.til}
+                            onChange={(dato?: string) =>
+                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.til, dato)
+                            }
+                            size="small"
+                            feil={errorState[indeks].til}
+                        />
+                    </React.Fragment>
+                ))}
+            </Grid>
+        </Container>
+    );
+};
+
+export default StønadsperiodeValg;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -61,7 +61,7 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
                             erLesevisning={!behandlingErRedigerbar}
                             value={stønadsperiode.fra}
                             onChange={(dato?: string) =>
-                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.fra, dato)
+                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.FRA, dato)
                             }
                             size="small"
                             feil={errorState[indeks].fra}
@@ -72,7 +72,7 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
                             erLesevisning={!behandlingErRedigerbar}
                             value={stønadsperiode.til}
                             onChange={(dato?: string) =>
-                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.til, dato)
+                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.TIL, dato)
                             }
                             size="small"
                             feil={errorState[indeks].til}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -64,7 +64,7 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
                                 oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.FRA, dato)
                             }
                             size="small"
-                            feil={errorState[indeks].fra}
+                            feil={errorState && errorState[indeks]?.fra}
                         />
                         <DateInput
                             label="Til"
@@ -75,7 +75,7 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
                                 oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.TIL, dato)
                             }
                             size="small"
-                            feil={errorState[indeks].til}
+                            feil={errorState && errorState[indeks]?.til}
                         />
                     </React.Fragment>
                 ))}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -1,4 +1,4 @@
-import { Utgiftsperiode } from '../../../../typer/vedtak';
+import { Stønadsperiode, Utgiftsperiode } from '../../../../typer/vedtak';
 
 export const tomUtgiftsperiodeRad = (): Utgiftsperiode => ({
     fra: '',
@@ -9,4 +9,9 @@ export const tomUtgiftsperiodeRad = (): Utgiftsperiode => ({
     barn: [],
     utgifter: undefined,
     dagerMedTilsyn: undefined,
+});
+
+export const tomStønadsperiodeRad = (): Stønadsperiode => ({
+    fra: '',
+    til: '',
 });

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -12,6 +12,7 @@ export interface Props {
     hideLabel?: boolean;
     label?: string;
     onChange: (dato?: string) => void;
+    size?: 'small' | 'medium';
     value?: string;
 }
 
@@ -22,6 +23,7 @@ const DateInput: React.FC<Props> = ({
     hideLabel,
     label,
     onChange,
+    size,
     value,
 }) => {
     const { datepickerProps, inputProps, selectedDay } = useDatepicker({
@@ -38,7 +40,13 @@ const DateInput: React.FC<Props> = ({
         />
     ) : (
         <DatePicker {...datepickerProps}>
-            <DatePicker.Input {...inputProps} label={label} hideLabel={hideLabel} error={feil} />
+            <DatePicker.Input
+                {...inputProps}
+                label={label}
+                hideLabel={hideLabel}
+                error={feil}
+                size={size}
+            />
         </DatePicker>
     );
 };

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -20,8 +20,8 @@ export type Stønadsperiode = {
 };
 
 export enum StønadsperiodeProperty {
-    fra = 'fra',
-    til = 'til',
+    FRA = 'fra',
+    TIL = 'til',
 }
 
 export type Utgiftsperiode = {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -7,11 +7,22 @@ export enum VedtakType {
 export type InnvilgeVedtakForBarnetilsyn = {
     resultatType: BehandlingResultat.INNVILGET;
     begrunnelse?: string;
+    stønadsperioder: Stønadsperiode[];
     perioder: Utgiftsperiode[];
     // perioderKontantstøtte: IPeriodeMedBeløp[];
     // tilleggsstønad: ITilleggsstønad;
     _type?: VedtakType.InnvilgelseBarnetilsyn;
 };
+
+export type Stønadsperiode = {
+    fra: string;
+    til: string;
+};
+
+export enum StønadsperiodeProperty {
+    fra = 'fra',
+    til = 'til',
+}
 
 export type Utgiftsperiode = {
     periodetype: Utgiftsperiodetype | undefined;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lage felter som trengs for å beregne og gjøre vedtak. 

Målet er å splitte eksisterende felter (tatt fra EF) opp i en gruppe med felter for stønadsperiode og en gruppe med utgifter. 

Foreløpig ser det sånn her ut, men kun feltene under "perioder for stønad" skal faktisk være sånn:
<img width="1044" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/214b4f6a-d929-409b-815a-59645b859ffc">