### PR TITLE
Søke opp fnr og ekstern fagsakid

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useState } from 'react';
 
-import { BrowserRouter, Route, Routes } from 'react-router-dom';
+import { BrowserRouter, Outlet, Route, Routes } from 'react-router-dom';
 
 import { InternalHeader, Spacer } from '@navikt/ds-react';
 
 import { AppProvider, useApp } from './context/AppContext';
+import PersonSøk from './komponenter/PersonSøk';
 import { Sticky } from './komponenter/Visningskomponenter/Sticky';
 import BehandlingContainer from './Sider/Behandling/BehandlingContainer';
 import Oppgavebenk from './Sider/Oppgavebenk/Oppgavebenk';
@@ -12,15 +13,26 @@ import Personoversikt from './Sider/Personoversikt/Personoversikt';
 import { AppEnv, hentEnv } from './utils/env';
 import { hentInnloggetSaksbehandler, Saksbehandler } from './utils/saksbehandler';
 
-const AppRoutes = () => {
+const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
+    innloggetSaksbehandler,
+}) => {
     const { autentisert } = useApp();
     return (
         <BrowserRouter>
             {autentisert ? (
                 <Routes>
-                    <Route path={'/'} element={<Oppgavebenk />} />
-                    <Route path={'/person/:fagsakPersonId/*'} element={<Personoversikt />} />
-                    <Route path={'/behandling/:behandlingId/*'} element={<BehandlingContainer />} />
+                    <Route
+                        path={'/'}
+                        element={<AppInnhold innloggetSaksbehandler={innloggetSaksbehandler} />}
+                    >
+                        <Route path={''} element={<Oppgavebenk />} />
+                        <Route path={'/person/:fagsakPersonId/*'} element={<Personoversikt />} />
+
+                        <Route
+                            path={'/behandling/:behandlingId/*'}
+                            element={<BehandlingContainer />}
+                        />
+                    </Route>
                 </Routes>
             ) : (
                 <Routes>
@@ -45,15 +57,26 @@ const App: React.FC = () => {
     }
     return (
         <AppProvider saksbehandler={innloggetSaksbehandler} appEnv={appEnv}>
+            <AppRoutes innloggetSaksbehandler={innloggetSaksbehandler} />
+        </AppProvider>
+    );
+};
+
+const AppInnhold: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
+    innloggetSaksbehandler,
+}) => {
+    return (
+        <>
             <Sticky>
                 <InternalHeader>
                     <InternalHeader.Title as="h1">Tilleggsstønader</InternalHeader.Title>
                     <Spacer />
+                    <PersonSøk />
                     <InternalHeader.User name={innloggetSaksbehandler.name} />
                 </InternalHeader>
             </Sticky>
-            <AppRoutes />
-        </AppProvider>
+            <Outlet />
+        </>
     );
 };
 

--- a/src/frontend/komponenter/PersonSøk.tsx
+++ b/src/frontend/komponenter/PersonSøk.tsx
@@ -27,6 +27,8 @@ const StyledAlert = styled(Alert)`
     color: ${ATextDefault};
 `;
 
+const erPositivtTall = (verdi: string) => /^\d+$/.test(verdi) && Number(verdi) !== 0;
+
 const PersonSøk: React.FC = () => {
     const { request } = useApp();
     const navigate = useNavigate();
@@ -38,11 +40,26 @@ const PersonSøk: React.FC = () => {
         (personIdent: string) => {
             request<Søkeresultat, { personIdent: string }>(`/api/sak/sok/person`, 'POST', {
                 personIdent: personIdent,
-            }).then((res) => {
-                if (res.status === RessursStatus.SUKSESS) {
-                    navigate(`/person/${res.data.fagsakPersonId}`);
+            }).then((resultat) => {
+                if (resultat.status === RessursStatus.SUKSESS) {
+                    navigate(`/person/${resultat.data.fagsakPersonId}`);
                 } else {
-                    settFeilmelding(res.frontendFeilmelding);
+                    settFeilmelding(resultat.frontendFeilmelding);
+                }
+            });
+        },
+        [navigate, request]
+    );
+
+    const søkPersonEksternFagsakId = useCallback(
+        (eksternFagsakId: string) => {
+            request<Søkeresultat, null>(
+                `/api/sak/sok/person/fagsak-ekstern/${eksternFagsakId}`
+            ).then((resultat) => {
+                if (resultat.status === RessursStatus.SUKSESS) {
+                    navigate(`/person/${resultat.data.fagsakPersonId}`);
+                } else {
+                    settFeilmelding(resultat.frontendFeilmelding);
                 }
             });
         },
@@ -53,7 +70,11 @@ const PersonSøk: React.FC = () => {
         event.preventDefault();
         if (!søkestreng) return;
 
-        søkPerson(søkestreng);
+        if (erPositivtTall(søkestreng) && søkestreng.length !== 11) {
+            søkPersonEksternFagsakId(søkestreng);
+        } else {
+            søkPerson(søkestreng);
+        }
     };
 
     return (

--- a/src/frontend/komponenter/PersonSøk.tsx
+++ b/src/frontend/komponenter/PersonSøk.tsx
@@ -22,6 +22,10 @@ enum Kjønn {
     UKJENT = 'UKJENT',
 }
 
+const Container = styled.div`
+    padding: 0.5rem;
+`;
+
 const StyledAlert = styled(Alert)`
     width: 24rem;
     color: ${ATextDefault};
@@ -78,7 +82,7 @@ const PersonSøk: React.FC = () => {
     };
 
     return (
-        <>
+        <Container>
             <form role="search" onSubmit={søk}>
                 <Search
                     variant="simple"
@@ -87,6 +91,7 @@ const PersonSøk: React.FC = () => {
                     onChange={settSøkestreng}
                     value={søkestreng}
                     ref={søkRef}
+                    size="small"
                 />
             </form>
             <Popover
@@ -106,7 +111,7 @@ const PersonSøk: React.FC = () => {
                     <StyledAlert variant="error">{feilmelding}</StyledAlert>
                 </Popover.Content>
             </Popover>
-        </>
+        </Container>
     );
 };
 

--- a/src/frontend/komponenter/PersonSøk.tsx
+++ b/src/frontend/komponenter/PersonSøk.tsx
@@ -1,13 +1,15 @@
-import React, { FormEvent, useCallback, useState } from 'react';
+import React, { FormEvent, useCallback, useRef, useState } from 'react';
 
 import { useNavigate } from 'react-router-dom';
+import { styled } from 'styled-components';
 
-import { Search } from '@navikt/ds-react';
+import { Alert, Popover, Search } from '@navikt/ds-react';
+import { ATextDefault } from '@navikt/ds-tokens/dist/tokens';
 
 import { useApp } from '../context/AppContext';
 import { RessursStatus } from '../typer/ressurs';
 
-type Søkeresultat = {
+export type Søkeresultat = {
     personIdent: string;
     visningsnavn: string;
     kjønn: Kjønn;
@@ -19,10 +21,18 @@ enum Kjønn {
     MANN = 'MANN',
     UKJENT = 'UKJENT',
 }
+
+const StyledAlert = styled(Alert)`
+    width: 24rem;
+    color: ${ATextDefault};
+`;
+
 const PersonSøk: React.FC = () => {
     const { request } = useApp();
     const navigate = useNavigate();
+    const søkRef = useRef<HTMLDivElement>(null);
     const [søkestreng, settSøkestreng] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<string>();
 
     const søkPerson = useCallback(
         (personIdent: string) => {
@@ -32,8 +42,7 @@ const PersonSøk: React.FC = () => {
                 if (res.status === RessursStatus.SUKSESS) {
                     navigate(`/person/${res.data.fagsakPersonId}`);
                 } else {
-                    // eslint-disable-next-line no-console
-                    console.log('Feilet', res);
+                    settFeilmelding(res.frontendFeilmelding);
                 }
             });
         },
@@ -48,15 +57,35 @@ const PersonSøk: React.FC = () => {
     };
 
     return (
-        <form role="search" onSubmit={søk}>
-            <Search
-                variant="simple"
-                label="Søk etter fagsak for en person"
-                name="søk"
-                onChange={settSøkestreng}
-                value={søkestreng}
-            />
-        </form>
+        <>
+            <form role="search" onSubmit={søk}>
+                <Search
+                    variant="simple"
+                    label="Søk etter fagsak for en person"
+                    name="søk"
+                    onChange={settSøkestreng}
+                    value={søkestreng}
+                    ref={søkRef}
+                />
+            </form>
+            <Popover
+                anchorEl={søkRef.current}
+                open={feilmelding !== undefined}
+                onClose={() => {
+                    return;
+                }}
+                arrow={false}
+                placement="bottom"
+            >
+                <Popover.Content
+                    style={{
+                        padding: '0px',
+                    }}
+                >
+                    <StyledAlert variant="error">{feilmelding}</StyledAlert>
+                </Popover.Content>
+            </Popover>
+        </>
     );
 };
 

--- a/src/frontend/komponenter/PersonSøk.tsx
+++ b/src/frontend/komponenter/PersonSøk.tsx
@@ -93,7 +93,7 @@ const PersonSøk: React.FC = () => {
                 anchorEl={søkRef.current}
                 open={feilmelding !== undefined}
                 onClose={() => {
-                    return;
+                    settFeilmelding(undefined);
                 }}
                 arrow={false}
                 placement="bottom"

--- a/src/frontend/komponenter/PersonSøk.tsx
+++ b/src/frontend/komponenter/PersonSøk.tsx
@@ -1,0 +1,63 @@
+import React, { FormEvent, useCallback, useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+
+import { Search } from '@navikt/ds-react';
+
+import { useApp } from '../context/AppContext';
+import { RessursStatus } from '../typer/ressurs';
+
+type Søkeresultat = {
+    personIdent: string;
+    visningsnavn: string;
+    kjønn: Kjønn;
+    fagsakPersonId?: string;
+};
+
+enum Kjønn {
+    KVINNE = 'KVINNE',
+    MANN = 'MANN',
+    UKJENT = 'UKJENT',
+}
+const PersonSøk: React.FC = () => {
+    const { request } = useApp();
+    const navigate = useNavigate();
+    const [søkestreng, settSøkestreng] = useState<string>();
+
+    const søkPerson = useCallback(
+        (personIdent: string) => {
+            request<Søkeresultat, { personIdent: string }>(`/api/sak/sok/person`, 'POST', {
+                personIdent: personIdent,
+            }).then((res) => {
+                if (res.status === RessursStatus.SUKSESS) {
+                    navigate(`/person/${res.data.fagsakPersonId}`);
+                } else {
+                    // eslint-disable-next-line no-console
+                    console.log('Feilet', res);
+                }
+            });
+        },
+        [navigate, request]
+    );
+
+    const søk = (event: FormEvent<HTMLFormElement>) => {
+        event.preventDefault();
+        if (!søkestreng) return;
+
+        søkPerson(søkestreng);
+    };
+
+    return (
+        <form role="search" onSubmit={søk}>
+            <Search
+                variant="simple"
+                label="Søk etter fagsak for en person"
+                name="søk"
+                onChange={settSøkestreng}
+                value={søkestreng}
+            />
+        </form>
+    );
+};
+
+export default PersonSøk;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne [søke opp personer i systemet](https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-16841) slik at det er mulig å finne brukere uten å gå via databasen. 

### Hvordan fungerer det?
- Man kan søke på både fnr og ekstern fagsakid
- Ved suksess redirectes man rett til personens side
- Ved feil vises en popover med feilmelding

### Bilder 🎨 
<img width="1278" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/83e91b28-c5a9-4aaf-838e-dd3cc292bb58">

Feil ved søk på fnr som ikke har fagsak: 
<img width="520" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/1dc6f59f-82f0-4727-af41-9428b2062201">

Feil ved søk på ekstern fagsakid: 
<img width="520" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/c140c614-94e3-4e1c-a310-216d457e08fa">
