### PR TITLE
Godkjenne/underkjenne totrinnskontroll

### DIFF
--- a/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
@@ -3,11 +3,7 @@ import * as React from 'react';
 import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
 
 const Høyremeny = () => {
-    return (
-        <>
-            <Totrinnskontroll />
-        </>
-    );
+    return <Totrinnskontroll />;
 };
 
 export default Høyremeny;

--- a/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
@@ -1,7 +1,13 @@
 import * as React from 'react';
 
+import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
+
 const Høyremeny = () => {
-    return <></>;
+    return (
+        <>
+            <Totrinnskontroll />
+        </>
+    );
 };
 
 export default Høyremeny;

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
@@ -55,15 +55,15 @@ const FatteVedtak: React.FC<{
     const navigate = useNavigate();
     const { behandling } = useBehandling();
 
-    const [godkjent, settGodkjent] = useState<Totrinnsresultat>(Totrinnsresultat.IKKE_VALGT);
+    const [resultat, settResultat] = useState<Totrinnsresultat>(Totrinnsresultat.IKKE_VALGT);
     const [årsakerUnderkjent, settÅrsakerUnderkjent] = useState<ÅrsakUnderkjent[]>([]);
     const [begrunnelse, settBegrunnelse] = useState<string>();
     const [feil, settFeil] = useState<string>();
     const [laster, settLaster] = useState<boolean>(false);
 
     const erUtfylt =
-        godkjent === Totrinnsresultat.GODKJENT ||
-        (godkjent === Totrinnsresultat.UNDERKJENT && begrunnelse && årsakerUnderkjent.length > 0);
+        resultat === Totrinnsresultat.GODKJENT ||
+        (resultat === Totrinnsresultat.UNDERKJENT && begrunnelse && årsakerUnderkjent.length > 0);
 
     const beslutteVedtak = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -76,14 +76,14 @@ const FatteVedtak: React.FC<{
             `/api/sak/vedtak/${behandling.id}/beslutte-vedtak`,
             'POST',
             {
-                godkjent: godkjent === Totrinnsresultat.GODKJENT,
+                godkjent: resultat === Totrinnsresultat.GODKJENT,
                 begrunnelse,
                 årsakerUnderkjent,
             }
         )
             .then((response) => {
                 if (response.status === RessursStatus.SUKSESS) {
-                    if (godkjent === Totrinnsresultat.GODKJENT) {
+                    if (resultat === Totrinnsresultat.GODKJENT) {
                         //hentBehandlingshistorikk.rerun();
                         //hentTotrinnskontroll.rerun();
                         settVisGodkjentModal(true);
@@ -99,7 +99,7 @@ const FatteVedtak: React.FC<{
     };
 
     const oppdaterResultat = (resultat: Totrinnsresultat) => {
-        settGodkjent(resultat);
+        settResultat(resultat);
         settBegrunnelse(undefined);
         if (resultat === Totrinnsresultat.GODKJENT) {
             settÅrsakerUnderkjent([]);
@@ -119,7 +119,7 @@ const FatteVedtak: React.FC<{
             <WrapperMedMargin>
                 <RadioGroup
                     legend={'Beslutt vedtak'}
-                    value={godkjent}
+                    value={resultat}
                     hideLegend
                     onChange={oppdaterResultat}
                 >
@@ -127,7 +127,7 @@ const FatteVedtak: React.FC<{
                     <Radio value={Totrinnsresultat.UNDERKJENT}>Underkjenn</Radio>
                 </RadioGroup>
             </WrapperMedMargin>
-            {godkjent === Totrinnsresultat.UNDERKJENT && (
+            {resultat === Totrinnsresultat.UNDERKJENT && (
                 <>
                     <WrapperMedMargin>
                         <CheckboxGroup

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
@@ -1,0 +1,171 @@
+import * as React from 'react';
+import { FormEvent, useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import {
+    Alert,
+    BodyShort,
+    Button,
+    Checkbox,
+    CheckboxGroup,
+    Heading,
+    Radio,
+    RadioGroup,
+    Textarea,
+} from '@navikt/ds-react';
+
+import { ÅrsakUnderkjent, årsakUnderkjentTilTekst } from './typer';
+import { useApp } from '../../../context/AppContext';
+import { useBehandling } from '../../../context/BehandlingContext';
+import { RessursStatus } from '../../../typer/ressurs';
+
+const WrapperMedMargin = styled.div`
+    display: block;
+    margin: 0.5rem 0;
+`;
+
+const SubmitButtonWrapper = styled.div`
+    display: flex;
+    justify-content: center;
+    margin-top: 0.5rem;
+`;
+
+const TittelContainer = styled.div`
+    margin: 0.5rem 0;
+`;
+
+interface TotrinnskontrollForm {
+    godkjent: boolean;
+    begrunnelse?: string;
+    årsakerUnderkjent: ÅrsakUnderkjent[];
+}
+
+enum Totrinnsresultat {
+    IKKE_VALGT = 'IKKE_VALGT',
+    GODKJENT = 'GODKJENT',
+    UNDERKJENT = 'UNDERKJENT',
+}
+
+const FatteVedtak: React.FC<{
+    settVisGodkjentModal: (vis: boolean) => void;
+}> = ({ settVisGodkjentModal }) => {
+    const { request } = useApp();
+    const navigate = useNavigate();
+    const { behandling } = useBehandling();
+
+    const [godkjent, settGodkjent] = useState<Totrinnsresultat>(Totrinnsresultat.IKKE_VALGT);
+    const [årsakerUnderkjent, settÅrsakerUnderkjent] = useState<ÅrsakUnderkjent[]>([]);
+    const [begrunnelse, settBegrunnelse] = useState<string>();
+    const [feil, settFeil] = useState<string>();
+    const [laster, settLaster] = useState<boolean>(false);
+
+    const erUtfylt =
+        godkjent === Totrinnsresultat.GODKJENT ||
+        (godkjent === Totrinnsresultat.UNDERKJENT &&
+            (begrunnelse || '').length > 0 &&
+            årsakerUnderkjent.length > 0);
+
+    const beslutteVedtak = (e: FormEvent<HTMLFormElement>) => {
+        e.preventDefault();
+        settLaster(true);
+        if (!erUtfylt) {
+            return;
+        }
+        settFeil(undefined);
+        request<never, TotrinnskontrollForm>(
+            `/api/sak/vedtak/${behandling.id}/beslutte-vedtak`,
+            'POST',
+            {
+                godkjent: godkjent === Totrinnsresultat.GODKJENT,
+                begrunnelse,
+                årsakerUnderkjent,
+            }
+        )
+            .then((response) => {
+                if (response.status === RessursStatus.SUKSESS) {
+                    if (godkjent === Totrinnsresultat.GODKJENT) {
+                        //hentBehandlingshistorikk.rerun();
+                        //hentTotrinnskontroll.rerun();
+                        settVisGodkjentModal(true);
+                    } else {
+                        //settToast(EToast.VEDTAK_UNDERKJENT);
+                        navigate('/oppgavebenk');
+                    }
+                } else {
+                    settFeil(response.frontendFeilmeldingUtenFeilkode);
+                }
+            })
+            .finally(() => settLaster(false));
+    };
+
+    const oppdaterResultat = (resultat: Totrinnsresultat) => {
+        settGodkjent(resultat);
+        settBegrunnelse(undefined);
+        if (resultat === Totrinnsresultat.GODKJENT) {
+            settÅrsakerUnderkjent([]);
+        }
+    };
+
+    return (
+        <form onSubmit={beslutteVedtak}>
+            <TittelContainer>
+                <Heading size={'small'} level={'3'}>
+                    Totrinnskontroll
+                </Heading>
+            </TittelContainer>
+            <BodyShort size={'small'}>
+                Kontroller opplysninger og faglige vurderinger gjort under behandlingen
+            </BodyShort>
+            <WrapperMedMargin>
+                <RadioGroup
+                    legend={'Beslutt vedtak'}
+                    value={godkjent}
+                    hideLegend
+                    onChange={oppdaterResultat}
+                >
+                    <Radio value={Totrinnsresultat.GODKJENT}>Godkjenn</Radio>
+                    <Radio value={Totrinnsresultat.UNDERKJENT}>Underkjenn</Radio>
+                </RadioGroup>
+            </WrapperMedMargin>
+            {godkjent === Totrinnsresultat.UNDERKJENT && (
+                <>
+                    <WrapperMedMargin>
+                        <CheckboxGroup
+                            legend={'Årsak til underkjennelse'}
+                            description={'Manglende eller feil opplysninger om:'}
+                            value={årsakerUnderkjent}
+                            onChange={settÅrsakerUnderkjent}
+                        >
+                            {Object.values(ÅrsakUnderkjent).map((årsak) => (
+                                <Checkbox key={årsak} value={årsak}>
+                                    {årsakUnderkjentTilTekst[årsak]}
+                                </Checkbox>
+                            ))}
+                        </CheckboxGroup>
+                    </WrapperMedMargin>
+                    <Textarea
+                        value={begrunnelse || ''}
+                        maxLength={0}
+                        onChange={(e) => {
+                            settBegrunnelse(e.target.value);
+                        }}
+                        label={'Begrunnelse'}
+                    />
+                </>
+            )}
+            {erUtfylt && (
+                <SubmitButtonWrapper>
+                    <Button type="submit" disabled={laster}>
+                        Fullfør
+                    </Button>
+                </SubmitButtonWrapper>
+            )}
+            {/* TODO AlertStripeFeilPreWrap */}
+            {feil && <Alert variant={'error'}>{feil}</Alert>}
+        </form>
+    );
+};
+
+export default FatteVedtak;

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
@@ -63,9 +63,7 @@ const FatteVedtak: React.FC<{
 
     const erUtfylt =
         godkjent === Totrinnsresultat.GODKJENT ||
-        (godkjent === Totrinnsresultat.UNDERKJENT &&
-            (begrunnelse || '').length > 0 &&
-            årsakerUnderkjent.length > 0);
+        (godkjent === Totrinnsresultat.UNDERKJENT && begrunnelse && årsakerUnderkjent.length > 0);
 
     const beslutteVedtak = (e: FormEvent<HTMLFormElement>) => {
         e.preventDefault();
@@ -162,7 +160,6 @@ const FatteVedtak: React.FC<{
                     </Button>
                 </SubmitButtonWrapper>
             )}
-            {/* TODO AlertStripeFeilPreWrap */}
             {feil && <Alert variant={'error'}>{feil}</Alert>}
         </form>
     );

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -1,0 +1,76 @@
+import * as React from 'react';
+import { FC, useEffect, useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
+
+import FatteVedtak from './FatteVedtak';
+import { TotrinnskontrollResponse, TotrinnskontrollStatus } from './typer';
+import { useBehandling } from '../../../context/BehandlingContext';
+import { useHentTotrinnskontroll } from '../../../hooks/useHentTotrinnskontroll';
+import { ModalWrapper } from '../../../komponenter/Modal/ModalWrapper';
+import { RessursStatus } from '../../../typer/ressurs';
+
+const BorderBox = styled.div`
+    border: 1px solid ${ABorderSubtle};
+    padding: 0.5rem 1rem;
+    margin: 1rem 0.5rem;
+    border-radius: 0.125rem;
+`;
+
+const TotrinnskontrollSwitch: FC<{
+    totrinnskontroll: TotrinnskontrollResponse;
+    settVisModalGodkjent: (vis: boolean) => void;
+}> = ({ totrinnskontroll, settVisModalGodkjent }) => {
+    switch (totrinnskontroll.status) {
+        case TotrinnskontrollStatus.KAN_FATTE_VEDTAK:
+            return <FatteVedtak settVisGodkjentModal={settVisModalGodkjent} />;
+        default:
+            return null;
+    }
+};
+
+const Totrinnskontroll: FC = () => {
+    const navigate = useNavigate();
+    const { behandling } = useBehandling();
+    const [visGodkjentModal, settVisGodkjentModal] = useState(false);
+
+    const { totrinnskontroll, hentTotrinnskontroll } = useHentTotrinnskontroll();
+
+    // TODO denne skal oppdateres
+    useEffect(() => {
+        hentTotrinnskontroll(behandling.id);
+    }, [behandling.id, hentTotrinnskontroll]);
+
+    if (totrinnskontroll.status !== RessursStatus.SUKSESS) {
+        return null;
+    }
+
+    return (
+        <>
+            <BorderBox>
+                <TotrinnskontrollSwitch
+                    totrinnskontroll={totrinnskontroll.data}
+                    settVisModalGodkjent={settVisGodkjentModal}
+                />
+            </BorderBox>
+            <ModalWrapper
+                tittel={'Vedtaket er godkjent'}
+                visModal={visGodkjentModal}
+                onClose={() => settVisGodkjentModal(false)}
+                aksjonsknapper={{
+                    hovedKnapp: {
+                        onClick: () => navigate('/oppgavebenk'),
+                        tekst: 'Til oppgavebenk',
+                    },
+                    lukkKnapp: { onClick: () => settVisGodkjentModal(false), tekst: 'Lukk' },
+                    marginTop: 4,
+                }}
+            />
+        </>
+    );
+};
+
+export default Totrinnskontroll;

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -39,7 +39,7 @@ const Totrinnskontroll: FC = () => {
 
     const { totrinnskontroll, hentTotrinnskontroll } = useHentTotrinnskontroll();
 
-    // TODO denne skal oppdateres
+    // TODO denne skal oppdateres med når/hvordan den skal hentes og at den hentes ved endringer i behandling, gjøres i egen oppgave
     useEffect(() => {
         hentTotrinnskontroll(behandling.id);
     }, [behandling.id, hentTotrinnskontroll]);

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -44,7 +44,10 @@ const Totrinnskontroll: FC = () => {
         hentTotrinnskontroll(behandling.id);
     }, [behandling.id, hentTotrinnskontroll]);
 
-    if (totrinnskontroll.status !== RessursStatus.SUKSESS) {
+    if (
+        totrinnskontroll.status !== RessursStatus.SUKSESS ||
+        totrinnskontroll.data.status == TotrinnskontrollStatus.UAKTUELT
+    ) {
         return null;
     }
 

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/typer.ts
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/typer.ts
@@ -1,0 +1,41 @@
+export enum TotrinnskontrollStatus {
+    IKKE_AUTORISERT = 'IKKE_AUTORISERT',
+    TOTRINNSKONTROLL_UNDERKJENT = 'TOTRINNSKONTROLL_UNDERKJENT',
+    UAKTUELT = 'UAKTUELT',
+    KAN_FATTE_VEDTAK = 'KAN_FATTE_VEDTAK',
+}
+
+export type TotrinnskontrollResponse =
+    | {
+          status: TotrinnskontrollStatus.IKKE_AUTORISERT;
+          totrinnskontroll: TotrinnskontrollOpprettet;
+      }
+    | {
+          status: TotrinnskontrollStatus.TOTRINNSKONTROLL_UNDERKJENT;
+          totrinnskontroll: TotrinnskontrollUnderkjentResponse;
+      }
+    | {
+          status: TotrinnskontrollStatus.KAN_FATTE_VEDTAK | TotrinnskontrollStatus.UAKTUELT;
+      };
+
+export type TotrinnskontrollOpprettet = {
+    opprettetAv: string;
+    opprettetTid: string;
+};
+
+export type TotrinnskontrollUnderkjentResponse = TotrinnskontrollOpprettet & {
+    begrunnelse: string;
+    årsakerUnderkjent: ÅrsakUnderkjent[];
+};
+
+export enum ÅrsakUnderkjent {
+    VEDTAK_OG_BEREGNING = 'VEDTAK_OG_BEREGNING',
+    VEDTAKSBREV = 'VEDTAKSBREV',
+    RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER = 'RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER',
+}
+
+export const årsakUnderkjentTilTekst: Record<ÅrsakUnderkjent, string> = {
+    VEDTAK_OG_BEREGNING: 'Vedtak og beregning',
+    VEDTAKSBREV: 'Vedtaksbrev',
+    RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER: 'Retur etter ønske fra saksbehandler',
+};

--- a/src/frontend/hooks/useHentTotrinnskontroll.ts
+++ b/src/frontend/hooks/useHentTotrinnskontroll.ts
@@ -1,0 +1,27 @@
+import { useCallback, useState } from 'react';
+
+import { useApp } from '../context/AppContext';
+import { TotrinnskontrollResponse } from '../Sider/Behandling/Totrinnskontroll/typer';
+import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../typer/ressurs';
+
+export const useHentTotrinnskontroll = () => {
+    const { request } = useApp();
+    const [totrinnskontroll, settTotrinnskontroll] = useState<Ressurs<TotrinnskontrollResponse>>(
+        byggTomRessurs()
+    );
+
+    const hentTotrinnskontroll = useCallback(
+        (behandlingId: string) => {
+            settTotrinnskontroll(byggHenterRessurs);
+            request<TotrinnskontrollResponse, null>(
+                `/api/sak/totrinnskontroll/${behandlingId}` // TODO
+            ).then(settTotrinnskontroll);
+        },
+        [request, settTotrinnskontroll]
+    );
+
+    return {
+        totrinnskontroll,
+        hentTotrinnskontroll,
+    };
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
En beslutter skal kunne godkjenne/underkjenne en behandling
https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0

Navngivning av `TotrinnskontrollStatus` gjøres i egen PR. 

Kan testes med dette i useHentTotrinnskontroll
```typescript
const hentTotrinnskontroll = useCallback(
        (behandlingId: string) => {
            settTotrinnskontroll(
                byggRessursSuksess({
                    status: TotrinnskontrollStatus.KAN_FATTE_VEDTAK,
                })
            );
        },
        [request, settTotrinnskontroll]
    );
```

<img width="314" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/9e80b614-2d93-4f12-9e3c-cb4c0cb9dac0">
<img width="315" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/121f123e-7640-4059-8292-6daab67a77b9">
