### PR TITLE
🚧 Felter for utgifter

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -34,11 +34,18 @@ const Form = styled.form`
 const initStønadsperioder = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) =>
     vedtak ? vedtak.stønadsperioder : [tomStønadsperiodeRad()];
 
+const initUtgifter = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined, barnIBehandling: Barn[]) =>
+    vedtak ? vedtak.utgifter : tomUtgiftMap(barnIBehandling);
+
 const initUtgiftsperioder = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) =>
     vedtak ? vedtak.perioder : [tomUtgiftsperiodeRad()];
 
-const initFormState = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) => ({
+const initFormState = (
+    vedtak: InnvilgeVedtakForBarnetilsyn | undefined,
+    barnIBehandling: Barn[]
+) => ({
     stønadsperioder: initStønadsperioder(vedtak),
+    utgifter: initUtgifter(vedtak, barnIBehandling),
     utgiftsperioder: initUtgiftsperioder(vedtak),
     begrunnelse: vedtak?.begrunnelse || '',
 });
@@ -50,12 +57,17 @@ interface Props {
 }
 
 export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
+    const barnIBehandling = [
+        { barnId: 'id1', registergrunnlag: { navn: 'Ronja Røverdatter' } },
+        { barnId: 'id2', registergrunnlag: { navn: 'Espen Askeladden' } },
+    ];
+
     const { behandlingErRedigerbar } = useBehandling();
     // TODO: Prøve å slippe denne castingen
     const lagretInnvilgetVedtak = lagretVedtak as InnvilgeVedtakForBarnetilsyn;
 
     const formState = useFormState<InnvilgeVedtakForm>(
-        initFormState(lagretInnvilgetVedtak),
+        initFormState(lagretInnvilgetVedtak, barnIBehandling),
         validerInnvilgetVedtakForm
     );
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -5,22 +5,27 @@ import styled from 'styled-components';
 import { Button } from '@navikt/ds-react';
 
 import StønadsperiodeValg from './Stønadsperiode/StønadsperiodeValg';
+import Utgifter from './Utgifter/Utgifter';
 import UtgiftsperiodeValg from './Utgiftsperiode/UtgiftsperiodeValg';
 import { validerInnvilgetVedtakForm } from './vedtaksvalidering';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import useFormState, { FormState } from '../../../../../hooks/felles/useFormState';
 import { ListState } from '../../../../../hooks/felles/useListState';
+import { RecordState } from '../../../../../hooks/felles/useRecordState';
 import { BehandlingResultat } from '../../../../../typer/behandling/behandlingResultat';
 import {
     InnvilgeVedtakForBarnetilsyn,
     Stønadsperiode,
     Utgiftsperiode,
+    Utgift,
     VedtakType,
 } from '../../../../../typer/vedtak';
-import { tomStønadsperiodeRad, tomUtgiftsperiodeRad } from '../utils';
+import { Barn } from '../../../vilkår';
+import { tomStønadsperiodeRad, tomUtgiftMap, tomUtgiftsperiodeRad } from '../utils';
 
 export type InnvilgeVedtakForm = {
     stønadsperioder: Stønadsperiode[];
+    utgifter: Record<string, Utgift[]>;
     utgiftsperioder: Utgiftsperiode[];
     begrunnelse?: string;
 };
@@ -72,6 +77,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
     );
 
     const stønadsperioderState = formState.getProps('stønadsperioder') as ListState<Stønadsperiode>;
+    const utgifterState = formState.getProps('utgifter') as RecordState<Utgift[]>;
     const utgiftsperiodeState = formState.getProps('utgiftsperioder') as ListState<Utgiftsperiode>;
 
     useEffect(() => {
@@ -95,6 +101,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
     const handleSubmit = (form: FormState<InnvilgeVedtakForm>) => {
         const vedtaksRequest: InnvilgeVedtakForBarnetilsyn = {
             stønadsperioder: form.stønadsperioder,
+            utgifter: form.utgifter,
             perioder: form.utgiftsperioder,
             // begrunnelse: form.begrunnelse,
             _type: VedtakType.InnvilgelseBarnetilsyn,
@@ -109,6 +116,11 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
             <StønadsperiodeValg
                 stønadsperioderState={stønadsperioderState}
                 errorState={formState.errors.stønadsperioder}
+            />
+            <Utgifter
+                barnIBehandling={barnIBehandling}
+                utgifterState={utgifterState}
+                errorState={formState.errors}
             />
             <UtgiftsperiodeValg
                 utgiftsperioderState={utgiftsperiodeState}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -120,7 +120,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak }) => {
             <Utgifter
                 barnIBehandling={barnIBehandling}
                 utgifterState={utgifterState}
-                errorState={formState.errors}
+                errorState={formState.errors.utgifter}
             />
             <UtgiftsperiodeValg
                 utgiftsperioderState={utgiftsperiodeState}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -21,7 +21,7 @@ import {
     VedtakType,
 } from '../../../../../typer/vedtak';
 import { Barn } from '../../../vilkår';
-import { tomStønadsperiodeRad, tomUtgiftMap, tomUtgiftsperiodeRad } from '../utils';
+import { tomStønadsperiodeRad, tomUtgiftPerBarn, tomUtgiftsperiodeRad } from '../utils';
 
 export type InnvilgeVedtakForm = {
     stønadsperioder: Stønadsperiode[];
@@ -40,7 +40,7 @@ const initStønadsperioder = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) 
     vedtak ? vedtak.stønadsperioder : [tomStønadsperiodeRad()];
 
 const initUtgifter = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined, barnIBehandling: Barn[]) =>
-    vedtak ? vedtak.utgifter : tomUtgiftMap(barnIBehandling);
+    vedtak ? vedtak.utgifter : tomUtgiftPerBarn(barnIBehandling);
 
 const initUtgiftsperioder = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) =>
     vedtak ? vedtak.perioder : [tomUtgiftsperiodeRad()];

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Heading } from '@navikt/ds-react';
+import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
+
+import UtgifterValg from './UtgifterValg';
+import { FormErrors } from '../../../../../../hooks/felles/useFormState';
+import { RecordState } from '../../../../../../hooks/felles/useRecordState';
+import { Utgift } from '../../../../../../typer/vedtak';
+import { Barn } from '../../../../vilkår';
+import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
+
+const Container = styled.div`
+    padding: 1rem;
+    background-color: ${AGray50};
+`;
+
+interface Props {
+    errorState: FormErrors<InnvilgeVedtakForm>;
+    utgifterState: RecordState<Utgift[]>;
+    barnIBehandling: Barn[];
+}
+
+const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling }) => {
+    return (
+        <Container>
+            <Heading spacing size="small" level="5">
+                Dokumenterte utgifter
+            </Heading>
+            {barnIBehandling.map((barn) => (
+                <UtgifterValg barn={barn} utgifter={utgifterState.value[barn.barnId]} />
+            ))}
+        </Container>
+    );
+};
+
+export default Utgifter;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -22,7 +22,7 @@ interface Props {
     barnIBehandling: Barn[];
 }
 
-const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling }) => {
+const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling, errorState }) => {
     return (
         <Container>
             <Heading spacing size="small" level="5">

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -33,6 +33,7 @@ const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling, errorState 
                     barn={barn}
                     utgifter={utgifterState.value[barn.barnId]}
                     errorState={errorState && errorState[barn.barnId]}
+                    key={barn.barnId}
                 />
             ))}
         </Container>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -10,7 +10,6 @@ import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import { RecordState } from '../../../../../../hooks/felles/useRecordState';
 import { Utgift } from '../../../../../../typer/vedtak';
 import { Barn } from '../../../../vilkår';
-import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
 
 const Container = styled.div`
     padding: 1rem;
