### PR TITLE
Totrinnskontroll - visning at behandling er Sendt til beslutter

### DIFF
--- a/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
@@ -73,7 +73,7 @@ const FatteVedtak: React.FC<{
         }
         settFeil(undefined);
         request<never, TotrinnskontrollForm>(
-            `/api/sak/vedtak/${behandling.id}/beslutte-vedtak`,
+            `/api/sak/totrinnskontroll/${behandling.id}/beslutte-vedtak`,
             'POST',
             {
                 godkjent: resultat === Totrinnsresultat.GODKJENT,

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/SendtTilBeslutter.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/SendtTilBeslutter.tsx
@@ -1,0 +1,79 @@
+import * as React from 'react';
+import { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react';
+
+import { TotrinnskontrollOpprettet } from './typer';
+import { useApp } from '../../../context/AppContext';
+import { useBehandling } from '../../../context/BehandlingContext';
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
+import { formaterIsoDatoTid } from '../../../utils/dato';
+
+const AngreSendTilBeslutterContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+    margin-top: 1rem;
+`;
+
+const SendtTilBeslutter: React.FC<{
+    totrinnskontroll: TotrinnskontrollOpprettet;
+}> = ({ totrinnskontroll }) => {
+    const { request } = useApp();
+    const { behandling, hentBehandling } = useBehandling();
+    const [feilmelding, settFeilmelding] = useState<string>('');
+    const [laster, settLaster] = useState(false);
+
+    const angreSendTilBeslutter = () => {
+        if (laster) {
+            return;
+        }
+        settLaster(true);
+        settFeilmelding('');
+        request<string, null>(`/api/sak/totrinnskontroll/${behandling.id}/angre-send-til-beslutter`)
+            .then((res: RessursSuksess<string> | RessursFeilet) => {
+                if (res.status === RessursStatus.SUKSESS) {
+                    hentBehandling.rerun();
+                    //hentTotrinnskontroll.rerun();
+                    //hentBehandlingshistorikk.rerun();
+                } else {
+                    settFeilmelding(res.frontendFeilmelding);
+                }
+            })
+            .finally(() => {
+                settLaster(false);
+            });
+    };
+
+    return (
+        <>
+            <Heading size={'small'} level={'3'}>
+                Totrinnskontroll
+            </Heading>
+            <Alert variant={'info'} inline={true}>
+                Vedtaket er sendt til godkjenning
+            </Alert>
+            <div>
+                <BodyShort size={'small'}>{totrinnskontroll.opprettetAv}</BodyShort>
+                <BodyShort size={'small'}>
+                    {formaterIsoDatoTid(totrinnskontroll.opprettetTid)}
+                </BodyShort>
+            </div>
+            <AngreSendTilBeslutterContainer>
+                <Button
+                    size="small"
+                    disabled={laster}
+                    variant={'secondary'}
+                    onClick={angreSendTilBeslutter}
+                >
+                    Angre sendt til beslutter
+                </Button>
+                {feilmelding && <Alert variant={'error'}>{feilmelding}</Alert>}
+            </AngreSendTilBeslutterContainer>
+        </>
+    );
+};
+
+export default SendtTilBeslutter;

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -7,6 +7,7 @@ import styled from 'styled-components';
 import { ABorderSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import FatteVedtak from './FatteVedtak';
+import SendtTilBeslutter from './SendtTilBeslutter';
 import TotrinnskontrollUnderkjent from './TotrinnskontrollUnderkjent';
 import { TotrinnskontrollResponse, TotrinnskontrollStatus } from './typer';
 import { useBehandling } from '../../../context/BehandlingContext';
@@ -34,6 +35,8 @@ const TotrinnskontrollSwitch: FC<{
             return (
                 <TotrinnskontrollUnderkjent totrinnskontroll={totrinnskontroll.totrinnskontroll} />
             );
+        case TotrinnskontrollStatus.IKKE_AUTORISERT:
+            return <SendtTilBeslutter totrinnskontroll={totrinnskontroll.totrinnskontroll} />;
         default:
             return null;
     }

--- a/src/frontend/hooks/useHentTotrinnskontroll.ts
+++ b/src/frontend/hooks/useHentTotrinnskontroll.ts
@@ -14,7 +14,7 @@ export const useHentTotrinnskontroll = () => {
         (behandlingId: string) => {
             settTotrinnskontroll(byggHenterRessurs);
             request<TotrinnskontrollResponse, null>(
-                `/api/sak/totrinnskontroll/${behandlingId}` // TODO
+                `/api/sak/totrinnskontroll/${behandlingId}`
             ).then(settTotrinnskontroll);
         },
         [request, settTotrinnskontroll]


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Flyttet ut visning at den er sendt til beslutter i egen oppgave, backend må jeg kanskje vente litt med.
https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16831

<img width="289" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/655f8d73-f7ce-4060-b338-9b8413e98500">

Kan testes med
```typescript
settTotrinnskontroll(
                byggRessursSuksess({
                    status: TotrinnskontrollStatus.IKKE_AUTORISERT,
                    totrinnskontroll: { opprettetTid: '2023-01-01T13:10:13', opprettetAv: 'Meg' },
                })
            );
```

`TotrinnskontrollStatus`-enum kan endres senere når backend kommit lengre