### PR TITLE
Skjul variabler som er html-felter fra brevmeny

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Variabler.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Variabler.tsx
@@ -20,16 +20,18 @@ const Variabler: React.FC<Props> = ({ variabler, variablerState, settVariabler }
                         [variabel._id]: e.target.value,
                     }));
 
-                return (
-                    <div key={variabel._id}>
-                        <TextField
-                            label={variabel.visningsnavn}
-                            key={variabel._id}
-                            value={variablerState[variabel._id] || ''}
-                            onChange={håndterInput}
-                        />
-                    </div>
-                );
+                if (!variabel.erHtml) {
+                    return (
+                        <div key={variabel._id}>
+                            <TextField
+                                label={variabel.visningsnavn}
+                                key={variabel._id}
+                                value={variablerState[variabel._id] || ''}
+                                onChange={håndterInput}
+                            />
+                        </div>
+                    );
+                }
             })}
         </>
     );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke vise html-variabler i brevmeny, kun i generert brev ([favro](https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-17363&secret=WJKlDZ3sr_1ysJBnmrdKLkanApcz-OOZlzcZkuS4pQb))


Før: 
<img width="1363" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/21108c41-a75b-44ea-a58d-a7d4f500226e">

Etter: 
<img width="1363" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/b92b8916-7581-457d-a450-e90fb49bfd0f">
