### PR TITLE
✨ Legg til personHeader med navn og personident

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -12,6 +12,7 @@ import { BehandlingProvider } from '../../context/BehandlingContext';
 import { PersonopplysningerProvider } from '../../context/PersonopplysningerContext';
 import { VilkårProvider } from '../../context/VilkårContext';
 import { RerrunnableEffect } from '../../hooks/useRerunnableEffect';
+import PersonHeader from '../../komponenter/PersonHeader/PersonHeader';
 import { Behandling } from '../../typer/behandling/behandling';
 import { Personopplysninger } from '../../typer/personopplysninger';
 
@@ -48,6 +49,7 @@ const BehandlingInnhold: React.FC<{
     return (
         <BehandlingProvider behandling={behandling} hentBehandling={hentBehandling}>
             <PersonopplysningerProvider personopplysninger={personopplysninger}>
+                <PersonHeader />
                 <BehandlingContainer>
                     <VilkårProvider behandling={behandling}>
                         <InnholdWrapper>

--- a/src/frontend/Sider/Behandling/Fanemeny/Fanemeny.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/Fanemeny.tsx
@@ -11,7 +11,6 @@ import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
 
 const Container = styled(Sticky)`
     box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
-    top: 3rem;
     z-index: 22;
     display: flex;
     border-bottom: ${ABorderDefault} solid 2px;

--- a/src/frontend/Sider/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Personoversikt.tsx
@@ -6,6 +6,7 @@ import PersonoversiktInnhold from './PersonoversiktInnhold';
 import { useApp } from '../../context/AppContext';
 import { PersonopplysningerProvider } from '../../context/PersonopplysningerContext';
 import DataViewer from '../../komponenter/DataViewer';
+import PersonHeader from '../../komponenter/PersonHeader/PersonHeader';
 import { Personopplysninger } from '../../typer/personopplysninger';
 import { byggTomRessurs, Ressurs } from '../../typer/ressurs';
 
@@ -14,8 +15,9 @@ const Personoversikt = () => {
 
     const fagsakPersonId = useParams<{ fagsakPersonId: string }>().fagsakPersonId as string;
 
-    const [personopplysninger, settPersonopplysninger] =
-        useState<Ressurs<Personopplysninger>>(byggTomRessurs());
+    const [personopplysninger, settPersonopplysninger] = useState<Ressurs<Personopplysninger>>(
+        byggTomRessurs()
+    );
 
     useEffect(() => {
         request<Personopplysninger, null>(
@@ -27,6 +29,7 @@ const Personoversikt = () => {
         <DataViewer response={{ personopplysninger }}>
             {({ personopplysninger }) => (
                 <PersonopplysningerProvider personopplysninger={personopplysninger}>
+                    <PersonHeader />
                     <PersonoversiktInnhold fagsakPersonId={fagsakPersonId} />
                 </PersonopplysningerProvider>
             )}

--- a/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
@@ -16,7 +16,7 @@ const Container = styled(Sticky)`
     padding: ${ASpacing2} ${ASpacing4};
 
     border-bottom: 1px solid ${ABorderStrong};
-    top: 55px;
+    top: 48px;
 `;
 
 const PersonHeader: React.FC = () => {

--- a/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
@@ -1,0 +1,37 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { BodyShort, CopyButton, HStack, Heading } from '@navikt/ds-react';
+import { ABorderStrong, ASpacing2, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
+
+import { usePersonopplysninger } from '../../context/PersonopplysningerContext';
+import { Sticky } from '../Visningskomponenter/Sticky';
+
+const Container = styled(Sticky)`
+    display: flex;
+    align-items: center;
+    gap: ${ASpacing4};
+
+    padding: ${ASpacing2} ${ASpacing4};
+
+    border-bottom: 1px solid ${ABorderStrong};
+    top: 55px;
+`;
+
+const PersonHeader: React.FC = () => {
+    const { personopplysninger } = usePersonopplysninger();
+
+    return (
+        <Container>
+            <Heading size="xsmall">{personopplysninger.navn.visningsnavn}</Heading>
+            <BodyShort>|</BodyShort>
+            <HStack gap="2" align="center">
+                {personopplysninger.personIdent}
+                <CopyButton copyText={personopplysninger.personIdent} size="small" />
+            </HStack>
+        </Container>
+    );
+};
+
+export default PersonHeader;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Enkelt kunne se navn og kopiere fnr

<img width="1712" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/98e0e36f-84c6-4ae5-a64a-640481cf247c">

PS: Har brukt `CopyButton` som er beta. Siden jeg først hadde beta i filen så testet jeg ut `HStack` også 🤠.
PSS: Prøvde å ta i bruk spacing fra aksel. 1 hos aksel = 4px, dvs. at  f.eks. `ASpacing4 = 1rem`