### PR TITLE
Lagre vedtak ved bruk av ekte barn

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -24,7 +24,7 @@ import {
     Stønadsperiode,
     Utgift,
 } from '../../../../../typer/vedtak';
-import { Barn, Vilkårsresultat } from '../../../vilkår';
+import { GrunnlagBarn, Vilkårsresultat } from '../../../vilkår';
 import { lagVedtakRequest, tomStønadsperiodeRad, tomUtgiftPerBarn } from '../utils';
 
 export type InnvilgeVedtakForm = {
@@ -56,12 +56,14 @@ const Knapp = styled(Button)`
 const initStønadsperioder = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined) =>
     vedtak ? vedtak.stønadsperioder : [tomStønadsperiodeRad()];
 
-const initUtgifter = (vedtak: InnvilgeVedtakForBarnetilsyn | undefined, barnIBehandling: Barn[]) =>
-    vedtak ? vedtak.utgifter : tomUtgiftPerBarn(barnIBehandling);
+const initUtgifter = (
+    vedtak: InnvilgeVedtakForBarnetilsyn | undefined,
+    barnIBehandling: GrunnlagBarn[]
+) => (vedtak ? vedtak.utgifter : tomUtgiftPerBarn(barnIBehandling));
 
 const initFormState = (
     vedtak: InnvilgeVedtakForBarnetilsyn | undefined,
-    barnIBehandling: Barn[]
+    barnIBehandling: GrunnlagBarn[]
 ) => ({
     stønadsperioder: initStønadsperioder(vedtak),
     utgifter: initUtgifter(vedtak, barnIBehandling),
@@ -71,7 +73,7 @@ interface Props {
     lagretVedtak?: InnvilgeVedtakForBarnetilsyn;
     settResultatType: (val: BehandlingResultat | undefined) => void;
     låsFraDatoFørsteRad: boolean;
-    barnIBehandling: Barn[];
+    barnIBehandling: GrunnlagBarn[];
 }
 
 export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnIBehandling }) => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 
-import { v4 as uuidv4 } from 'uuid';
-
 import { InnvilgeBarnetilsyn } from './InnvilgeBarnetilsyn';
+import { useVilkår } from '../../../../../context/VilkårContext';
+import DataViewer from '../../../../../komponenter/DataViewer';
 import { BehandlingResultat } from '../../../../../typer/behandling/behandlingResultat';
 
 interface Props {
@@ -10,19 +10,18 @@ interface Props {
 }
 
 export const InnvilgeVedtak: FC<Props> = ({ settResultatType }) => {
-    const barnIBehandling = [
-        { barnId: uuidv4(), registergrunnlag: { navn: 'Ronja Røverdatter' } },
-        { barnId: uuidv4(), registergrunnlag: { navn: 'Espen Askeladden' } },
-    ];
+    const { vilkårsvurdering } = useVilkår();
 
     return (
-        <>
-            {/* TODO: Revurderes fra og med */}
-            <InnvilgeBarnetilsyn
-                settResultatType={settResultatType}
-                låsFraDatoFørsteRad={false}
-                barnIBehandling={barnIBehandling}
-            />
-        </>
+        // TODO: Revurderes fra og med
+        <DataViewer response={{ vilkårsvurdering }}>
+            {({ vilkårsvurdering }) => (
+                <InnvilgeBarnetilsyn
+                    settResultatType={settResultatType}
+                    låsFraDatoFørsteRad={false}
+                    barnIBehandling={vilkårsvurdering.grunnlag.barn}
+                />
+            )}
+        </DataViewer>
     );
 };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -8,7 +8,7 @@ import UtgifterValg from './UtgifterValg';
 import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import { RecordState } from '../../../../../../hooks/felles/useRecordState';
 import { Utgift } from '../../../../../../typer/vedtak';
-import { Barn } from '../../../../vilkår';
+import { GrunnlagBarn } from '../../../../vilkår';
 
 const Container = styled.div`
     display: flex;
@@ -19,7 +19,7 @@ const Container = styled.div`
 interface Props {
     errorState: FormErrors<Record<string, Utgift[]>>;
     utgifterState: RecordState<Utgift[]>;
-    barnIBehandling: Barn[];
+    barnIBehandling: GrunnlagBarn[];
 }
 
 const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling, errorState }) => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -11,7 +11,7 @@ import TextField from '../../../../../../komponenter/Skjema/TextField';
 import { Utgift, UtgifterProperty } from '../../../../../../typer/vedtak';
 import { tilÅrMåned } from '../../../../../../utils/dato';
 import { harTallverdi, tilTallverdi } from '../../../../../../utils/tall';
-import { Barn } from '../../../../vilkår';
+import { GrunnlagBarn } from '../../../../vilkår';
 
 const Grid = styled.div<{ $lesevisning?: boolean }>`
     display: grid;
@@ -24,7 +24,7 @@ interface Props {
     // begrunnelseState: FieldState;
     errorState: FormErrors<Utgift[]>;
     utgifter: Utgift[];
-    barn: Barn;
+    barn: GrunnlagBarn;
     oppdaterUtgift: (utgiftIndeks: number, utgift: Utgift) => void;
     // oppdaterUtgifter: (utgifter: Utgift[]) => void;
     // settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -7,14 +7,14 @@ import {
     Utgift,
     VedtakType,
 } from '../../../../typer/vedtak';
-import { Barn } from '../../vilkår';
+import { GrunnlagBarn } from '../../vilkår';
 
 export const tomStønadsperiodeRad = (): Stønadsperiode => ({
     fom: '',
     tom: '',
 });
 
-export const tomUtgiftPerBarn = (barnIBehandling: Barn[]): Record<string, Utgift[]> =>
+export const tomUtgiftPerBarn = (barnIBehandling: GrunnlagBarn[]): Record<string, Utgift[]> =>
     barnIBehandling.reduce((acc, barn) => {
         return { ...acc, [barn.barnId]: [tomUtgiftRad()] };
     }, {});

--- a/src/frontend/Sider/Behandling/vilkår.ts
+++ b/src/frontend/Sider/Behandling/vilkår.ts
@@ -9,18 +9,6 @@ export enum Vilkårsresultat {
     SKAL_IKKE_VURDERES = 'SKAL_IKKE_VURDERES',
 }
 
-export interface Barn {
-    barnId: string;
-    // søknadsgrunnlag: BarnSøknadsgrunnlag;
-    registergrunnlag: BarnRegistergrunnlag;
-    // barnepass?: Barnepass;
-}
-
-interface BarnRegistergrunnlag {
-    navn?: string;
-    fødselsdato?: string;
-}
-
 export type Vilkårtype = Inngangsvilkårtype;
 
 export enum Inngangsvilkårtype {
@@ -55,7 +43,29 @@ export interface Delvilkår {
     vurderinger: Vurdering[];
 }
 
-interface VilkårGrunnlag {}
+interface GrunnlagHovedytelse {}
+
+interface GrunnlagAktivitet {}
+
+export interface GrunnlagBarn {
+    ident: string;
+    barnId: string;
+    registergrunnlag: RegistergrunnlagBarn;
+    søknadgrunnlag?: SøknadsgrunnlagBarn;
+}
+
+interface RegistergrunnlagBarn {
+    navn: string;
+    dødsdato?: string;
+}
+
+interface SøknadsgrunnlagBarn {}
+
+interface VilkårGrunnlag {
+    hovedytelse: GrunnlagHovedytelse;
+    aktivitet: GrunnlagAktivitet;
+    barn: GrunnlagBarn[];
+}
 
 export interface Vilkårsvurdering {
     vilkårsett: Vilkår[];


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Til nå har barn vært mocket i vedtak og beregning, som har gjort at kallet feiler. Nå henter man barnene fra grunnlagsdata i vilkårsvurdering, og lagring av vedtak fungerer 🥳 

For å få det til måtte kallet for å hente vilkår endres så det til med barnId (UUID). Se [PR 73](https://github.com/navikt/tilleggsstonader-sak/pull/73)