### PR TITLE
🚧 Skal hente brevmottakere når brevfanen åpnes

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brevmottakere/brevmottakereTyper.ts
+++ b/src/frontend/Sider/Behandling/Brev/Brevmottakere/brevmottakereTyper.ts
@@ -1,0 +1,21 @@
+export interface Brevmottaker {
+    personIdent: string;
+    mottakerRolle: BrevmottakerRolle;
+}
+
+export interface Brevmottakere {
+    personer: Brevmottaker[];
+    organisasjoner: OrganisasjonMottaker[];
+}
+
+export interface OrganisasjonMottaker {
+    organisasjonsnummer: string;
+    navnHosOrganisasjon: string;
+    mottakerRolle: BrevmottakerRolle.VERGE | BrevmottakerRolle.FULLMAKT;
+}
+
+export enum BrevmottakerRolle {
+    BRUKER = 'BRUKER',
+    VERGE = 'VERGE',
+    FULLMAKT = 'FULLMAKT',
+}

--- a/src/frontend/Sider/Behandling/Brev/useBrev.ts
+++ b/src/frontend/Sider/Behandling/Brev/useBrev.ts
@@ -1,8 +1,11 @@
 import { useCallback, useEffect, useState } from 'react';
 
+import { Brevmottakere } from './Brevmottakere/brevmottakereTyper';
 import { hentMalerQuery, malQuery } from './Sanity/queries';
 import { useSanityClient } from './Sanity/useSanityClient';
 import { Brevmal, MalStruktur } from './typer';
+import { useApp } from '../../../context/AppContext';
+import { useBehandling } from '../../../context/BehandlingContext';
 import { Stønadstype } from '../../../typer/behandling/behandlingTema';
 import {
     byggRessursFeilet,
@@ -13,10 +16,13 @@ import {
 
 const useBrev = (ytelse: Stønadstype, resultat: string) => {
     const sanityClient = useSanityClient();
+    const { request } = useApp();
+    const { behandling } = useBehandling();
 
     const [brevmal, settBrevmal] = useState<string>();
     const [brevmaler, settBrevmaler] = useState<Ressurs<Brevmal[]>>(byggTomRessurs());
-    const [malStruktur, settMalStruktur] = useState<Ressurs<MalStruktur>>(byggTomRessurs);
+    const [malStruktur, settMalStruktur] = useState<Ressurs<MalStruktur>>(byggTomRessurs());
+    const [brevmottakere, settBrevmottakere] = useState<Ressurs<Brevmottakere>>(byggTomRessurs());
 
     const hentBrevmaler = useCallback(() => {
         sanityClient
@@ -42,14 +48,22 @@ const useBrev = (ytelse: Stønadstype, resultat: string) => {
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [brevmal]);
 
+    const hentBrevmottakere = useCallback(() => {
+        request<Brevmottakere, unknown>(`/api/sak/brevmottakere/${behandling.id}`).then(
+            settBrevmottakere
+        );
+    }, [request, behandling.id]);
+
     useEffect(hentBrevmaler, [hentBrevmaler]);
     useEffect(hentMalStruktur, [hentMalStruktur]);
+    useEffect(hentBrevmottakere, [hentBrevmottakere]);
 
     return {
         brevmaler,
         brevmal,
         settBrevmal,
         malStruktur,
+        brevmottakere,
     };
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
En behandling på ha minst en brevmottaker for å kunne journalføre vedtaksbrevet. Foreløpig har vi lagt opp til at brevmottakere opprettes første gang man henter brevmottakere. Brevfanen må derfor gjøre kallet for at brevet skal kunne sendes. 