### PR TITLE
✨ Flere rader for stønadsperiode og utgifter i vedtak og beregning

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -154,6 +154,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnIBehand
                     <StønadsperiodeValg
                         stønadsperioderState={stønadsperioderState}
                         errorState={formState.errors.stønadsperioder}
+                        settValideringsFeil={formState.setErrors}
                     />
                     <Divider />
                     <Utgifter

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -161,6 +161,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnIBehand
                         barnIBehandling={barnIBehandling}
                         utgifterState={utgifterState}
                         errorState={formState.errors.utgifter}
+                        settValideringsFeil={formState.setErrors}
                     />
                     <DataViewer response={{ beregningsresultat }}>
                         {({ beregningsresultat }) => (

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -2,19 +2,25 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Heading, Label } from '@navikt/ds-react';
+import { PlusCircleIcon } from '@navikt/aksel-icons';
+import { Button, Heading, Label } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import { ListState } from '../../../../../../hooks/felles/useListState';
 import DateInput from '../../../../../../komponenter/Skjema/DateInput';
 import { Stønadsperiode, StønadsperiodeProperty } from '../../../../../../typer/vedtak';
+import { tomStønadsperiodeRad } from '../../utils';
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: repeat(2, max-content);
+    grid-template-columns: repeat(3, max-content);
     grid-gap: 0.5rem 1rem;
     align-items: start;
+
+    > :nth-child(3n + 3) {
+        grid-column: 1;
+    }
 `;
 
 interface Props {
@@ -39,6 +45,14 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
         );
     };
 
+    const leggTilTomRadUnder = (indeks: number) => {
+        stønadsperioderState.setValue((prevState) => [
+            ...prevState.slice(0, indeks + 1),
+            tomStønadsperiodeRad(),
+            ...prevState.slice(indeks + 1, prevState.length),
+        ]);
+    };
+
     return (
         <div>
             <Heading spacing size="small" level="5">
@@ -49,7 +63,7 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
                 <Label size="small">Til</Label>
                 {stønadsperioderState.value.map((stønadsperiode, indeks) => (
                     // TODO: Skal ikke bruke indeks som key
-                    <React.Fragment key={indeks}>
+                    <React.Fragment key={stønadsperiode.endretKey}>
                         <DateInput
                             label="Fra"
                             hideLabel
@@ -71,6 +85,13 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
                             }
                             size="small"
                             feil={errorState && errorState[indeks]?.tom}
+                        />
+                        <Button
+                            type="button"
+                            onClick={() => leggTilTomRadUnder(indeks)}
+                            variant="tertiary"
+                            icon={<PlusCircleIcon />}
+                            size="small"
                         />
                     </React.Fragment>
                 ))}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -63,9 +63,7 @@ const StønadsperiodeValg: React.FC<Props> = ({
         stønadsperioderState.remove(indeks);
 
         settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => {
-            const stønadsperioder = (prevState.stønadsperioder ?? []).filter(
-                (_, i) => i !== indeks
-            );
+            const stønadsperioder = (prevState.stønadsperioder ?? []).splice(indeks, 1);
             return { ...prevState, stønadsperioder };
         });
     };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -79,7 +79,6 @@ const StønadsperiodeValg: React.FC<Props> = ({
                 <Label size="small">Fra</Label>
                 <Label size="small">Til</Label>
                 {stønadsperioderState.value.map((stønadsperiode, indeks) => (
-                    // TODO: Skal ikke bruke indeks som key
                     <React.Fragment key={stønadsperiode.endretKey}>
                         <DateInput
                             label="Fra"

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -1,8 +1,8 @@
-import React from 'react';
+import React, { Dispatch, SetStateAction } from 'react';
 
 import styled from 'styled-components';
 
-import { PlusCircleIcon } from '@navikt/aksel-icons';
+import { PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
 import { Button, Heading, Label } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../../../context/BehandlingContext';
@@ -11,6 +11,7 @@ import { ListState } from '../../../../../../hooks/felles/useListState';
 import DateInput from '../../../../../../komponenter/Skjema/DateInput';
 import { Stønadsperiode, StønadsperiodeProperty } from '../../../../../../typer/vedtak';
 import { tomStønadsperiodeRad } from '../../utils';
+import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
 
 const Grid = styled.div`
     display: grid;
@@ -26,9 +27,14 @@ const Grid = styled.div`
 interface Props {
     errorState: FormErrors<Stønadsperiode[]>;
     stønadsperioderState: ListState<Stønadsperiode>;
+    settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;
 }
 
-const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorState }) => {
+const StønadsperiodeValg: React.FC<Props> = ({
+    stønadsperioderState,
+    errorState,
+    settValideringsFeil,
+}) => {
     const { behandlingErRedigerbar } = useBehandling();
 
     const oppdaterUtgiftsperiode = (
@@ -51,6 +57,17 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
             tomStønadsperiodeRad(),
             ...prevState.slice(indeks + 1, prevState.length),
         ]);
+    };
+
+    const slettPeriode = (indeks: number) => {
+        stønadsperioderState.remove(indeks);
+
+        settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => {
+            const stønadsperioder = (prevState.stønadsperioder ?? []).filter(
+                (_, i) => i !== indeks
+            );
+            return { ...prevState, stønadsperioder };
+        });
     };
 
     return (
@@ -86,13 +103,24 @@ const StønadsperiodeValg: React.FC<Props> = ({ stønadsperioderState, errorStat
                             size="small"
                             feil={errorState && errorState[indeks]?.tom}
                         />
-                        <Button
-                            type="button"
-                            onClick={() => leggTilTomRadUnder(indeks)}
-                            variant="tertiary"
-                            icon={<PlusCircleIcon />}
-                            size="small"
-                        />
+                        <div>
+                            <Button
+                                type="button"
+                                onClick={() => leggTilTomRadUnder(indeks)}
+                                variant="tertiary"
+                                icon={<PlusCircleIcon />}
+                                size="small"
+                            />
+                            {indeks !== 0 && (
+                                <Button
+                                    type="button"
+                                    onClick={() => slettPeriode(indeks)}
+                                    variant="tertiary"
+                                    icon={<TrashIcon />}
+                                    size="small"
+                                />
+                            )}
+                        </div>
                     </React.Fragment>
                 ))}
             </Grid>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -10,7 +10,7 @@ import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import { ListState } from '../../../../../../hooks/felles/useListState';
 import DateInput from '../../../../../../komponenter/Skjema/DateInput';
 import { Stønadsperiode, StønadsperiodeProperty } from '../../../../../../typer/vedtak';
-import { tomStønadsperiodeRad } from '../../utils';
+import { leggTilTomRadUnderIListe, tomStønadsperiodeRad } from '../../utils';
 import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
 
 const Grid = styled.div`
@@ -52,11 +52,9 @@ const StønadsperiodeValg: React.FC<Props> = ({
     };
 
     const leggTilTomRadUnder = (indeks: number) => {
-        stønadsperioderState.setValue((prevState) => [
-            ...prevState.slice(0, indeks + 1),
-            tomStønadsperiodeRad(),
-            ...prevState.slice(indeks + 1, prevState.length),
-        ]);
+        stønadsperioderState.setValue((prevState) =>
+            leggTilTomRadUnderIListe(prevState, tomStønadsperiodeRad(), indeks)
+        );
     };
 
     const slettPeriode = (indeks: number) => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -18,7 +18,7 @@ const Grid = styled.div`
     grid-gap: 0.5rem 1rem;
     align-items: start;
 
-    > :nth-child(3n + 3) {
+    > :nth-child(3n) {
         grid-column: 1;
     }
 `;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -37,7 +37,7 @@ const StønadsperiodeValg: React.FC<Props> = ({
 }) => {
     const { behandlingErRedigerbar } = useBehandling();
 
-    const oppdaterUtgiftsperiode = (
+    const oppdaterStønadsperiode = (
         indeks: number,
         property: StønadsperiodeProperty,
         value: string | undefined
@@ -84,7 +84,7 @@ const StønadsperiodeValg: React.FC<Props> = ({
                             erLesevisning={!behandlingErRedigerbar}
                             value={stønadsperiode.fom}
                             onChange={(dato?: string) =>
-                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.FOM, dato)
+                                oppdaterStønadsperiode(indeks, StønadsperiodeProperty.FOM, dato)
                             }
                             size="small"
                             feil={errorState && errorState[indeks]?.fom}
@@ -95,7 +95,7 @@ const StønadsperiodeValg: React.FC<Props> = ({
                             erLesevisning={!behandlingErRedigerbar}
                             value={stønadsperiode.tom}
                             onChange={(dato?: string) =>
-                                oppdaterUtgiftsperiode(indeks, StønadsperiodeProperty.TOM, dato)
+                                oppdaterStønadsperiode(indeks, StønadsperiodeProperty.TOM, dato)
                             }
                             size="small"
                             feil={errorState && errorState[indeks]?.tom}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -9,7 +9,6 @@ import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import { RecordState } from '../../../../../../hooks/felles/useRecordState';
 import { Utgift } from '../../../../../../typer/vedtak';
 import { GrunnlagBarn } from '../../../../vilkår';
-import { tomUtgiftRad } from '../../utils';
 import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
 
 const Container = styled.div`
@@ -31,37 +30,6 @@ const Utgifter: React.FC<Props> = ({
     errorState,
     settValideringsFeil,
 }) => {
-    const oppdaterUtgift = (barnId: string, utgiftIndex: number, oppdatertUtgift: Utgift) => {
-        const oppdaterteUtgifter = utgifterState.value[barnId].map((utgift, indeks) =>
-            indeks === utgiftIndex ? oppdatertUtgift : utgift
-        );
-
-        utgifterState.update(barnId, oppdaterteUtgifter);
-    };
-
-    const leggTilTomRadUnder = (barnId: string, utgiftIndex: number) => {
-        const prevState = utgifterState.value[barnId];
-        utgifterState.update(barnId, [
-            ...prevState.slice(0, utgiftIndex + 1),
-            tomUtgiftRad(),
-            ...prevState.slice(utgiftIndex + 1, prevState.length),
-        ]);
-    };
-
-    const slettPeriode = (barnId: string, utgiftIndex: number) => {
-        const oppdaterteUtgifter = utgifterState.value[barnId].filter((_, i) => i != utgiftIndex);
-
-        utgifterState.update(barnId, oppdaterteUtgifter);
-
-        settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => {
-            const utgiftsperioder = (
-                (prevState.utgifter && prevState.utgifter[barnId]) ??
-                []
-            ).splice(utgiftIndex, 1);
-            return { ...prevState, utgiftsperioder };
-        });
-    };
-
     return (
         <div>
             <Heading spacing size="small" level="5">
@@ -74,15 +42,10 @@ const Utgifter: React.FC<Props> = ({
                         utgifter={utgifterState.value[barn.barnId]}
                         errorState={errorState && errorState[barn.barnId]}
                         key={barn.barnId}
-                        oppdaterUtgift={(utgiftIndeks: number, oppdatertUtgift: Utgift) =>
-                            oppdaterUtgift(barn.barnId, utgiftIndeks, oppdatertUtgift)
+                        oppdaterUtgiter={(utgifter: Utgift[]) =>
+                            utgifterState.update(barn.barnId, utgifter)
                         }
-                        leggTilTomRadUnder={(utgiftIndeks: number) =>
-                            leggTilTomRadUnder(barn.barnId, utgiftIndeks)
-                        }
-                        slettPeriode={(utgiftIndeks: number) =>
-                            slettPeriode(barn.barnId, utgiftIndeks)
-                        }
+                        settValideringsFeil={settValideringsFeil}
                     />
                 ))}
             </Container>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -9,6 +9,7 @@ import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import { RecordState } from '../../../../../../hooks/felles/useRecordState';
 import { Utgift } from '../../../../../../typer/vedtak';
 import { GrunnlagBarn } from '../../../../vilkår';
+import { tomUtgiftRad } from '../../utils';
 
 const Container = styled.div`
     display: flex;
@@ -31,6 +32,15 @@ const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling, errorState 
         utgifterState.update(barnId, oppdaterteUtgifter);
     };
 
+    const leggTilTomRadUnder = (barnId: string, utgiftIndex: number) => {
+        const prevState = utgifterState.value[barnId];
+        utgifterState.update(barnId, [
+            ...prevState.slice(0, utgiftIndex + 1),
+            tomUtgiftRad(),
+            ...prevState.slice(utgiftIndex + 1, prevState.length),
+        ]);
+    };
+
     return (
         <div>
             <Heading spacing size="small" level="5">
@@ -45,6 +55,9 @@ const Utgifter: React.FC<Props> = ({ utgifterState, barnIBehandling, errorState 
                         key={barn.barnId}
                         oppdaterUtgift={(utgiftIndeks: number, oppdatertUtgift: Utgift) =>
                             oppdaterUtgift(barn.barnId, utgiftIndeks, oppdatertUtgift)
+                        }
+                        leggTilTomRadUnder={(utgiftIndeks: number) =>
+                            leggTilTomRadUnder(barn.barnId, utgiftIndeks)
                         }
                     />
                 ))}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/Utgifter.tsx
@@ -57,7 +57,7 @@ const Utgifter: React.FC<Props> = ({
             const utgiftsperioder = (
                 (prevState.utgifter && prevState.utgifter[barnId]) ??
                 []
-            ).filter((_, i) => i !== utgiftIndex);
+            ).splice(utgiftIndex, 1);
             return { ...prevState, utgiftsperioder };
         });
     };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { PlusCircleIcon } from '@navikt/aksel-icons';
+import { PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
 import { Button, Heading, Label } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../../../context/BehandlingContext';
@@ -31,6 +31,7 @@ interface Props {
     barn: GrunnlagBarn;
     oppdaterUtgift: (utgiftIndeks: number, utgift: Utgift) => void;
     leggTilTomRadUnder: (utgiftIndeks: number) => void;
+    slettPeriode: (utgiftIndeks: number) => void;
 }
 
 const UtgifterValg: React.FC<Props> = ({
@@ -39,6 +40,7 @@ const UtgifterValg: React.FC<Props> = ({
     errorState,
     oppdaterUtgift,
     leggTilTomRadUnder,
+    slettPeriode,
 }) => {
     const { behandlingErRedigerbar } = useBehandling();
 
@@ -114,13 +116,24 @@ const UtgifterValg: React.FC<Props> = ({
                                 feil={errorState && errorState[indeks]?.tom}
                                 size="small"
                             />
-                            <Button
-                                type="button"
-                                onClick={() => leggTilTomRadUnder(indeks)}
-                                variant="tertiary"
-                                icon={<PlusCircleIcon />}
-                                size="small"
-                            />
+                            <div>
+                                <Button
+                                    type="button"
+                                    onClick={() => leggTilTomRadUnder(indeks)}
+                                    variant="tertiary"
+                                    icon={<PlusCircleIcon />}
+                                    size="small"
+                                />
+                                {indeks !== 0 && (
+                                    <Button
+                                        type="button"
+                                        onClick={() => slettPeriode(indeks)}
+                                        variant="tertiary"
+                                        icon={<TrashIcon />}
+                                        size="small"
+                                    />
+                                )}
+                            </div>
                         </React.Fragment>
                     ))}
                 </Grid>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -2,7 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Heading, Label } from '@navikt/ds-react';
+import { PlusCircleIcon } from '@navikt/aksel-icons';
+import { Button, Heading, Label } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../../hooks/felles/useFormState';
@@ -15,9 +16,13 @@ import { GrunnlagBarn } from '../../../../vilkår';
 
 const Grid = styled.div<{ $lesevisning?: boolean }>`
     display: grid;
-    grid-template-columns: repeat(3, max-content);
+    grid-template-columns: repeat(4, max-content);
     grid-gap: 0.5rem 1rem;
     align-items: start;
+
+    > :nth-child(4n) {
+        grid-column: 1;
+    }
 `;
 
 interface Props {
@@ -26,13 +31,20 @@ interface Props {
     utgifter: Utgift[];
     barn: GrunnlagBarn;
     oppdaterUtgift: (utgiftIndeks: number, utgift: Utgift) => void;
+    leggTilTomRadUnder: (utgiftIndeks: number) => void;
     // oppdaterUtgifter: (utgifter: Utgift[]) => void;
     // settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;
     // barn: IBarnMedSamvær[];
     // låsFraDatoFørsteRad: boolean;
 }
 
-const UtgifterValg: React.FC<Props> = ({ utgifter, barn, errorState, oppdaterUtgift }) => {
+const UtgifterValg: React.FC<Props> = ({
+    utgifter,
+    barn,
+    errorState,
+    oppdaterUtgift,
+    leggTilTomRadUnder,
+}) => {
     // begrunnelseState,
     // errorState,
     // settValideringsFeil,
@@ -115,7 +127,7 @@ const UtgifterValg: React.FC<Props> = ({ utgifter, barn, errorState, oppdaterUtg
 
                     {utgifter.map((utgiftsperiode, indeks) => (
                         // TODO: Skal ikke bruke indeks som key
-                        <React.Fragment key={indeks}>
+                        <React.Fragment key={utgiftsperiode.endretKey}>
                             <TextField
                                 erLesevisning={!behandlingErRedigerbar}
                                 label="Utgifter"
@@ -161,6 +173,13 @@ const UtgifterValg: React.FC<Props> = ({ utgifter, barn, errorState, oppdaterUtg
                                     )
                                 }
                                 feil={errorState && errorState[indeks]?.tom}
+                                size="small"
+                            />
+                            <Button
+                                type="button"
+                                onClick={() => leggTilTomRadUnder(indeks)}
+                                variant="tertiary"
+                                icon={<PlusCircleIcon />}
                                 size="small"
                             />
                         </React.Fragment>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -67,7 +67,6 @@ const UtgifterValg: React.FC<Props> = ({
                     <Label size="small">Til</Label>
 
                     {utgifter.map((utgiftsperiode, indeks) => (
-                        // TODO: Skal ikke bruke indeks som key
                         <React.Fragment key={utgiftsperiode.endretKey}>
                             <TextField
                                 erLesevisning={!behandlingErRedigerbar}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -26,16 +26,11 @@ const Grid = styled.div<{ $lesevisning?: boolean }>`
 `;
 
 interface Props {
-    // begrunnelseState: FieldState;
     errorState: FormErrors<Utgift[]>;
     utgifter: Utgift[];
     barn: GrunnlagBarn;
     oppdaterUtgift: (utgiftIndeks: number, utgift: Utgift) => void;
     leggTilTomRadUnder: (utgiftIndeks: number) => void;
-    // oppdaterUtgifter: (utgifter: Utgift[]) => void;
-    // settValideringsFeil: Dispatch<SetStateAction<FormErrors<InnvilgeVedtakForm>>>;
-    // barn: IBarnMedSamvær[];
-    // låsFraDatoFørsteRad: boolean;
 }
 
 const UtgifterValg: React.FC<Props> = ({
@@ -45,16 +40,7 @@ const UtgifterValg: React.FC<Props> = ({
     oppdaterUtgift,
     leggTilTomRadUnder,
 }) => {
-    // begrunnelseState,
-    // errorState,
-    // settValideringsFeil,
-    // barn,
-    // låsFraDatoFørsteRad,
     const { behandlingErRedigerbar } = useBehandling();
-    // const { settIkkePersistertKomponent } = useApp();
-    // const [sanksjonsmodal, settSanksjonsmodal] = useState<Sanksjonsmodal>({
-    //     visModal: false,
-    // });
 
     const oppdaterUtgiftFelt = (
         indeks: number,
@@ -67,53 +53,6 @@ const UtgifterValg: React.FC<Props> = ({
         });
     };
 
-    // Oppdater for riktig rad
-    // Returner hele utgift objekt?
-
-    // const leggTilTomRadUnder = () => {
-    //     // const
-    //     if (utgifter) oppdaterUtgifter([...utgifter, { fra: '', til: '' }]);
-    //     else oppdaterUtgifter([{ fra: '', til: '' }]);
-    // };
-
-    // const periodeVariantTilUtgiftsperiodeProperty = (
-    //     periodeVariant: PeriodeVariant
-    // ): EUtgiftsperiodeProperty => {
-    //     switch (periodeVariant) {
-    //         case PeriodeVariant.ÅR_MÅNED_FRA:
-    //             return EUtgiftsperiodeProperty.årMånedFra;
-    //         case PeriodeVariant.ÅR_MÅNED_TIL:
-    //             return EUtgiftsperiodeProperty.årMånedTil;
-    //     }
-    // };
-
-    // const lukkSanksjonsmodal = () => {
-    //     settSanksjonsmodal({ visModal: false });
-    // };
-
-    // const slettPeriode = (indeks: number) => {
-    //     if (sanksjonsmodal.visModal) {
-    //         lukkSanksjonsmodal();
-    //     }
-    //     utgiftsperioderState.remove(indeks);
-    //     settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => {
-    //         const utgiftsperioder = (prevState.utgiftsperioder ?? []).filter((_, i) => i !== indeks);
-    //         return { ...prevState, utgiftsperioder };
-    //     });
-    // };
-
-    // const slettPeriodeModalHvisSanksjon = (indeks: number) => {
-    //     const periode = utgiftsperioderState.value[indeks];
-    //     if (periode.periodetype === EUtgiftsperiodetype.SANKSJON_1_MND) {
-    //         settSanksjonsmodal({
-    //             visModal: true,
-    //             indeks: indeks,
-    //             årMånedFra: periode.årMånedFra,
-    //         });
-    //     } else {
-    //         slettPeriode(indeks);
-    //     }
-    // };
     return (
         <div>
             <Heading spacing size="xsmall" level="5">

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -13,7 +13,7 @@ import { Utgift, UtgifterProperty } from '../../../../../../typer/vedtak';
 import { tilÅrMåned } from '../../../../../../utils/dato';
 import { harTallverdi, tilTallverdi } from '../../../../../../utils/tall';
 import { GrunnlagBarn } from '../../../../vilkår';
-import { tomUtgiftRad } from '../../utils';
+import { leggTilTomRadUnderIListe, tomUtgiftRad } from '../../utils';
 import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
 
 const Grid = styled.div<{ $lesevisning?: boolean }>`
@@ -64,12 +64,7 @@ const UtgifterValg: React.FC<Props> = ({
     };
 
     const leggTilTomRadUnder = (utgiftIndex: number) => {
-        const prevState = utgifter;
-        oppdaterUtgiter([
-            ...prevState.slice(0, utgiftIndex + 1),
-            tomUtgiftRad(),
-            ...prevState.slice(utgiftIndex + 1, prevState.length),
-        ]);
+        oppdaterUtgiter(leggTilTomRadUnderIListe(utgifter, tomUtgiftRad(), utgiftIndex));
     };
 
     const slettPeriode = (barnId: string, utgiftIndex: number) => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/vedtaksvalidering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/vedtaksvalidering.ts
@@ -82,11 +82,11 @@ const validerUtgifter = (
 
                 // TODO: Tilpass validering
                 if (!utgift.fom) {
-                    return { ...utgiftFeil, fra: 'Mangler fradato for periode' };
+                    return { ...utgiftFeil, fom: 'Mangler fradato for periode' };
                 }
 
                 if (!utgift.tom) {
-                    return { ...utgiftFeil, til: 'Mangler tildato for periode' };
+                    return { ...utgiftFeil, tom: 'Mangler tildato for periode' };
                 }
 
                 // TODO: Bytt ut validering av dato med noe som funker for årmåned

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -28,6 +28,10 @@ export const tomUtgiftRad = (): Utgift => ({
     endretKey: uuidv4(),
 });
 
+export const leggTilTomRadUnderIListe = <T>(liste: T[], nyRad: T, indeks: number): T[] => {
+    return [...liste.slice(0, indeks + 1), nyRad, ...liste.slice(indeks + 1, liste.length)];
+};
+
 export const lagVedtakRequest = (
     form: FormState<InnvilgeVedtakForm>
 ): InnvilgeVedtakForBarnetilsyn => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -1,3 +1,5 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { InnvilgeVedtakForm } from './InnvilgeVedtak/InnvilgeBarnetilsyn';
 import { FormState } from '../../../../hooks/felles/useFormState';
 import { BehandlingResultat } from '../../../../typer/behandling/behandlingResultat';
@@ -12,6 +14,7 @@ import { GrunnlagBarn } from '../../vilkår';
 export const tomStønadsperiodeRad = (): Stønadsperiode => ({
     fom: '',
     tom: '',
+    endretKey: uuidv4(),
 });
 
 export const tomUtgiftPerBarn = (barnIBehandling: GrunnlagBarn[]): Record<string, Utgift[]> =>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -25,6 +25,7 @@ export const tomUtgiftPerBarn = (barnIBehandling: GrunnlagBarn[]): Record<string
 export const tomUtgiftRad = (): Utgift => ({
     fom: '',
     tom: '',
+    endretKey: uuidv4(),
 });
 
 export const lagVedtakRequest = (

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -26,6 +26,7 @@ export type Utgift = {
     fom: string;
     tom: string;
     utgift?: number;
+    endretKey?: string; // intern for re-rendring
 };
 
 export enum UtgifterProperty {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -14,6 +14,7 @@ export type InnvilgeVedtakForBarnetilsyn = {
 export type Stønadsperiode = {
     fom: string;
     tom: string;
+    endretKey?: string; // intern for re-rendring
 };
 
 export enum StønadsperiodeProperty {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er nødvendig å kunne legge til flere rader for både [stønadsperiode](https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16143) og [utgifter per barn](https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16144) 

**Se commit for commit (om du vil men er litt smooth)**

<img width="1055" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/a9df3e80-a8f2-4c62-baa1-aed5c5d8e1bb">

### Tanker 💭 
Burde `RecordState` som ble laget tidligere for å håndtere utgifter endres fra å være en egen greie til å bare være `Record<ListState<Utgift>>`. Usikker på hvordan dette vil være i praksis, men det er kanskje litt smudere å ha en egen state per liste og ikke en stor, men så lagres statene i formen i en record. 

Nå er hele `Record<string, Utgift[]>` en egendefinert formstate-greie. Spesielt ved sletting av element i lista ser dette litt corny ut. Ved endring vil kun `Utgift[]` være en state og så ser samles alle statene i en record. 