### PR TITLE
Totrinn -> fatter vedtak skal vise feilmelding hvis det feiler

### DIFF
--- a/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/FatteVedtak.tsx
@@ -94,7 +94,7 @@ const FatteVedtak: React.FC<{
                         navigate('/');
                     }
                 } else {
-                    settFeil(response.frontendFeilmeldingUtenFeilkode);
+                    settFeil(response.frontendFeilmelding);
                 }
             })
             .finally(() => settLaster(false));


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
`frontendFeilmeldingUtenFeilkode` var feil felt :-) 