### PR TITLE
✨ Brevhtml skal ha placeholder for signatur for saksbehandler og beslutter

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Html.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Html.tsx
@@ -22,6 +22,9 @@ interface Props {
     fritekst: Partial<Record<string, Record<string, FritekstAvsnitt[] | undefined>>>;
 }
 
+const saksbehandlerSignaturPlaceholder = 'SAKSBEHANDLER_SIGNATUR';
+const beslutterSignaturPlaceholder = 'BESLUTTER_SIGNATUR';
+
 const HtmlBrev: React.FC<Props> = ({
     navn,
     personIdent,
@@ -78,6 +81,10 @@ const HtmlBrev: React.FC<Props> = ({
                                 )}
                             />
                         ))}
+                </div>
+                <div style={{ marginRight: '20px' }}>
+                    <span>{saksbehandlerSignaturPlaceholder}</span>
+                    <span style={{ marginLeft: '20px' }}>{beslutterSignaturPlaceholder}</span>
                 </div>
             </div>
         </body>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Brev skal signerer av saksbehandler og beslutter. Legger derfor inn placeholdere i html'en, så backend kan legge på signaturene.

Må se på spacing/styling i avslutningen siden 🤠 

[Favro](https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16779)

**Brev med signatur** 📷 
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/3b49708b-1e7c-4129-985e-01d7f64b92cc)