@@ -18,7 +17,7 @@ const Container = styled.div`
 `;
 
 interface Props {
-    errorState: FormErrors<InnvilgeVedtakForm>;
+    errorState: FormErrors<Record<string, Utgift[]>>;
     utgifterState: RecordState<Utgift[]>;
     barnIBehandling: Barn[];
 }
@@ -30,7 +29,11 @@ const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling }) => {
                 Dokumenterte utgifter
             </Heading>
             {barnIBehandling.map((barn) => (
-                <UtgifterValg barn={barn} utgifter={utgifterState.value[barn.barnId]} />
+                <UtgifterValg
+                    barn={barn}
+                    utgifter={utgifterState.value[barn.barnId]}
+                    errorState={errorState && errorState[barn.barnId]}
+                />
             ))}
         </Container>
     );

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Heading, Label } from '@navikt/ds-react';
+
+import { useBehandling } from '../../../../../../context/BehandlingContext';
+import DateInput from '../../../../../../komponenter/Skjema/DateInput';
+import TextField from '../../../../../../komponenter/Skjema/TextField';
+import { Utgift } from '../../../../../../typer/vedtak';
+import { harTallverdi } from '../../../../../../utils/tall';
+import { Barn } from '../../../../vilkår';
+
+const Grid = styled.div<{ $lesevisning?: boolean }>`
+    display: grid;
+    grid-template-columns: repeat(3, max-content);
+    grid-gap: 0.5rem 1rem;
+    align-items: start;
+`;
+
+interface Props {
+    utgifter: Utgift[] | undefined;
+    barn: Barn;
+}
+
+const UtgifterValg: React.FC<Props> = ({ utgifter, barn }) => {
+    const { behandlingErRedigerbar } = useBehandling();
+
+    return (
+        <>
+            <Heading spacing size="xsmall" level="5">
+                {barn.registergrunnlag.navn}
+            </Heading>
+            {utgifter && utgifter.length > 0 && (
+                <Grid $lesevisning={!behandlingErRedigerbar}>
+                    <Label>Månedlig utgift</Label>
+                    <Label>Fra</Label>
+                    <Label>Til</Label>
+
+                    {utgifter.map((utgiftsperiode, indeks) => (
+                        <React.Fragment key={indeks}>
+                            <TextField
+                                erLesevisning={!behandlingErRedigerbar}
+                                label="Utgifter"
+                                hideLabel
+                                value={
+                                    harTallverdi(utgiftsperiode.utgift) ? utgiftsperiode.utgift : ''
+                                }
+                                size="small"
+                            />
+                            <DateInput
+                                label="Fra"
+                                hideLabel
+                                erLesevisning={!behandlingErRedigerbar}
+                                value={utgiftsperiode.fra}
+                                onChange={
+                                    // eslint-disable-next-line no-console
+                                    (dato?: string) => console.log(dato)
+                                }
+                                size="small"
+                            />
+                            <DateInput
+                                label="Til"
+                                hideLabel
+                                erLesevisning={!behandlingErRedigerbar}
+                                value={utgiftsperiode.til}
+                                onChange={
+                                    // eslint-disable-next-line no-console
+                                    (dato?: string) => console.log(dato)
+                                    // oppdaterUtgiftsperiode(indeks, UtgifterProperty.til, dato)
+                                }
+                                size="small"
+                            />
+                        </React.Fragment>
+                    ))}
+                </Grid>
+            )}
+        </>
+    );
+};
+
+export default UtgifterValg;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Heading, Label } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../../../context/BehandlingContext';
+import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import DateInput from '../../../../../../komponenter/Skjema/DateInput';
 import TextField from '../../../../../../komponenter/Skjema/TextField';
 import { Utgift } from '../../../../../../typer/vedtak';
