### PR TITLE
Dokumentoversikt

### DIFF
--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
@@ -2,17 +2,18 @@ import React from 'react';
 
 import { Table } from '@navikt/ds-react';
 
-import { DokumentInfo } from '../../../typer/dokument';
+import { DokumentInfo, journalstatuserTilTekst } from '../../../typer/dokument';
+import { formaterIsoDatoTid } from '../../../utils/dato';
 
 const DokumentRad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
     return (
         <Table.Row>
-            <Table.DataCell>{dokument.dato}</Table.DataCell>
+            <Table.DataCell>{formaterIsoDatoTid(dokument.dato)}</Table.DataCell>
             <Table.DataCell>{dokument.journalposttype}</Table.DataCell>
             <Table.DataCell>{dokument.tittel}</Table.DataCell>
             <Table.DataCell>{dokument.avsenderMottaker?.navn}</Table.DataCell>
             <Table.DataCell>{dokument.tema}</Table.DataCell>
-            <Table.DataCell>{dokument.journalstatus}</Table.DataCell>
+            <Table.DataCell>{journalstatuserTilTekst[dokument.journalstatus]}</Table.DataCell>
         </Table.Row>
     );
 };

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+import { Table } from '@navikt/ds-react';
+
+import { DokumentInfo } from '../../../typer/dokument';
+
+const DokumentRad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
+    return (
+        <Table.Row>
+            <Table.DataCell>{dokument.dato}</Table.DataCell>
+            <Table.DataCell>{dokument.journalposttype}</Table.DataCell>
+            <Table.DataCell>{dokument.tittel}</Table.DataCell>
+            <Table.DataCell>{dokument.avsenderMottaker?.navn}</Table.DataCell>
+            <Table.DataCell>{dokument.tema}</Table.DataCell>
+            <Table.DataCell>{dokument.journalstatus}</Table.DataCell>
+        </Table.Row>
+    );
+};
+
+export default DokumentRad;

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -54,7 +54,7 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                         </Table.Header>
                         <Table.Body>
                             {dokumenter.map((dokument) => (
-                                <DokumentRad dokument={dokument} />
+                                <DokumentRad key={dokument.dokumentinfoId} dokument={dokument} />
                             ))}
                         </Table.Body>
                     </Table>

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Table } from '@navikt/ds-react';
+
+import DokumentRad from './DokumentRad';
+import { useApp } from '../../../context/AppContext';
+import DataViewer from '../../../komponenter/DataViewer';
+import { DokumentInfo } from '../../../typer/dokument';
+import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
+
+type VedleggRequest = {
+    fagsakPersonId: string;
+    tema?: string[]; // Arkiv
+    journalposttype?: string;
+    journalstatus?: string;
+};
+
+const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
+    const { request } = useApp();
+
+    const [dokumenter, settDokumenter] = useState<Ressurs<DokumentInfo[]>>(byggTomRessurs());
+
+    const hentDokumenter = useCallback(
+        (fagsakPersonId: string) => {
+            request<DokumentInfo[], VedleggRequest>(`/api/sak/vedlegg/fagsak-person`, 'POST', {
+                fagsakPersonId: fagsakPersonId,
+            }).then(settDokumenter);
+        },
+        [request]
+    );
+
+    useEffect(() => {
+        hentDokumenter(fagsakPersonId);
+    }, [fagsakPersonId, hentDokumenter]);
+
+    return (
+        <DataViewer response={{ dokumenter }}>
+            {({ dokumenter }) => (
+                <Table size="small">
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.HeaderCell>Dato</Table.HeaderCell>
+                            <Table.HeaderCell>Inn/ut</Table.HeaderCell>
+                            <Table.HeaderCell>Tittel</Table.HeaderCell>
+                            <Table.HeaderCell>Avsender/mottaker</Table.HeaderCell>
+                            <Table.HeaderCell>Tema</Table.HeaderCell>
+                            <Table.HeaderCell>Status</Table.HeaderCell>
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {dokumenter.map((dokument) => (
+                            <DokumentRad dokument={dokument} />
+                        ))}
+                    </Table.Body>
+                </Table>
+            )}
+        </DataViewer>
+    );
+};
+
+export default Dokumentoversikt;

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Table } from '@navikt/ds-react';
+import { Heading, Table } from '@navikt/ds-react';
 
 import DokumentRad from './DokumentRad';
 import { useApp } from '../../../context/AppContext';
