### PR TITLE
Fikset totrinnskontroll med flyt og state

### DIFF
--- a/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
@@ -16,7 +16,7 @@ import {
     Textarea,
 } from '@navikt/ds-react';
 
-import { ÅrsakUnderkjent, årsakUnderkjentTilTekst } from './typer';
+import { TotrinnskontrollResponse, ÅrsakUnderkjent, årsakUnderkjentTilTekst } from './typer';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { RessursStatus } from '../../../typer/ressurs';
@@ -53,7 +53,7 @@ const FatteVedtak: React.FC<{
 }> = ({ settVisGodkjentModal }) => {
     const { request } = useApp();
     const navigate = useNavigate();
-    const { behandling } = useBehandling();
+    const { behandling, hentBehandling } = useBehandling();
 
     const [resultat, settResultat] = useState<Totrinnsresultat>(Totrinnsresultat.IKKE_VALGT);
     const [årsakerUnderkjent, settÅrsakerUnderkjent] = useState<ÅrsakUnderkjent[]>([]);
@@ -72,7 +72,7 @@ const FatteVedtak: React.FC<{
             return;
         }
         settFeil(undefined);
-        request<never, TotrinnskontrollForm>(
+        request<TotrinnskontrollResponse, TotrinnskontrollForm>(
             `/api/sak/totrinnskontroll/${behandling.id}/beslutte-vedtak`,
             'POST',
             {
@@ -84,12 +84,12 @@ const FatteVedtak: React.FC<{
             .then((response) => {
                 if (response.status === RessursStatus.SUKSESS) {
                     if (resultat === Totrinnsresultat.GODKJENT) {
+                        hentBehandling.rerun();
                         //hentBehandlingshistorikk.rerun();
-                        //hentTotrinnskontroll.rerun();
                         settVisGodkjentModal(true);
                     } else {
                         //settToast(EToast.VEDTAK_UNDERKJENT);
-                        navigate('/oppgavebenk');
+                        navigate('/');
                     }
                 } else {
                     settFeil(response.frontendFeilmeldingUtenFeilkode);

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
@@ -19,7 +19,7 @@ import {
 import { TotrinnskontrollResponse, ÅrsakUnderkjent, årsakUnderkjentTilTekst } from './typer';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
-import { RessursStatus } from '../../../typer/ressurs';
+import { Ressurs, RessursStatus } from '../../../typer/ressurs';
 
 const WrapperMedMargin = styled.div`
     display: block;
@@ -50,7 +50,8 @@ enum Totrinnsresultat {
 
 const FatteVedtak: React.FC<{
     settVisGodkjentModal: (vis: boolean) => void;
-}> = ({ settVisGodkjentModal }) => {
+    settTotrinnskontroll: React.Dispatch<React.SetStateAction<Ressurs<TotrinnskontrollResponse>>>;
+}> = ({ settVisGodkjentModal, settTotrinnskontroll }) => {
     const { request } = useApp();
     const navigate = useNavigate();
     const { behandling, hentBehandling } = useBehandling();
@@ -85,6 +86,7 @@ const FatteVedtak: React.FC<{
                 if (response.status === RessursStatus.SUKSESS) {
                     if (resultat === Totrinnsresultat.GODKJENT) {
                         hentBehandling.rerun();
+                        settTotrinnskontroll(response);
                         //hentBehandlingshistorikk.rerun();
                         settVisGodkjentModal(true);
                     } else {

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/SendtTilBeslutter.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/SendtTilBeslutter.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react';
 
-import { TotrinnskontrollOpprettet } from './typer';
+import { TotrinnskontrollOpprettet, TotrinnskontrollResponse } from './typer';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
@@ -32,11 +32,13 @@ const SendtTilBeslutter: React.FC<{
         }
         settLaster(true);
         settFeilmelding('');
-        request<string, null>(`/api/sak/totrinnskontroll/${behandling.id}/angre-send-til-beslutter`)
-            .then((res: RessursSuksess<string> | RessursFeilet) => {
+        request<TotrinnskontrollResponse, null>(
+            `/api/sak/totrinnskontroll/${behandling.id}/angre-send-til-beslutter`,
+            'POST'
+        )
+            .then((res: RessursSuksess<TotrinnskontrollResponse> | RessursFeilet) => {
                 if (res.status === RessursStatus.SUKSESS) {
                     hentBehandling.rerun();
-                    //hentTotrinnskontroll.rerun();
                     //hentBehandlingshistorikk.rerun();
                 } else {
                     settFeilmelding(res.frontendFeilmelding);

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/SendtTilBeslutter.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/SendtTilBeslutter.tsx
@@ -8,7 +8,7 @@ import { Alert, BodyShort, Button, Heading } from '@navikt/ds-react';
 import { TotrinnskontrollOpprettet, TotrinnskontrollResponse } from './typer';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
-import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
+import { Ressurs, RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
 import { formaterIsoDatoTid } from '../../../utils/dato';
 
 const AngreSendTilBeslutterContainer = styled.div`
@@ -20,7 +20,8 @@ const AngreSendTilBeslutterContainer = styled.div`
 
 const SendtTilBeslutter: React.FC<{
     totrinnskontroll: TotrinnskontrollOpprettet;
-}> = ({ totrinnskontroll }) => {
+    settTotrinnskontroll: React.Dispatch<React.SetStateAction<Ressurs<TotrinnskontrollResponse>>>;
+}> = ({ totrinnskontroll, settTotrinnskontroll }) => {
     const { request } = useApp();
     const { behandling, hentBehandling } = useBehandling();
     const [feilmelding, settFeilmelding] = useState<string>('');
@@ -36,12 +37,13 @@ const SendtTilBeslutter: React.FC<{
             `/api/sak/totrinnskontroll/${behandling.id}/angre-send-til-beslutter`,
             'POST'
         )
-            .then((res: RessursSuksess<TotrinnskontrollResponse> | RessursFeilet) => {
-                if (res.status === RessursStatus.SUKSESS) {
+            .then((response: RessursSuksess<TotrinnskontrollResponse> | RessursFeilet) => {
+                if (response.status === RessursStatus.SUKSESS) {
                     hentBehandling.rerun();
+                    settTotrinnskontroll(response);
                     //hentBehandlingshistorikk.rerun();
                 } else {
-                    settFeilmelding(res.frontendFeilmelding);
+                    settFeilmelding(response.frontendFeilmelding);
                 }
             })
             .finally(() => {

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -12,8 +12,11 @@ import TotrinnskontrollUnderkjent from './TotrinnskontrollUnderkjent';
 import { TotrinnskontrollResponse, TotrinnskontrollStatus } from './typer';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { useHentTotrinnskontroll } from '../../../hooks/useHentTotrinnskontroll';
+import { usePrevious } from '../../../hooks/usePrevious';
 import { ModalWrapper } from '../../../komponenter/Modal/ModalWrapper';
-import { RessursStatus } from '../../../typer/ressurs';
+import { Behandling } from '../../../typer/behandling/behandling';
+import { BehandlingStatus } from '../../../typer/behandling/behandlingStatus';
+import { Ressurs, RessursStatus } from '../../../typer/ressurs';
 
 const BorderBox = styled.div`
     border: 1px solid ${ABorderSubtle};
@@ -25,39 +28,65 @@ const BorderBox = styled.div`
 const TotrinnskontrollSwitch: FC<{
     totrinnskontroll: TotrinnskontrollResponse;
     settVisModalGodkjent: (vis: boolean) => void;
-}> = ({ totrinnskontroll, settVisModalGodkjent }) => {
+    settTotrinnskontroll: React.Dispatch<React.SetStateAction<Ressurs<TotrinnskontrollResponse>>>;
+}> = ({ totrinnskontroll, settVisModalGodkjent, settTotrinnskontroll }) => {
     switch (totrinnskontroll.status) {
         case TotrinnskontrollStatus.UAKTUELT:
             return null;
         case TotrinnskontrollStatus.KAN_FATTE_VEDTAK:
-            return <FatteVedtak settVisGodkjentModal={settVisModalGodkjent} />;
+            return (
+                <FatteVedtak
+                    settVisGodkjentModal={settVisModalGodkjent}
+                    settTotrinnskontroll={settTotrinnskontroll}
+                />
+            );
         case TotrinnskontrollStatus.TOTRINNSKONTROLL_UNDERKJENT:
             return (
                 <TotrinnskontrollUnderkjent totrinnskontroll={totrinnskontroll.totrinnskontroll} />
             );
         case TotrinnskontrollStatus.IKKE_AUTORISERT:
-            return <SendtTilBeslutter totrinnskontroll={totrinnskontroll.totrinnskontroll} />;
+            return (
+                <SendtTilBeslutter
+                    totrinnskontroll={totrinnskontroll.totrinnskontroll}
+                    settTotrinnskontroll={settTotrinnskontroll}
+                />
+            );
         default:
             return null;
     }
 };
 
+/**
+ * Håndtering av ulike states for å håndtere flyten av at en behandling skal hente totrinnskontroll på nytt eller ikke
+ */
+const behandlingErSendtTilBeslutter = (
+    prevBehandling: Behandling | undefined,
+    behandling: Behandling
+) => {
+    return (
+        prevBehandling?.status !== behandling.status &&
+        behandling.status === BehandlingStatus.FATTER_VEDTAK
+    );
+};
 const Totrinnskontroll: FC = () => {
     const navigate = useNavigate();
     const { behandling } = useBehandling();
+    const prevBehandling = usePrevious(behandling);
+
     const [visGodkjentModal, settVisGodkjentModal] = useState(false);
 
-    const { totrinnskontroll, hentTotrinnskontroll } = useHentTotrinnskontroll();
+    const { totrinnskontroll, hentTotrinnskontroll, settTotrinnskontroll } =
+        useHentTotrinnskontroll();
 
-    // TODO denne skal oppdateres med når/hvordan den skal hentes og at den hentes ved endringer i behandling, gjøres i egen oppgave
     useEffect(() => {
-        hentTotrinnskontroll(behandling.id);
-    }, [behandling.id, hentTotrinnskontroll]);
+        if (behandlingErSendtTilBeslutter(prevBehandling, behandling)) {
+            hentTotrinnskontroll(behandling.id);
+        }
+    }, [prevBehandling, behandling, hentTotrinnskontroll]);
 
     const skalViseTotrinnskontrollSwitch =
         totrinnskontroll.status === RessursStatus.SUKSESS &&
         totrinnskontroll.data.status !== TotrinnskontrollStatus.UAKTUELT;
-
     return (
         <>
             {skalViseTotrinnskontrollSwitch && (
@@ -65,6 +94,7 @@ const Totrinnskontroll: FC = () => {
                     <TotrinnskontrollSwitch
                         totrinnskontroll={totrinnskontroll.data}
                         settVisModalGodkjent={settVisGodkjentModal}
+                        settTotrinnskontroll={settTotrinnskontroll}
                     />
                 </BorderBox>
             )}

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -54,21 +54,20 @@ const Totrinnskontroll: FC = () => {
         hentTotrinnskontroll(behandling.id);
     }, [behandling.id, hentTotrinnskontroll]);
 
-    if (
-        totrinnskontroll.status !== RessursStatus.SUKSESS ||
-        totrinnskontroll.data.status == TotrinnskontrollStatus.UAKTUELT
-    ) {
-        return null;
-    }
+    const skalViseTotrinnskontrollSwitch =
+        totrinnskontroll.status === RessursStatus.SUKSESS &&
+        totrinnskontroll.data.status !== TotrinnskontrollStatus.UAKTUELT;
 
     return (
         <>
-            <BorderBox>
-                <TotrinnskontrollSwitch
-                    totrinnskontroll={totrinnskontroll.data}
-                    settVisModalGodkjent={settVisGodkjentModal}
-                />
-            </BorderBox>
+            {skalViseTotrinnskontrollSwitch && (
+                <BorderBox>
+                    <TotrinnskontrollSwitch
+                        totrinnskontroll={totrinnskontroll.data}
+                        settVisModalGodkjent={settVisGodkjentModal}
+                    />
+                </BorderBox>
+            )}
             <ModalWrapper
                 tittel={'Vedtaket er godkjent'}
                 visModal={visGodkjentModal}

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -2,6 +2,7 @@ import constate from 'constate';
 
 import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
 import { Behandling } from '../typer/behandling/behandling';
+import { erBehandlingRedigerbar } from '../typer/behandling/behandlingStatus';
 
 interface Props {
     behandling: Behandling;
@@ -10,7 +11,7 @@ interface Props {
 
 export const [BehandlingProvider, useBehandling] = constate(
     ({ behandling, hentBehandling }: Props) => {
-        const behandlingErRedigerbar = true;
+        const behandlingErRedigerbar = erBehandlingRedigerbar(behandling);
 
         return {
             behandling,

--- a/src/frontend/hooks/useHentTotrinnskontroll.ts
+++ b/src/frontend/hooks/useHentTotrinnskontroll.ts
@@ -23,5 +23,6 @@ export const useHentTotrinnskontroll = () => {
     return {
         totrinnskontroll,
         hentTotrinnskontroll,
+        settTotrinnskontroll,
     };
 };

--- a/src/frontend/hooks/usePrevious.ts
+++ b/src/frontend/hooks/usePrevious.ts
@@ -1,0 +1,9 @@
+import { useEffect, useRef } from 'react';
+
+export const usePrevious = <T>(value: T): T | undefined => {
+    const ref = useRef<T>();
+    useEffect(() => {
+        ref.current = value;
+    });
+    return ref.current;
+};

--- a/src/frontend/typer/behandling/behandlingStatus.ts
+++ b/src/frontend/typer/behandling/behandlingStatus.ts
@@ -1,3 +1,5 @@
+import { Behandling } from './behandling';
+
 export enum BehandlingStatus {
     OPPRETTET = 'OPPRETTET',
     UTREDES = 'UTREDES',
@@ -6,3 +8,6 @@ export enum BehandlingStatus {
     FERDIGSTILT = 'FERDIGSTILT',
     SATT_PÅ_VENT = 'SATT_PÅ_VENT',
 }
+
+export const erBehandlingRedigerbar = (behandling: Behandling): boolean =>
+    [BehandlingStatus.OPPRETTET, BehandlingStatus.UTREDES].includes(behandling.status);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Div endringer for å få totrinnskontroll til å virke. Har delt opp commits, den siste er den største
Har valgt å ikke flytte send til beslutter i denne PR, men at det gjøres i en egen oppgave. Det er både backend og frontend som skal til for at den skal virke.

[Skal oppdatere behandlingErRedigerbar](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/e309ceab6514e504629061f675b3b3bcc33553f6)
[Post for å angre send til beslutter](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/384f97bf5583dc6c92ce10e69514afda1b383480)

[Når man godkjenner så skal man fortsatt vise modalen, men ikke vise n…](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/3bb0b19b4441c4c69995c5a90bee6f2d2ffb72b1) 

[Når man fatter vedtak skal man trigge henting av behandling på nytt, …](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/b9f7e905c5ece78d423c576072484712d4d142da)

[Oppdaterer state for totrinnskontroll i de ulike komponentene](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/d5113172e5c32a8e0418a5fffba50245aee7da5f)