### PR TITLE
✨ Skal hente lagret brev når behandling ikke er redigerbar

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
+import BrevLesevisning from './BrevLesevisning';
 import Brevmeny from './Brevmeny';
 import useBrev from './useBrev';
 import VelgBrevmal from './VelgBrevmal';
@@ -17,7 +18,7 @@ const Container = styled.div`
 `;
 
 const Brev: React.FC = () => {
-    const { behandling } = useBehandling();
+    const { behandling, behandlingErRedigerbar } = useBehandling();
     const { brevmaler, brevmal, settBrevmal, malStruktur } = useBrev(
         behandling.stønadstype,
         'INNVILGET'
@@ -25,25 +26,29 @@ const Brev: React.FC = () => {
 
     return (
         <Container>
-            <DataViewer response={{ brevmaler }}>
-                {({ brevmaler }) => (
-                    <>
-                        <VelgBrevmal
-                            brevmaler={brevmaler}
-                            brevmal={brevmal}
-                            settBrevmal={settBrevmal}
-                        />
-                        <DataViewer response={{ malStruktur }}>
-                            {({ malStruktur }) => (
-                                <>
-                                    <Brevmeny mal={malStruktur} behandlingId={behandling.id} />
-                                    <SendTilBeslutterFooter />
-                                </>
-                            )}
-                        </DataViewer>
-                    </>
-                )}
-            </DataViewer>
+            {behandlingErRedigerbar ? (
+                <DataViewer response={{ brevmaler }}>
+                    {({ brevmaler }) => (
+                        <>
+                            <VelgBrevmal
+                                brevmaler={brevmaler}
+                                brevmal={brevmal}
+                                settBrevmal={settBrevmal}
+                            />
+                            <DataViewer response={{ malStruktur }}>
+                                {({ malStruktur }) => (
+                                    <>
+                                        <Brevmeny mal={malStruktur} behandlingId={behandling.id} />
+                                        <SendTilBeslutterFooter />
+                                    </>
+                                )}
+                            </DataViewer>
+                        </>
+                    )}
+                </DataViewer>
+            ) : (
+                <BrevLesevisning />
+            )}
         </Container>
     );
 };

--- a/src/frontend/Sider/Behandling/Brev/BrevLesevisning.tsx
+++ b/src/frontend/Sider/Behandling/Brev/BrevLesevisning.tsx
@@ -1,0 +1,33 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { useApp } from '../../../context/AppContext';
+import { useBehandling } from '../../../context/BehandlingContext';
+import PdfVisning from '../../../komponenter/PdfVisning';
+import { byggTomRessurs } from '../../../typer/ressurs';
+
+const Container = styled.div`
+    display: flex;
+    align-items: center;
+`;
+
+const BrevLesevisning: React.FC = () => {
+    const { behandling } = useBehandling();
+    const { request } = useApp();
+    const [brevPdf, settBrevPdf] = useState(byggTomRessurs<string>());
+
+    const hentBrevCallback = useCallback(() => {
+        request<string, unknown>(`/api/sak/brev/${behandling.id}`).then(settBrevPdf);
+    }, [request, behandling.id]);
+
+    useEffect(hentBrevCallback, [hentBrevCallback]);
+
+    return (
+        <Container>
+            <PdfVisning pdfFilInnhold={brevPdf} />;
+        </Container>
+    );
+};
+
+export default BrevLesevisning;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når en behandling er sendt til beslutter, eller ferdigstilt skal det lagrede brevet vises.

### Screenshot 📸 
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/4791ab5b-0bba-4ecf-b46f-5f9a5606a18d)
