### PR TITLE
Legg til flere målgrupper og aktiviteter i inngangsvilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer.ts
@@ -13,6 +13,10 @@ export interface Målgruppe extends Periode {
 export enum MålgruppeType {
     AAP = 'AAP',
     AAP_FERDIG_AVKLART = 'AAP_FERDIG_AVKLART',
+    DAGPENGER = 'DAGPENGER',
+    UFØRETRYGD = 'UFØRETRYGD',
+    OMSTILLINGSSTØNAD = 'OMSTILLINGSSTØNAD',
+    OVERGANGSSTØNAD = 'OVERGANGSSTØNAD',
 }
 
 export interface Aktivitet extends Periode {
@@ -23,6 +27,7 @@ export interface Aktivitet extends Periode {
 export enum AktivitetType {
     TILTAK = 'TILTAK',
     UTDANNING = 'UTDANNING',
+    REEL_ARBEIDSSØKER = 'REEL_ARBEIDSSØKER',
 }
 
 export interface Stønadsperiode extends Periode {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -2,6 +2,7 @@ export const regelIdTilTekst: Record<string, string> = {
     // MÅLGRUPPE
     MÅLGRUPPE: 'Tilhører bruker riktig målgruppe?',
     NEDSATT_ARBEIDSEVNE: 'Har bruker nedsatt arbeidsevne etter §11 A-3?',
+    OMSTILLINGSSTØNAD_LEDD: 'Etter hvilket ledd er stønaden vurdert?',
 
     // AKTIVITET
     ER_AKTIVITET_REGISTRERT: 'Er bruker registrert med en aktivitet?',
@@ -20,6 +21,10 @@ export const regelIdTilTekst: Record<string, string> = {
 export const svarIdTilTekst: Record<string, string> = {
     JA: 'Ja',
     NEI: 'Nei',
+
+    // MÅLGRUPPE
+    FØRSTE_LEDD: 'Første ledd',
+    ANDRE_LEDD: 'Andre ledd',
 
     // PASS_BARN
     TRENGER_MER_TILSYN_ENN_JEVNALDRENDE:


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vise frem målgrupper og aktiviter som ble lagt til i [PR 122 i sak](https://github.com/navikt/tilleggsstonader-sak/pull/122) som valg i inngangsvilkårene. 

![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/49ddfd9e-7fbb-4805-99ef-47424d28dad1)

PS: Vi har ikke laget noe mapping for penere navn i dropdown. Det kan legges inn når siden skal styles