### PR TITLE
✨ Målgruppe - valider periode

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -8,9 +8,11 @@ import EndreMålgruppeInnhold from './EndreMålgruppeInnhold';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
+import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
 import DateInput from '../../../../komponenter/Skjema/DateInput';
 import { RessursStatus } from '../../../../typer/ressurs';
+import { Periode, validerPeriodeForm } from '../../../../utils/periode';
 import { DelvilkårMålgruppe, Målgruppe } from '../typer/målgruppe';
 import { KildeVilkårsperiode, Vurdering } from '../typer/vilkårperiode';
 
@@ -34,8 +36,8 @@ interface EndreMålgruppe {
 }
 
 export interface EndreMålgruppeForm {
-    fom?: string;
-    tom?: string;
+    fom: string;
+    tom: string;
     delvilkår: DelvilkårMålgruppe;
     begrunnelse?: string;
 }
@@ -51,28 +53,35 @@ const EndreMålgruppeRad: React.FC<{
     const [målgruppeForm, settMålgruppeForm] = useState<EndreMålgruppeForm>(målgruppe);
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
+    const [periodeFeil, settPeriodeFeil] = useState<FormErrors<Periode>>();
 
     const endreMålgruppe = (form: EndreMålgruppeForm) => {
         if (laster) return;
-        settLaster(true);
         settFeilmelding(undefined);
-        return request<Målgruppe, EndreMålgruppe>(
-            `/api/sak/vilkarperiode/${målgruppe.id}`,
-            'POST',
-            {
-                ...form,
-                behandlingId: behandling.id,
-            }
-        )
-            .then((res) => {
-                if (res.status === RessursStatus.SUKSESS) {
-                    oppdaterMålgruppe(res.data);
-                    avbrytRedigering();
-                } else {
-                    settFeilmelding(`Feilet legg til periode:${res.frontendFeilmelding}`);
+
+        const periodeFeil = validerPeriodeForm(målgruppeForm);
+        settPeriodeFeil(periodeFeil);
+
+        if (isValid(periodeFeil)) {
+            settLaster(true);
+            return request<Målgruppe, EndreMålgruppe>(
+                `/api/sak/vilkarperiode/${målgruppe.id}`,
+                'POST',
+                {
+                    ...form,
+                    behandlingId: behandling.id,
                 }
-            })
-            .finally(() => settLaster(false));
+            )
+                .then((res) => {
+                    if (res.status === RessursStatus.SUKSESS) {
+                        oppdaterMålgruppe(res.data);
+                        avbrytRedigering();
+                    } else {
+                        settFeilmelding(`Feilet legg til periode:${res.frontendFeilmelding}`);
+                    }
+                })
+                .finally(() => settLaster(false));
+        }
     };
 
     return (
@@ -89,9 +98,10 @@ const EndreMålgruppeRad: React.FC<{
                         hideLabel
                         value={målgruppeForm.fom}
                         onChange={(dato) =>
-                            settMålgruppeForm((prevState) => ({ ...prevState, fom: dato }))
+                            settMålgruppeForm((prevState) => ({ ...prevState, fom: dato || '' }))
                         }
                         size="small"
+                        feil={periodeFeil?.fom}
                     />
                 </Table.DataCell>
                 <Table.DataCell>
@@ -101,9 +111,10 @@ const EndreMålgruppeRad: React.FC<{
                         hideLabel
                         value={målgruppeForm.tom}
                         onChange={(dato) =>
-                            settMålgruppeForm((prevState) => ({ ...prevState, tom: dato }))
+                            settMålgruppeForm((prevState) => ({ ...prevState, tom: dato || '' }))
                         }
                         size="small"
+                        feil={periodeFeil?.tom}
                     />
                 </Table.DataCell>
                 <Table.DataCell>{målgruppe.kilde}</Table.DataCell>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -52,7 +52,7 @@ const EndreMålgruppeRad: React.FC<{
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const leggTilNyMålgruppe = (form: EndreMålgruppeForm) => {
+    const endreMålgruppe = (form: EndreMålgruppeForm) => {
         if (laster) return;
         settLaster(true);
         settFeilmelding(undefined);
@@ -109,7 +109,7 @@ const EndreMålgruppeRad: React.FC<{
                 <Table.DataCell>{målgruppe.kilde}</Table.DataCell>
                 <Table.DataCell>
                     <KnappeRad>
-                        <Button size="small" onClick={() => leggTilNyMålgruppe(målgruppeForm)}>
+                        <Button size="small" onClick={() => endreMålgruppe(målgruppeForm)}>
                             Lagre
                         </Button>
                         <Button onClick={avbrytRedigering} variant="secondary" size="small">

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -19,6 +19,7 @@ import { KildeVilkårsperiode, Vurdering } from '../typer/vilkårperiode';
 const TabellRad = styled(Table.Row)`
     .navds-table__data-cell {
         border-color: transparent;
+        vertical-align: top;
     }
 `;
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -56,14 +56,20 @@ const EndreMålgruppeRad: React.FC<{
     const [feilmelding, settFeilmelding] = useState<string>();
     const [periodeFeil, settPeriodeFeil] = useState<FormErrors<Periode>>();
 
+    const validerForm = (): boolean => {
+        const periodeFeil = validerPeriodeForm(målgruppeForm);
+        settPeriodeFeil(periodeFeil);
+
+        return isValid(periodeFeil);
+    };
+
     const endreMålgruppe = (form: EndreMålgruppeForm) => {
         if (laster) return;
         settFeilmelding(undefined);
 
-        const periodeFeil = validerPeriodeForm(målgruppeForm);
-        settPeriodeFeil(periodeFeil);
+        const kanSendeInn = validerForm();
 
-        if (isValid(periodeFeil)) {
+        if (kanSendeInn) {
             settLaster(true);
             return request<Målgruppe, EndreMålgruppe>(
                 `/api/sak/vilkarperiode/${målgruppe.id}`,

--- a/src/frontend/hooks/felles/useFormState.ts
+++ b/src/frontend/hooks/felles/useFormState.ts
@@ -94,7 +94,7 @@ export default function useFormState<T extends Record<string, unknown>>(
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-function isValid<T extends Record<string, any>>(errors: FormErrors<T>): boolean {
+export function isValid<T extends Record<string, any>>(errors: FormErrors<T>): boolean {
     return Object.keys(errors).reduce<boolean>((acc, key) => {
         const value = errors[key];
         if (typeof value === 'object') {

--- a/src/frontend/utils/periode.ts
+++ b/src/frontend/utils/periode.ts
@@ -1,4 +1,5 @@
 import { erDatoEtterEllerLik, erDatoFørEllerLik } from './dato';
+import { FormErrors } from '../hooks/felles/useFormState';
 
 export type Periode = {
     fom: string;
@@ -27,4 +28,21 @@ export const validerPeriode = (periode: Periode): undefined | Partial<Periode> =
         };
     }
     return undefined;
+};
+
+export const validerPeriodeForm = (målgruppe: Periode): FormErrors<Periode> => {
+    const feil: FormErrors<Periode> = {
+        fom: undefined,
+        tom: undefined,
+    };
+
+    const periodeValidering = validerPeriode(målgruppe);
+    if (periodeValidering) {
+        return {
+            ...feil,
+            ...periodeValidering,
+        };
+    }
+
+    return feil;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Backend gjør mye validering av målgruppe når det sendes inn, men for å fange de verste feilene er det lagt inn validering av perioden (fom <= tom osv). 

Validering av begrunnelse på vilkårsvurdering bør legges til når det er bestemt når det er påkrevd og ikke.

Som alltid er ikke feilvisning på felter i tabell det fineste, men hvertfall alignet alle felter på topp:
<img width="831" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/2b24af6a-7ca4-4e98-8c00-e420c24f68b2">
