### PR TITLE
Skal minimere rader når man lagrer et vilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -25,7 +25,12 @@ const Aktivitet: React.FC<{ aktiviteter: Aktivitet[]; regler: ReglerForVilkår }
     aktiviteter,
     regler,
 }) => {
-    const { vilkårFeilmeldinger, oppdaterAktivitetVilkårState } = useInngangsvilkår();
+    const {
+        vilkårFeilmeldinger,
+        oppdaterAktivitetVilkårState,
+        aktivitetsrader,
+        oppdaterAktivitetsrad,
+    } = useInngangsvilkår();
 
     const [skalViseLeggTilPeriode, settSkalViseLeggTilPeriode] = useState<boolean>(false);
 
@@ -47,6 +52,13 @@ const Aktivitet: React.FC<{ aktiviteter: Aktivitet[]; regler: ReglerForVilkår }
                             key={aktivitet.vilkår.id}
                             togglePlacement={'right'}
                             expansionDisabled={aktivitet.vilkår.delvilkårsett.length === 0}
+                            open={!!aktivitetsrader[aktivitet.vilkår.id]}
+                            onOpenChange={(open) =>
+                                oppdaterAktivitetsrad(
+                                    aktivitet.vilkår.id,
+                                    open ? 'åpen' : undefined
+                                )
+                            }
                             content={
                                 <>
                                     <Heading size={'xsmall'}>Vilkårsvurdering</Heading>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -25,7 +25,12 @@ const Målgruppe: React.FC<{ målgrupper: Målgruppe[]; regler: ReglerForVilkår
     målgrupper,
     regler,
 }) => {
-    const { vilkårFeilmeldinger, oppdaterMålgruppeVilkårState } = useInngangsvilkår();
+    const {
+        vilkårFeilmeldinger,
+        oppdaterMålgruppeVilkårState,
+        målgrupperader,
+        oppdaterMålgrupperad,
+    } = useInngangsvilkår();
 
     const [skalViseLeggTilPeriode, settSkalViseLeggTilPeriode] = useState<boolean>(false);
 
@@ -47,6 +52,10 @@ const Målgruppe: React.FC<{ målgrupper: Målgruppe[]; regler: ReglerForVilkår
                             key={målgruppe.vilkår.id}
                             togglePlacement={'right'}
                             expansionDisabled={målgruppe.vilkår.delvilkårsett.length === 0}
+                            open={!!målgrupperader[målgruppe.vilkår.id]}
+                            onOpenChange={(open) =>
+                                oppdaterMålgrupperad(målgruppe.vilkår.id, open ? 'åpen' : undefined)
+                            }
                             content={
                                 <>
                                     <Heading size={'xsmall'}>Vilkårsvurdering</Heading>

--- a/src/frontend/utils/features.ts
+++ b/src/frontend/utils/features.ts
@@ -1,3 +1,3 @@
 export const features = {
-    nyeInngangsvilkår: false,
+    nyeInngangsvilkår: true,
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å minimere en rad når man lagrer et vilkår.
For å kunne gjøre det trenger vi en state for å kontrollere om den er åpen/lukket.

Jeg har lagt den staten i Contexten til vilkårsvurdering. Den blir oppdatert(lukket) i det at man mottar "OK" fra backend.
Det er enkelt å utvidede dette til å håndtere om en rad er i redigeringsmodus, og då også sjekke at ikke fler enn en rad kan være i redigeringsmodus.

https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-17406

https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/24441cf4-e433-4528-81ea-2040b6075460