@@ -19,11 +20,12 @@ const Grid = styled.div<{ $lesevisning?: boolean }>`
 `;
 
 interface Props {
+    errorState: FormErrors<Utgift[]>;
     utgifter: Utgift[] | undefined;
     barn: Barn;
 }
 
-const UtgifterValg: React.FC<Props> = ({ utgifter, barn }) => {
+const UtgifterValg: React.FC<Props> = ({ utgifter, barn, errorState }) => {
     const { behandlingErRedigerbar } = useBehandling();
 
     return (
@@ -46,6 +48,7 @@ const UtgifterValg: React.FC<Props> = ({ utgifter, barn }) => {
                                 value={
                                     harTallverdi(utgiftsperiode.utgift) ? utgiftsperiode.utgift : ''
                                 }
+                                error={errorState && errorState[indeks]?.utgift}
                                 size="small"
                             />
                             <DateInput
@@ -57,6 +60,7 @@ const UtgifterValg: React.FC<Props> = ({ utgifter, barn }) => {
                                     // eslint-disable-next-line no-console
                                     (dato?: string) => console.log(dato)
                                 }
+                                feil={errorState && errorState[indeks]?.fra}
                                 size="small"
                             />
                             <DateInput
@@ -69,6 +73,7 @@ const UtgifterValg: React.FC<Props> = ({ utgifter, barn }) => {
                                     (dato?: string) => console.log(dato)
                                     // oppdaterUtgiftsperiode(indeks, UtgifterProperty.til, dato)
                                 }
+                                feil={errorState && errorState[indeks]?.til}
                                 size="small"
                             />
                         </React.Fragment>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -17,7 +17,7 @@ export const tomStønadsperiodeRad = (): Stønadsperiode => ({
     til: '',
 });
 
-export const tomUtgiftMap = (barnIBehandling: Barn[]): Record<string, Utgift[]> =>
+export const tomUtgiftPerBarn = (barnIBehandling: Barn[]): Record<string, Utgift[]> =>
     barnIBehandling.reduce((acc, barn) => {
         return { ...acc, [barn.barnId]: [tomUtgiftRad()] };
     }, {});

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -1,4 +1,5 @@
-import { Stønadsperiode, Utgiftsperiode } from '../../../../typer/vedtak';
+import { Stønadsperiode, Utgift, Utgiftsperiode } from '../../../../typer/vedtak';
+import { Barn } from '../../vilkår';
 
 export const tomUtgiftsperiodeRad = (): Utgiftsperiode => ({
     fra: '',
@@ -12,6 +13,16 @@ export const tomUtgiftsperiodeRad = (): Utgiftsperiode => ({
 });
 
 export const tomStønadsperiodeRad = (): Stønadsperiode => ({
+    fra: '',
+    til: '',
+});
+
+export const tomUtgiftMap = (barnIBehandling: Barn[]): Record<string, Utgift[]> =>
+    barnIBehandling.reduce((acc, barn) => {
+        return { ...acc, [barn.barnId]: [tomUtgiftRad()] };
+    }, {});
+
+export const tomUtgiftRad = () => ({
     fra: '',
     til: '',
 });

--- a/src/frontend/hooks/felles/useFormState.ts
+++ b/src/frontend/hooks/felles/useFormState.ts
@@ -3,15 +3,18 @@ import { Dispatch, FormEventHandler, SetStateAction, useMemo, useState } from 'r
 
 import useFieldState, { FieldState } from './useFieldState';
 import useListState, { ListState } from './useListState';
+import useRecordState, { RecordState } from './useRecordState';
 
 export type FormState<T> = {
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     [P in keyof T]: any;
 };
-export type InternalFormState<T> = { [P in keyof T]: FieldState | ListState<unknown> };
+export type InternalFormState<T> = {
+    [P in keyof T]: FieldState | ListState<unknown> | RecordState<unknown>;
+};
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export type FormHook<T extends Record<string, any>> = {
-    getProps(key: keyof T): FieldState | ListState<unknown>;
+    getProps(key: keyof T): FieldState | ListState<unknown> | RecordState<unknown>;
     errors: FormErrors<T>;
     setErrors: Dispatch<SetStateAction<FormErrors<T>>>;
     validateForm: () => boolean;
@@ -51,6 +54,8 @@ export default function useFormState<T extends Record<string, unknown>>(
                 return { key, value: useFieldState(value) }; // eslint-disable-line
             } else if (Array.isArray(value)) {
                 return { key, value: useListState(value) }; // eslint-disable-line
+            } else if (typeof value === 'object') {
+                return { key, value: useRecordState(value) }; // eslint-disable-line
             } else {
                 throw Error(`Støtter ikke den typen: ${key}`);
             }

--- a/src/frontend/hooks/felles/useRecordState.ts
+++ b/src/frontend/hooks/felles/useRecordState.ts
@@ -1,0 +1,33 @@
+import { Dispatch, SetStateAction, useState } from 'react';
+
+export interface RecordState<T> {
+    value: Record<string, T>;
+    setValue: Dispatch<SetStateAction<Record<string, T>>>;
+    push(key: string, value: T): void;
+    remove(key: string): void;
+    update(key: string, value: T): void;
+}
+
+export default function useRecordState<T>(initialState: Record<string, T>): RecordState<T> {
+    const [value, setValue] = useState(initialState);
+
+    const remove = (key: string) => {
+        const prevValue = { ...value };
+        delete prevValue[key];
+        setValue(prevValue);
+    };
+
+    const update = (key: string, value: T) =>
+        setValue((prevState) => ({
+            ...prevState,
+            [key]: value,
+        }));
+
+    return {
+        value,
+        setValue,
+        push,
+        remove,
+        update,
+    };
+}

--- a/src/frontend/hooks/felles/useRecordState.ts
+++ b/src/frontend/hooks/felles/useRecordState.ts
@@ -3,7 +3,6 @@ import { Dispatch, SetStateAction, useState } from 'react';
 export interface RecordState<T> {
     value: Record<string, T>;
     setValue: Dispatch<SetStateAction<Record<string, T>>>;
-    push(key: string, value: T): void;
     remove(key: string): void;
     update(key: string, value: T): void;
 }
@@ -26,7 +25,6 @@ export default function useRecordState<T>(initialState: Record<string, T>): Reco
     return {
         value,
         setValue,
-        push,
         remove,
         update,
     };

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -8,6 +8,7 @@ export type InnvilgeVedtakForBarnetilsyn = {
     resultatType: BehandlingResultat.INNVILGET;
     begrunnelse?: string;
     stønadsperioder: Stønadsperiode[];
+    utgifter: Record<string, Utgift[]>;
     perioder: Utgiftsperiode[];
     // perioderKontantstøtte: IPeriodeMedBeløp[];
     // tilleggsstønad: ITilleggsstønad;
@@ -22,6 +23,18 @@ export type Stønadsperiode = {
 export enum StønadsperiodeProperty {
     FRA = 'fra',
     TIL = 'til',
+}
+
+export type Utgift = {
+    fra: string;
+    til: string;
+    utgift?: number;
+};
+
+export enum UtgifterProperty {
+    fra = 'fra',
+    til = 'til',
+    utgift = 'utgift',
 }
 
 export type Utgiftsperiode = {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger inn felter for å registrere utgifter per barn i behandling. 

**Hva er gjort:** 
- Lagt til felter. Skal være år måned på utgift, men har foreløpig bare brukt dato fordi de input-feltene var alt laget med leservisning så det gikk raskere. 
- Endret formstate slik at den håndterer states av records.
- Initialiserer hvert barn med 1 tom utgiftsrad. 
- Alt er lister, men foreløpig kan man bare registrere 1 utgift likevel. 

**Uvissheter:**
- Usikker på om barn skal initialiseres med 1 tom rad eller vise knapp for å "legge til en ny". Enkelt å bytte, men det gjøres i såfall når mulighet for å legge til flere utgifter kommer fordi samme logikk brukes for å legge til ny.
- Valideringen må gås opp
- Mange spørsmål om barn og hvilke barn som skal med osv, foreløpig er dette hardkodet og må tas en egen diskusjon på.

**Mangler:**
- Oppdatering av state ved valg av verdi
- Legge til flere utgifter
- Styling (bare brukt kopier fra tidligere og EF)
- Riktig validering og sjekke at den faktisk funker ved oppdatering av verdier.

Tror det skal være litt ekstra smidigt å se på denne PR-en commit for commit

<img width="1246" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/c0941ff4-b4dc-44f4-973a-6030136eb95e">
