### PR TITLE
🐛 Behandling må sendes inn til useBrev

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -23,7 +23,8 @@ const Brev: React.FC = () => {
     const { behandling, behandlingErRedigerbar } = useBehandling();
     const { brevmaler, brevmal, settBrevmal, malStruktur } = useBrev(
         behandling.stønadstype,
-        'INNVILGET'
+        'INNVILGET',
+        behandling
     ); // TODO ikke bruk hardkodet resultat
 
     const { mellomlagretBrev } = useMellomlagrignBrev();

--- a/src/frontend/Sider/Behandling/Brev/useBrev.ts
+++ b/src/frontend/Sider/Behandling/Brev/useBrev.ts
@@ -5,7 +5,7 @@ import { hentMalerQuery, malQuery } from './Sanity/queries';
 import { useSanityClient } from './Sanity/useSanityClient';
 import { Brevmal, MalStruktur } from './typer';
 import { useApp } from '../../../context/AppContext';
-import { useBehandling } from '../../../context/BehandlingContext';
+import { Behandling } from '../../../typer/behandling/behandling';
 import { Stønadstype } from '../../../typer/behandling/behandlingTema';
 import {
     byggRessursFeilet,
@@ -14,10 +14,9 @@ import {
     Ressurs,
 } from '../../../typer/ressurs';
 
-const useBrev = (ytelse: Stønadstype, resultat: string) => {
+const useBrev = (ytelse: Stønadstype, resultat: string, behandling?: Behandling) => {
     const sanityClient = useSanityClient();
     const { request } = useApp();
-    const { behandling } = useBehandling();
 
     const [brevmal, settBrevmal] = useState<string>();
     const [brevmaler, settBrevmaler] = useState<Ressurs<Brevmal[]>>(byggTomRessurs());
@@ -49,10 +48,12 @@ const useBrev = (ytelse: Stønadstype, resultat: string) => {
     }, [brevmal]);
 
     const hentBrevmottakere = useCallback(() => {
-        request<Brevmottakere, unknown>(`/api/sak/brevmottakere/${behandling.id}`).then(
-            settBrevmottakere
-        );
-    }, [request, behandling.id]);
+        if (behandling) {
+            request<Brevmottakere, unknown>(`/api/sak/brevmottakere/${behandling.id}`).then(
+                settBrevmottakere
+            );
+        }
+    }, [request, behandling]);
 
     useEffect(hentBrevmaler, [hentBrevmaler]);
     useEffect(hentMalStruktur, [hentMalStruktur]);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Frittstående brev fungerer ikke atm fordi `useBrev` brukes både i frittstående brev og vedtaksbrev. Frittstående brev ligger utenfor contexten til en behandling og `useBehandlig()` kan derfor ikke kalles fra `useBrev()`. Behandling bør heller sendes inn så den er tilgjengelig. 

Siden frittstående brev ikke er knyttet til en behandling har den heller ingen `behandlingId` så det er lagt til sjekk for om denne er `undefined` slik at det ikke kastes feil ved initialisering av brevmottaker. 