### PR TITLE
🚧 Ta i bruk behandlingstema og behandlingstype som er gyldige for TSO og TSR

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -17,7 +17,7 @@ import SystemetLaster from '../../../komponenter/SystemetLaster/SystemetLaster';
 import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../../utils/roller';
 import { Saksbehandler } from '../../../utils/saksbehandler';
 import { enhetTilTekst, FortroligEnhet, IkkeFortroligEnhet } from '../typer/enhet';
-import { behandlingstemaStønadstypeTilTekst, OppgaveRequest } from '../typer/oppgave';
+import { behandlingstemaTilTekst, OppgaveRequest } from '../typer/oppgave';
 import { oppgaveTypeTilTekst } from '../typer/oppgavetema';
 
 const FlexDiv = styled.div`
@@ -114,7 +114,7 @@ export const Oppgavefiltrering = () => {
                     onChange={oppdaterOppgaveTargetValue('behandlingstema')}
                 >
                     <option value="">Alle</option>
-                    {Object.entries(behandlingstemaStønadstypeTilTekst).map(([type, val]) => (
+                    {Object.entries(behandlingstemaTilTekst).map(([type, val]) => (
                         <option key={type} value={type}>
                             {val}
                         </option>

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -76,28 +76,23 @@ export enum IdentGruppe {
     SAMHANDLERNR = 'SAMHANDLERNR',
 }
 
-export type BehandlingstemaStønadstype = 'ab0177' | 'ab0028' | 'ab0071';
-export type Behandlingstema = BehandlingstemaStønadstype | 'ab0007';
-
-export const behandlingstemaStønadstypeTilTekst: Record<BehandlingstemaStønadstype, string> = {
-    ab0071: 'Overgangsstønad',
-    ab0177: 'Skolepenger',
-    ab0028: 'Barnetilsyn',
-};
+export type Behandlingstema = 'ab0300';
 
 export const behandlingstemaTilTekst: Record<Behandlingstema, string> = {
-    ...behandlingstemaStønadstypeTilTekst,
-    ab0007: 'Tilbakekreving',
+    ab0300: 'Tilsyn barn',
 };
 
-export type OppgavetypeTilbakekreving = 'ae0161';
-export type OppgavetypeKlage = 'ae0058';
-export type OppgaveBehandlingstype = OppgavetypeTilbakekreving | OppgavetypeKlage;
-
-export const oppgavetypeTilbakekreving: OppgavetypeTilbakekreving = 'ae0161';
-export const oppgavetypeKlage: OppgavetypeKlage = 'ae0058';
-
+export enum OppgaveBehandlingstype {
+    Anke = 'ae0046',
+    Klage = 'ae0058',
+    Utland = 'ae0106',
+    TidligereHjemsendtsak = 'ae0114',
+    HjemsendtTilNyBehandling = 'ae0115',
+}
 export const oppgaveBehandlingstypeTilTekst: Record<OppgaveBehandlingstype, string> = {
-    ae0161: 'Tilbakekreving',
-    ae0058: 'Klage',
+    [OppgaveBehandlingstype.Klage]: 'Klage',
+    [OppgaveBehandlingstype.Anke]: 'Anke',
+    [OppgaveBehandlingstype.Utland]: 'Utland',
+    [OppgaveBehandlingstype.TidligereHjemsendtsak]: 'Tidligere hjemsendt sak',
+    [OppgaveBehandlingstype.HjemsendtTilNyBehandling]: 'Hjemsendt til ny behandling',
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Eksisterende kode gjenbrukte bare behandlingstema og behandlingstype som var brukt hos EF. Oppgavesystemet har eget kodeverk som definerer hvilke behandlingstemaer og behandlingstyper som er gyldige for et gitt tema (OBS: tema != behandlingstema)

Legger her til behandlingstema og behandlingstyper som er gyldige for temaene TSO og TSR, ref: https://github.com/navikt/oppgave/blob/faaf9374fa94c32f70ff47acdfe64526fe000bcf/src/main/resources/data/gjelder.json#L4

Betydning av kodene er hentet fra https://kodeverk-web.dev.intern.nav.no/