@@ -35,27 +35,32 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
     }, [fagsakPersonId, hentDokumenter]);
 
     return (
-        <DataViewer response={{ dokumenter }}>
-            {({ dokumenter }) => (
-                <Table size="small">
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.HeaderCell>Dato</Table.HeaderCell>
-                            <Table.HeaderCell>Inn/ut</Table.HeaderCell>
-                            <Table.HeaderCell>Tittel</Table.HeaderCell>
-                            <Table.HeaderCell>Avsender/mottaker</Table.HeaderCell>
-                            <Table.HeaderCell>Tema</Table.HeaderCell>
-                            <Table.HeaderCell>Status</Table.HeaderCell>
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {dokumenter.map((dokument) => (
-                            <DokumentRad dokument={dokument} />
-                        ))}
-                    </Table.Body>
-                </Table>
-            )}
-        </DataViewer>
+        <>
+            <Heading size="medium" level="1">
+                Dokumentoversikt
+            </Heading>
+            <DataViewer response={{ dokumenter }}>
+                {({ dokumenter }) => (
+                    <Table size="small" zebraStripes>
+                        <Table.Header>
+                            <Table.Row>
+                                <Table.HeaderCell>Dato</Table.HeaderCell>
+                                <Table.HeaderCell>Inn/ut</Table.HeaderCell>
+                                <Table.HeaderCell>Tittel</Table.HeaderCell>
+                                <Table.HeaderCell>Avsender/mottaker</Table.HeaderCell>
+                                <Table.HeaderCell>Tema</Table.HeaderCell>
+                                <Table.HeaderCell>Status</Table.HeaderCell>
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            {dokumenter.map((dokument) => (
+                                <DokumentRad dokument={dokument} />
+                            ))}
+                        </Table.Body>
+                    </Table>
+                )}
+            </DataViewer>
+        </>
     );
 };
 

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -9,7 +9,6 @@ import { DokumentInfo } from '../../../typer/dokument';
 import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
 
 type VedleggRequest = {
-    fagsakPersonId: string;
     tema?: string[]; // Arkiv
     journalposttype?: string;
     journalstatus?: string;
@@ -22,9 +21,11 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
 
     const hentDokumenter = useCallback(
         (fagsakPersonId: string) => {
-            request<DokumentInfo[], VedleggRequest>(`/api/sak/vedlegg/fagsak-person`, 'POST', {
-                fagsakPersonId: fagsakPersonId,
-            }).then(settDokumenter);
+            request<DokumentInfo[], VedleggRequest>(
+                `/api/sak/vedlegg/fagsak-person/${fagsakPersonId}`,
+                'POST',
+                {}
+            ).then(settDokumenter);
         },
         [request]
     );

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Tabs } from '@navikt/ds-react';
 
 import Behandlingsoversikt from './Behandlingsoversikt/BehandlingOversikt';
