### PR TITLE
Høyremeny for å kunne vise totrinnskontroll

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -5,13 +5,30 @@ import styled from 'styled-components';
 
 import Fanemeny from './Fanemeny/Fanemeny';
 import { behandlingFaner } from './Fanemeny/faner';
+import Høyremeny from './Høyremeny/Høyremeny';
 import { BehandlingProvider } from '../../context/BehandlingContext';
 import { VilkårProvider } from '../../context/VilkårContext';
 import { RerrunnableEffect } from '../../hooks/useRerunnableEffect';
 import { Behandling } from '../../typer/behandling/behandling';
 
+const BehandlingContainer = styled.div`
+    display: flex;
+`;
+
 const InnholdWrapper = styled.div`
     padding: 1rem;
+
+    flex-grow: 1;
+
+    max-width: calc(100% - 20rem);
+`;
+
+const HøyreMenyWrapper = styled.div`
+    width: 20rem;
+    min-width: 20rem;
+
+    // Når skjermen blir for liten  så blir høyremenyn liggendes ovenfor venstredelen
+    z-index: 10;
 `;
 
 const BehandlingInnhold: React.FC<{
@@ -24,24 +41,29 @@ const BehandlingInnhold: React.FC<{
 
     return (
         <BehandlingProvider behandling={behandling} hentBehandling={hentBehandling}>
-            <Fanemeny behandlingId={behandling.id} aktivFane={path} />
-            <VilkårProvider behandling={behandling}>
-                <InnholdWrapper>
-                    <Routes>
-                        {behandlingFaner.map((tab) => (
+            <BehandlingContainer>
+                <VilkårProvider behandling={behandling}>
+                    <InnholdWrapper>
+                        <Fanemeny behandlingId={behandling.id} aktivFane={path} />
+                        <Routes>
+                            {behandlingFaner.map((tab) => (
+                                <Route
+                                    key={tab.path}
+                                    path={`/${tab.path}`}
+                                    element={tab.komponent(behandling.id)}
+                                />
+                            ))}
                             <Route
-                                key={tab.path}
-                                path={`/${tab.path}`}
-                                element={tab.komponent(behandling.id)}
+                                path="*"
+                                element={<Navigate to={behandlingFaner[0].path} replace={true} />}
                             />
-                        ))}
-                        <Route
-                            path="*"
-                            element={<Navigate to={behandlingFaner[0].path} replace={true} />}
-                        />
-                    </Routes>
-                </InnholdWrapper>
-            </VilkårProvider>
+                        </Routes>
+                    </InnholdWrapper>
+                </VilkårProvider>
+                <HøyreMenyWrapper>
+                    <Høyremeny />
+                </HøyreMenyWrapper>
+            </BehandlingContainer>
         </BehandlingProvider>
     );
 };

--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { Navigate, Route, Routes, useLocation } from 'react-router-dom';
 import styled from 'styled-components';
 
+import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
+
 import Fanemeny from './Fanemeny/Fanemeny';
 import { behandlingFaner } from './Fanemeny/faner';
 import Høyremeny from './Høyremeny/Høyremeny';
@@ -22,6 +24,9 @@ const InnholdWrapper = styled.div`
 `;
 
 const HøyreMenyWrapper = styled.div`
+    border-left: 2px solid ${ABorderDefault};
+    background-color: white;
+
     width: 20rem;
     min-width: 20rem;
 

--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -16,8 +16,6 @@ const BehandlingContainer = styled.div`
 `;
 
 const InnholdWrapper = styled.div`
-    padding: 1rem;
-
     flex-grow: 1;
 
     max-width: calc(100% - 20rem);

--- a/src/frontend/Sider/Behandling/Brev/VelgBrevmal.tsx
+++ b/src/frontend/Sider/Behandling/Brev/VelgBrevmal.tsx
@@ -6,7 +6,7 @@ import { Select } from '@navikt/ds-react';
 
 import { Brevmal } from './typer';
 
-export const Container = styled.div`
+const Container = styled.div`
     max-width: 55rem;
 `;
 

--- a/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
@@ -1,0 +1,7 @@
+import * as React from 'react';
+
+const Høyremeny = () => {
+    return <></>;
+};
+
+export default Høyremeny;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Håndterer ikke åpen/lukket høyremeny

Har ikke tatt inn allt av flex-properties på `BehandlingContainer`, `InnholdWrapper` eller `HøyreMenyWrapper`

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16160

<img width="1783" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/6c9f6f54-79d3-400b-acd4-a9005c570aea">

<img width="674" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/93760fd0-8dbc-4c06-8a73-54482887e25e">

