### PR TITLE
Visning av underkjent totrinnskontroll

### DIFF
--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import FatteVedtak from './FatteVedtak';
+import TotrinnskontrollUnderkjent from './TotrinnskontrollUnderkjent';
 import { TotrinnskontrollResponse, TotrinnskontrollStatus } from './typer';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { useHentTotrinnskontroll } from '../../../hooks/useHentTotrinnskontroll';
@@ -25,8 +26,14 @@ const TotrinnskontrollSwitch: FC<{
     settVisModalGodkjent: (vis: boolean) => void;
 }> = ({ totrinnskontroll, settVisModalGodkjent }) => {
     switch (totrinnskontroll.status) {
+        case TotrinnskontrollStatus.UAKTUELT:
+            return null;
         case TotrinnskontrollStatus.KAN_FATTE_VEDTAK:
             return <FatteVedtak settVisGodkjentModal={settVisModalGodkjent} />;
+        case TotrinnskontrollStatus.TOTRINNSKONTROLL_UNDERKJENT:
+            return (
+                <TotrinnskontrollUnderkjent totrinnskontroll={totrinnskontroll.totrinnskontroll} />
+            );
         default:
             return null;
     }

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/TotrinnskontrollUnderkjent.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/TotrinnskontrollUnderkjent.tsx
@@ -35,7 +35,7 @@ const TotrinnskontrollUnderkjent: React.FC<{
             <Heading size={'small'} level={'3'}>
                 Totrinnskontroll
             </Heading>
-            <Alert variant={'info'} size={'small'}>
+            <Alert variant={'warning'} inline={true}>
                 Vedtaket er underkjent
             </Alert>
             <div>

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/TotrinnskontrollUnderkjent.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/TotrinnskontrollUnderkjent.tsx
@@ -22,11 +22,6 @@ const ÅrsakUnderkjentRad = styled(BodyShort)`
     align-items: center;
 `;
 
-const BreakWordBodyLong = styled(BodyLong)`
-    white-space: pre-wrap;
-    word-wrap: break-word;
-`;
-
 const TotrinnskontrollUnderkjent: React.FC<{
     totrinnskontroll: TotrinnskontrollUnderkjentResponse;
 }> = ({ totrinnskontroll }) => {
@@ -60,7 +55,7 @@ const TotrinnskontrollUnderkjent: React.FC<{
             )}
             <div>
                 <Label>Begrunnelse</Label>
-                <BreakWordBodyLong size={'small'}>{totrinnskontroll.begrunnelse}</BreakWordBodyLong>
+                <BodyLong size={'small'}>{totrinnskontroll.begrunnelse}</BodyLong>
             </div>
         </>
     );

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/TotrinnskontrollUnderkjent.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/TotrinnskontrollUnderkjent.tsx
@@ -1,0 +1,69 @@
+import * as React from 'react';
+
+import styled from 'styled-components';
+
+import { CheckmarkIcon } from '@navikt/aksel-icons';
+import { Alert, BodyLong, BodyShort, Detail, Heading, Label } from '@navikt/ds-react';
+
+import { TotrinnskontrollUnderkjentResponse, årsakUnderkjentTilTekst } from './typer';
+import { formaterIsoDatoTid } from '../../../utils/dato';
+
+const ÅrsakerUnderkjentWrapper = styled.div`
+    margin-top: 0.5rem;
+`;
+
+const SukksessIkonMedHøyreMargin = styled(CheckmarkIcon)`
+    margin-right: 0.5rem;
+`;
+
+const ÅrsakUnderkjentRad = styled(BodyShort)`
+    display: flex;
+    margin-bottom: 1rem;
+    align-items: center;
+`;
+
+const BreakWordBodyLong = styled(BodyLong)`
+    white-space: pre-wrap;
+    word-wrap: break-word;
+`;
+
+const TotrinnskontrollUnderkjent: React.FC<{
+    totrinnskontroll: TotrinnskontrollUnderkjentResponse;
+}> = ({ totrinnskontroll }) => {
+    return (
+        <>
+            <Heading size={'small'} level={'3'}>
+                Totrinnskontroll
+            </Heading>
+            <Alert variant={'info'} size={'small'}>
+                Vedtaket er underkjent
+            </Alert>
+            <div>
+                <BodyShort size={'small'}>{totrinnskontroll.opprettetAv}</BodyShort>
+                <BodyShort size={'small'}>
+                    {formaterIsoDatoTid(totrinnskontroll.opprettetTid)}
+                </BodyShort>
+            </div>
+            {totrinnskontroll.årsakerUnderkjent.length > 0 && (
+                <div>
+                    <Label>Årsak til underkjennelse</Label>
+                    <Detail>Manglende eller feil opplysninger om:</Detail>
+                    <ÅrsakerUnderkjentWrapper>
+                        {totrinnskontroll.årsakerUnderkjent.map((årsakUnderkjent) => (
+                            <ÅrsakUnderkjentRad key={årsakUnderkjent}>
+                                <SukksessIkonMedHøyreMargin />
+                                {årsakUnderkjentTilTekst[årsakUnderkjent]}
+                            </ÅrsakUnderkjentRad>
+                        ))}
+                    </ÅrsakerUnderkjentWrapper>
+                </div>
+            )}
+            <div>
+                <Label>Begrunnelse</Label>
+                <BreakWordBodyLong size={'small'}>{totrinnskontroll.begrunnelse}</BreakWordBodyLong>
+            </div>
+        </>
+    );
+};
+
+export default TotrinnskontrollUnderkjent;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Visning av at et vedtak er underkjent. Tenker styling kan fikses på senere.

Kan testes med
```typescript
const hentTotrinnskontroll = useCallback(
        (behandlingId: string) => {
            settTotrinnskontroll(
                byggRessursSuksess({
                    status: TotrinnskontrollStatus.TOTRINNSKONTROLL_UNDERKJENT,
                    totrinnskontroll: {
                        opprettetTid: '2023-01-01T01:01:01',
                        opprettetAv: 'Sara Eirik',
                        årsakerUnderkjent: [ÅrsakUnderkjent.VEDTAKSBREV],
                        begrunnelse:
                            'en god begrunnelse som går over flere rader kanskje? Idag er det fredag',
                    },
                })
            );
        },
        [request, settTotrinnskontroll]
    );
```

### Følgende kan ignoreres
Det ble fikset med å bruke inline på alert

<img width="299" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/69ff58bd-2d69-4bf4-ab05-2022f99ae84c">


Store forskjellen:
I EF har man dette for visning av ikone og tekst. Denne ikonen har bakgrunnsfarge. 
```typescript
<div className="ikon-med-tekst">
   <Info height={20} width={20} />
   <SmallTextLabel>Vedtaket er sendt til godkjenning</SmallTextLabel>
</div>
```
https://github.com/navikt/familie-ef-sak-frontend/blob/master/src/frontend/Komponenter/Behandling/Totrinnskontroll/Totrinnskontroll.tsx#L162-L165
Og ser sånn ut
<img width="338" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/020bdd6d-3e56-4d24-845e-55a77a759f4f">
