### PR TITLE
✨ Vise frem behandlinger i behandlingsoversikt

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingOversikt.tsx
@@ -5,11 +5,11 @@ import { useHentFagsakPersonUtvidet } from '../../../hooks/useFagsakPerson';
 import DataViewer from '../../../komponenter/DataViewer';
 
 const Behandlingsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
-    const { hentFagsakPerson, fagsakPerson } = useHentFagsakPersonUtvidet();
+    const { hentFagsakPersonUtvidet, fagsakPerson } = useHentFagsakPersonUtvidet();
 
     useEffect(() => {
-        hentFagsakPerson(fagsakPersonId);
-    }, [fagsakPersonId, hentFagsakPerson]);
+        hentFagsakPersonUtvidet(fagsakPersonId);
+    }, [fagsakPersonId, hentFagsakPersonUtvidet]);
 
     return (
         <DataViewer response={{ fagsakPerson }}>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 import { Table } from '@navikt/ds-react';
 
 import { Behandling } from '../../../typer/behandling/behandling';
@@ -40,7 +42,12 @@ const BehandlingTabell: React.FC<{
                         <Table.DataCell>
                             {formaterNullableIsoDatoTid(behandling.vedtaksdato)}
                         </Table.DataCell>
-                        <Table.DataCell>{formaterEnumVerdi(behandling.resultat)}</Table.DataCell>
+
+                        <Table.DataCell>
+                            <Link to={{ pathname: `/behandling/${behandling.id}` }}>
+                                {formaterEnumVerdi(behandling.resultat)}
+                            </Link>
+                        </Table.DataCell>
                     </Table.Row>
                 ))}
             </Table.Body>

--- a/src/frontend/hooks/useFagsakPerson.ts
+++ b/src/frontend/hooks/useFagsakPerson.ts
@@ -1,58 +1,32 @@
 import { useCallback, useState } from 'react';
 
-import { BehandlingResultat } from '../typer/behandling/behandlingResultat';
-import { BehandlingStatus } from '../typer/behandling/behandlingStatus';
-import { Stønadstype } from '../typer/behandling/behandlingTema';
-import { BehandlingType } from '../typer/behandling/behandlingType';
-import { BehandlingÅrsak } from '../typer/behandling/behandlingÅrsak';
-import { Steg } from '../typer/behandling/steg';
+import { useApp } from '../context/AppContext';
 import { FagsakPersonMedBehandlinger } from '../typer/fagsak';
-import { Ressurs, RessursStatus, byggTomRessurs } from '../typer/ressurs';
+import { Ressurs, byggTomRessurs } from '../typer/ressurs';
 
 interface HentFagsakPersonResponse {
-    hentFagsakPerson: (fagsakPersonId: string) => void;
+    hentFagsakPersonUtvidet: (fagsakPersonId: string) => void;
     fagsakPerson: Ressurs<FagsakPersonMedBehandlinger>;
 }
 
 export const useHentFagsakPersonUtvidet = (): HentFagsakPersonResponse => {
+    const { request } = useApp();
+
     const [fagsakPerson, settFagsakPerson] = useState<Ressurs<FagsakPersonMedBehandlinger>>(
         byggTomRessurs()
     );
 
-    const hentFagsakPerson = useCallback(() => {
-        settFagsakPerson({
-            status: RessursStatus.SUKSESS,
-            data: {
-                id: 'fagsakPersonId',
-                barnetilsyn: {
-                    id: 'fagsakIdBarnetilsyn',
-                    eksternId: 123,
-                    fagsakPersonId: 'fagsakPersonId',
-                    personIdent: 'personIdent',
-                    stønadstype: Stønadstype.BARNETILSYN,
-                    erLøpende: true,
-                    behandlinger: [
-                        {
-                            id: 'behandlingId',
-                            fagsakId: 'fagsakId',
-                            type: BehandlingType.FØRSTEGANGSBEHANDLING,
-                            steg: Steg.VILKÅR,
-                            status: BehandlingStatus.OPPRETTET,
-                            sistEndret: '2023-09-12T00:00:00',
-                            opprettet: '2023-09-12T00:00:00',
-                            opprettetAv: 'saksbehandler',
-                            resultat: BehandlingResultat.IKKE_SATT,
-                            behandlingsårsak: BehandlingÅrsak.SØKNAD,
-                            stønadstype: Stønadstype.BARNETILSYN,
-                        },
-                    ],
-                },
-            },
-        });
-    }, []);
+    const hentFagsakPersonUtvidet = useCallback(
+        (fagsakPersonId: string) => {
+            request<FagsakPersonMedBehandlinger, null>(
+                `/api/sak/fagsak-person/${fagsakPersonId}/utvidet`
+            ).then(settFagsakPerson);
+        },
+        [request]
+    );
 
     return {
-        hentFagsakPerson,
+        hentFagsakPersonUtvidet,
         fagsakPerson,
     };
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Behandlingsoversikten har til nå bare vært mocket, men nå hentes alle fagsaker med behandlinger fra API. 

Må merges etter [PR 96](https://github.com/navikt/tilleggsstonader-sak/pull/96) i ts-sak 

<img width="1145" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/45078c10-f59d-4e8f-8485-d0f1fa7edc3e">