+import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import FrittståendeBrevFane from './FrittståendeBrev/FrittståendeBrevFane';
 
 type TabWithRouter = {
@@ -19,6 +20,11 @@ const tabs: TabWithRouter[] = [
         label: 'Behandlingsoversikt',
         path: 'behandlinger',
         komponent: (fagsakPersonId) => <Behandlingsoversikt fagsakPersonId={fagsakPersonId} />,
+    },
+    {
+        label: 'Dokumentoversikt',
+        path: 'dokumentoversikt',
+        komponent: (fagsakPersonId) => <Dokumentoversikt fagsakPersonId={fagsakPersonId} />,
     },
     {
         label: 'Brev',

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -34,7 +34,10 @@ const tabs: TabWithRouter[] = [
 ];
 
 const InnholdWrapper = styled.div`
-    padding: 1rem;
+    padding: 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
 `;
 
 const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {

--- a/src/frontend/typer/dokument.tsx
+++ b/src/frontend/typer/dokument.tsx
@@ -1,0 +1,64 @@
+export interface DokumentInfo {
+    dokumentinfoId: string;
+    filnavn?: string;
+    tittel: string;
+    journalpostId: string;
+    dato: string;
+    tema?: string; // Arkiv
+    journalstatus: Journalstatus;
+    journalposttype: Journalposttype;
+    harSaksbehandlerTilgang: boolean;
+    logiskeVedlegg: LogiskVedlegg[];
+    avsenderMottaker?: AvsenderMottaker;
+    utsendingsinfo?: Utsendingsinfo;
+}
+
+enum Journalstatus {
+    MOTTATT = 'MOTTATT',
+    JOURNALFOERT = 'JOURNALFOERT',
+    FERDIGSTILT = 'FERDIGSTILT',
+    EKSPEDERT = 'EKSPEDERT',
+    UNDER_ARBEID = 'UNDER_ARBEID',
+    FEILREGISTRERT = 'FEILREGISTRERT',
+    UTGAAR = 'UTGAAR',
+    AVBRUTT = 'AVBRUTT',
+    UKJENT_BRUKER = 'UKJENT_BRUKER',
+    RESERVERT = 'RESERVERT',
+    OPPLASTING_DOKUMENT = 'OPPLASTING_DOKUMENT',
+    UKJENT = 'UKJENT',
+}
+
+type Journalposttype = 'I' | 'U' | 'N';
+
+interface LogiskVedlegg {
+    tittel: string;
+}
+
+interface AvsenderMottaker {
+    id?: string;
+    type?: AvsenderMottakerIdType;
+    navn?: string;
+    land?: string;
+    erLikBruker: boolean;
+}
+
+type AvsenderMottakerIdType = 'FNR' | 'HPRNR' | 'NULL' | 'ORGNR' | 'UKJENT' | 'UTL_ORG';
+
+interface Utsendingsinfo {
+    varselSendt: VarselSendt[];
+    fysiskpostSendt?: FysiskpostSendt;
+    digitalpostSendt?: DigitalpostSendt;
+}
+
+type FysiskpostSendt = {
+    adressetekstKonvolutt: string;
+};
+
+type DigitalpostSendt = {
+    adresse: string;
+};
+
+type VarselSendt = {
+    type: 'SMS' | 'EPOST';
+    varslingstidspunkt?: string;
+};

--- a/src/frontend/typer/dokument.tsx
+++ b/src/frontend/typer/dokument.tsx
@@ -28,6 +28,26 @@ enum Journalstatus {
     UKJENT = 'UKJENT',
 }
 
+export const journalstatuserTilTekst: Record<Journalstatus, string> = {
+    MOTTATT: 'Mottatt',
+    JOURNALFOERT: 'Journalført',
+    FERDIGSTILT: 'Ferdigstilt',
+    EKSPEDERT: 'Ekspedert',
+    UNDER_ARBEID: 'Under arbeid',
+    UTGAAR: 'Utgår',
+    UKJENT_BRUKER: 'Ukjent bruker',
+    RESERVERT: 'Reservert',
+    OPPLASTING_DOKUMENT: 'Opplasting',
+    UKJENT: 'Ukjent',
+    FEILREGISTRERT: 'Feilregistrert',
+    AVBRUTT: 'Avbrutt',
+};
+
+export const ugyldigeJournalstatuserTilTekst: Record<string, string> = {
+    FEILREGISTRERT: 'Feilregistrert',
+    AVBRUTT: 'Avbrutt',
+};
+
 type Journalposttype = 'I' | 'U' | 'N';
 
 interface LogiskVedlegg {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal kunne se alle dokumentene som hører til en bruker.

Hører sammen med: 
- [PR 57](https://github.com/navikt/tilleggsstonader-integrasjoner/pull/57) i integrasjoner
- [PR 143](https://github.com/navikt/tilleggsstonader-sak/pull/143) i sak

<img width="1718" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/cd638a81-d3a9-4705-9f32-0f09c3d68bce">

Valgte `zebraStripes`, derfor er øverste raden grå. Mulig det ikke ser så bra ut med få rader, men mer oversiktlig om det er flere rader
