### PR TITLE
✨ Oppsummering av fakta i venstre meny

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingContainer.tsx
@@ -13,8 +13,9 @@ import { byggTomRessurs, Ressurs } from '../../typer/ressurs';
 const BehandlingContainer = () => {
     const { request } = useApp();
     const [behandling, settBehandling] = useState<Ressurs<Behandling>>(byggTomRessurs());
-    const [personopplysninger, settPersonopplysninger] =
-        useState<Ressurs<Personopplysninger>>(byggTomRessurs());
+    const [personopplysninger, settPersonopplysninger] = useState<Ressurs<Personopplysninger>>(
+        byggTomRessurs()
+    );
 
     const behandlingId = useParams<{
         behandlingId: string;

--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -8,6 +8,7 @@ import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 import Fanemeny from './Fanemeny/Fanemeny';
 import { behandlingFaner } from './Fanemeny/faner';
 import Høyremeny from './Høyremeny/Høyremeny';
+import VenstreMeny from './Venstremeny/Venstremeny';
 import { BehandlingProvider } from '../../context/BehandlingContext';
 import { PersonopplysningerProvider } from '../../context/PersonopplysningerContext';
 import { VilkårProvider } from '../../context/VilkårContext';
@@ -52,6 +53,7 @@ const BehandlingInnhold: React.FC<{
                 <PersonHeader />
                 <BehandlingContainer>
                     <VilkårProvider behandling={behandling}>
+                        <VenstreMeny />
                         <InnholdWrapper>
                             <Fanemeny behandlingId={behandling.id} aktivFane={path} />
                             <Routes>

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/BarnDetaljer.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/BarnDetaljer.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+import { InfoSeksjon, Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
+import {
+    FaktaBarn,
+    typeBarnepassTilTekst,
+    årsakBarnepassTilTekst,
+} from '../../../../typer/behandling/behandlingFakta/faktaBarn';
+import { JaNei } from '../../../../typer/common';
+
+const BarnDetaljer: React.FC<{ barn: FaktaBarn }> = ({ barn }) => {
+    const typePass = barn.søknadgrunnlag?.type;
+    const årsak = barn.søknadgrunnlag?.årsak;
+
+    return (
+        <InfoSeksjon label={`${barn.registergrunnlag.navn} ${barn.ident}`}>
+            <Informasjonsrad
+                kilde={Informasjonskilde.SØKNAD}
+                verdi={typePass && typeBarnepassTilTekst[typePass]}
+            />
+            {barn.søknadgrunnlag?.startetIFemte === JaNei.JA && (
+                <Informasjonsrad
+                    kilde={Informasjonskilde.SØKNAD}
+                    verdi={årsak && årsakBarnepassTilTekst[årsak]}
+                />
+            )}
+        </InfoSeksjon>
+    );
+};
+
+export default BarnDetaljer;

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/BarnDetaljer.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/BarnDetaljer.tsx
@@ -10,6 +10,7 @@ import { JaNei } from '../../../../typer/common';
 
 const BarnDetaljer: React.FC<{ barn: FaktaBarn }> = ({ barn }) => {
     const typePass = barn.søknadgrunnlag?.type;
+    const startetIFemte = barn.søknadgrunnlag?.startetIFemte;
     const årsak = barn.søknadgrunnlag?.årsak;
 
     return (
@@ -18,11 +19,23 @@ const BarnDetaljer: React.FC<{ barn: FaktaBarn }> = ({ barn }) => {
                 kilde={Informasjonskilde.SØKNAD}
                 verdi={typePass && typeBarnepassTilTekst[typePass]}
             />
-            {barn.søknadgrunnlag?.startetIFemte === JaNei.JA && (
-                <Informasjonsrad
-                    kilde={Informasjonskilde.SØKNAD}
-                    verdi={årsak && årsakBarnepassTilTekst[årsak]}
-                />
+            {startetIFemte !== undefined && (
+                <>
+                    <Informasjonsrad
+                        kilde={Informasjonskilde.SØKNAD}
+                        verdi={
+                            startetIFemte === JaNei.JA
+                                ? 'Startet i 5. klasse'
+                                : 'Ikke startet i 5. klasse'
+                        }
+                    />
+                    {startetIFemte === JaNei.JA && (
+                        <Informasjonsrad
+                            kilde={Informasjonskilde.SØKNAD}
+                            verdi={årsak && årsakBarnepassTilTekst[årsak]}
+                        />
+                    )}
+                </>
             )}
         </InfoSeksjon>
     );

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -51,7 +51,7 @@ const Oppsummering: React.FC = () => {
                     </InfoSeksjon>
 
                     {behandlingFakta.barn.map((barn) => (
-                        <BarnDetaljer barn={barn} />
+                        <BarnDetaljer barn={barn} key={barn.barnId} />
                     ))}
 
                     <InfoSeksjon label="Vedlegg" />

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -1,0 +1,61 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { VStack } from '@navikt/ds-react';
+
+import { InfoSeksjon, Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
+import { useApp } from '../../../../context/AppContext';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import DataViewer from '../../../../komponenter/DataViewer';
+import { BehandlingFakta } from '../../../../typer/behandling/behandlingFakta/behandlingFakta';
+import { JaNei } from '../../../../typer/common';
+import { Ressurs, byggTomRessurs } from '../../../../typer/ressurs';
+
+const Oppsummering: React.FC = () => {
+    const { request } = useApp();
+    const { behandling } = useBehandling();
+
+    const [behandlingFakta, settBehandlingFakta] =
+        useState<Ressurs<BehandlingFakta>>(byggTomRessurs);
+
+    const hentBehandlingFaktaCallback = useCallback(() => {
+        request<BehandlingFakta, null>(`/api/sak/behandling/${behandling.id}/fakta`).then(
+            settBehandlingFakta
+        );
+    }, [request, behandling.id]);
+
+    useEffect(hentBehandlingFaktaCallback, [hentBehandlingFaktaCallback]);
+
+    return (
+        <VStack gap="8">
+            <DataViewer response={{ behandlingFakta }}>
+                {({ behandlingFakta }) => (
+                    <>
+                        <InfoSeksjon label="Ytelse/situasjon">
+                            <Informasjonsrad
+                                kilde={Informasjonskilde.SØKNAD}
+                                verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse}
+                            />
+                        </InfoSeksjon>
+
+                        <InfoSeksjon label="Aktivitet">
+                            {/* TODO: Legg inn andre aktiviteter*/}
+                            <Informasjonsrad
+                                kilde={Informasjonskilde.SØKNAD}
+                                verdi={
+                                    behandlingFakta.aktivitet.søknadsgrunnlag?.utdanning ===
+                                    JaNei.JA
+                                        ? 'Utdanning'
+                                        : undefined
+                                }
+                            />
+                        </InfoSeksjon>
+
+                        <InfoSeksjon label="Vedlegg" />
+                    </>
+                )}
+            </DataViewer>
+        </VStack>
+    );
+};
+
+export default Oppsummering;

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -27,39 +27,36 @@ const Oppsummering: React.FC = () => {
     useEffect(hentBehandlingFaktaCallback, [hentBehandlingFaktaCallback]);
 
     return (
-        <VStack gap="8">
-            <DataViewer response={{ behandlingFakta }}>
-                {({ behandlingFakta }) => (
-                    <>
-                        <InfoSeksjon label="Ytelse/situasjon">
-                            <Informasjonsrad
-                                kilde={Informasjonskilde.SØKNAD}
-                                verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse}
-                            />
-                        </InfoSeksjon>
+        <DataViewer response={{ behandlingFakta }}>
+            {({ behandlingFakta }) => (
+                <VStack gap="8">
+                    <InfoSeksjon label="Ytelse/situasjon">
+                        <Informasjonsrad
+                            kilde={Informasjonskilde.SØKNAD}
+                            verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse}
+                        />
+                    </InfoSeksjon>
 
-                        <InfoSeksjon label="Aktivitet">
-                            {/* TODO: Legg inn andre aktiviteter*/}
-                            <Informasjonsrad
-                                kilde={Informasjonskilde.SØKNAD}
-                                verdi={
-                                    behandlingFakta.aktivitet.søknadsgrunnlag?.utdanning ===
-                                    JaNei.JA
-                                        ? 'Utdanning'
-                                        : undefined
-                                }
-                            />
-                        </InfoSeksjon>
+                    <InfoSeksjon label="Aktivitet">
+                        {/* TODO: Legg inn andre aktiviteter*/}
+                        <Informasjonsrad
+                            kilde={Informasjonskilde.SØKNAD}
+                            verdi={
+                                behandlingFakta.aktivitet.søknadsgrunnlag?.utdanning === JaNei.JA
+                                    ? 'Utdanning'
+                                    : undefined
+                            }
+                        />
+                    </InfoSeksjon>
 
-                        {behandlingFakta.barn.map((barn) => (
-                            <BarnDetaljer barn={barn} />
-                        ))}
+                    {behandlingFakta.barn.map((barn) => (
+                        <BarnDetaljer barn={barn} />
+                    ))}
 
-                        <InfoSeksjon label="Vedlegg" />
-                    </>
-                )}
-            </DataViewer>
-        </VStack>
+                    <InfoSeksjon label="Vedlegg" />
+                </VStack>
+            )}
+        </DataViewer>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { VStack } from '@navikt/ds-react';
 
+import BarnDetaljer from './BarnDetaljer';
 import { InfoSeksjon, Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
@@ -49,6 +50,10 @@ const Oppsummering: React.FC = () => {
                                 }
                             />
                         </InfoSeksjon>
+
+                        {behandlingFakta.barn.map((barn) => (
+                            <BarnDetaljer barn={barn} />
+                        ))}
 
                         <InfoSeksjon label="Vedlegg" />
                     </>

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -15,8 +15,9 @@ const Oppsummering: React.FC = () => {
     const { request } = useApp();
     const { behandling } = useBehandling();
 
-    const [behandlingFakta, settBehandlingFakta] =
-        useState<Ressurs<BehandlingFakta>>(byggTomRessurs);
+    const [behandlingFakta, settBehandlingFakta] = useState<Ressurs<BehandlingFakta>>(
+        byggTomRessurs()
+    );
 
     const hentBehandlingFaktaCallback = useCallback(() => {
         request<BehandlingFakta, null>(`/api/sak/behandling/${behandling.id}/fakta`).then(

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Visningskomponenter.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Visningskomponenter.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { DatabaseIcon, FileTextIcon } from '@navikt/aksel-icons';
+import { BodyShort, HStack, Label, VStack } from '@navikt/ds-react';
+
+export enum Informasjonskilde {
+    REGISTER = 'REGISTER',
+    SØKNAD = 'SØKNAD',
+}
+
+const mapIkon = (ikon: Informasjonskilde) => {
+    switch (ikon) {
+        case Informasjonskilde.REGISTER:
+            return <DatabaseIcon />;
+        case Informasjonskilde.SØKNAD:
+            return <FileTextIcon />;
+    }
+};
+
+export const Informasjonsrad: React.FC<{ kilde: Informasjonskilde; verdi?: string }> = ({
+    kilde,
+    verdi = 'Ingen data registrert',
+}) => {
+    return (
+        <HStack gap="2">
+            {mapIkon(kilde)}
+            <BodyShort size="small">{verdi}</BodyShort>
+        </HStack>
+    );
+};
+
+export const InfoSeksjon: React.FC<{ label: string; children?: React.ReactNode }> = ({
+    label,
+    children,
+}) => {
+    return (
+        <VStack gap="4">
+            <Label size="small">{label}</Label>
+            {children}
+        </VStack>
+    );
+};

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -1,0 +1,44 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Box, Tabs } from '@navikt/ds-react';
+import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
+
+import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
+
+const Container = styled(Sticky)`
+    top: 97px;
+    border-right: 1px solid ${ABorderDefault};
+    height: calc(100vh - 97px);
+    min-width: 18rem;
+`;
+
+const tabs = [
+    {
+        value: 'oppsummering',
+        label: 'Oppsummert',
+        komponent: <p>Oppsummering</p>,
+    },
+];
+
+const VenstreMeny: React.FC = () => {
+    return (
+        <Container>
+            <Tabs defaultValue="oppsummering" style={{ width: '100%' }}>
+                <Tabs.List>
+                    {tabs.map((tab) => (
+                        <Tabs.Tab label={tab.label} value={tab.value} />
+                    ))}
+                </Tabs.List>
+                {tabs.map((tab) => (
+                    <Tabs.Panel value={tab.value}>
+                        <Box padding="4">{tab.komponent}</Box>
+                    </Tabs.Panel>
+                ))}
+            </Tabs>
+        </Container>
+    );
+};
+
+export default VenstreMeny;

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -33,7 +33,7 @@ const VenstreMeny: React.FC = () => {
                     ))}
                 </Tabs.List>
                 {tabs.map((tab) => (
-                    <Tabs.Panel value={tab.value}>
+                    <Tabs.Panel value={tab.value} key={tab.value}>
                         <Box padding="4">{tab.komponent}</Box>
                     </Tabs.Panel>
                 ))}

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -29,7 +29,7 @@ const VenstreMeny: React.FC = () => {
             <Tabs defaultValue="oppsummering">
                 <Tabs.List>
                     {tabs.map((tab) => (
-                        <Tabs.Tab label={tab.label} value={tab.value} />
+                        <Tabs.Tab label={tab.label} value={tab.value} key={tab.value} />
                     ))}
                 </Tabs.List>
                 {tabs.map((tab) => (

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Box, Tabs } from '@navikt/ds-react';
 import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 
+import Oppsummering from './Oppsummering/Oppsummering';
 import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
 
 const Container = styled(Sticky)`
@@ -18,7 +19,7 @@ const tabs = [
     {
         value: 'oppsummering',
         label: 'Oppsummert',
-        komponent: <p>Oppsummering</p>,
+        komponent: <Oppsummering />,
     },
 ];
 

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -26,7 +26,7 @@ const tabs = [
 const VenstreMeny: React.FC = () => {
     return (
         <Container>
-            <Tabs defaultValue="oppsummering" style={{ width: '100%' }}>
+            <Tabs defaultValue="oppsummering">
                 <Tabs.List>
                     {tabs.map((tab) => (
                         <Tabs.Tab label={tab.label} value={tab.value} />

--- a/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
@@ -1,0 +1,9 @@
+import { FaktaAktivtet } from './faktaAktivitet';
+import { FaktaBarn } from './faktaBarn';
+import { FaktaHovedytelse } from './faktaHovedytelse';
+
+export interface BehandlingFakta {
+    hovedytelse: FaktaHovedytelse;
+    aktivitet: FaktaAktivtet;
+    barn: FaktaBarn[];
+}

--- a/src/frontend/typer/behandling/behandlingFakta/faktaAktivitet.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaAktivitet.ts
@@ -1,0 +1,9 @@
+import { JaNei } from '../../common';
+
+export interface FaktaAktivtet {
+    søknadsgrunnlag?: SøknadsgrunnlagAktivitet;
+}
+
+interface SøknadsgrunnlagAktivitet {
+    utdanning: JaNei;
+}

--- a/src/frontend/typer/behandling/behandlingFakta/faktaBarn.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaBarn.ts
@@ -1,0 +1,39 @@
+import { JaNei } from '../../common';
+
+export interface FaktaBarn {
+    ident: string;
+    barnId: string;
+    registergrunnlag: RegistergrunnlagBarn;
+    søknadgrunnlag?: SøknadsgrunnlagBarn;
+}
+
+interface RegistergrunnlagBarn {
+    navn: string;
+    dødsdato?: string;
+}
+
+interface SøknadsgrunnlagBarn {
+    type: TypeBarnepass;
+    startetIFemte?: JaNei;
+    årsak?: ÅrsakBarnepass;
+}
+
+enum TypeBarnepass {
+    BARNEHAGE_SFO_AKS = 'BARNEHAGE_SFO_AKS',
+    ANDRE = 'ANDRE',
+}
+
+export const typeBarnepassTilTekst: Record<TypeBarnepass, string> = {
+    BARNEHAGE_SFO_AKS: 'Barnehage, SFO eller AKS',
+    ANDRE: 'Andre',
+};
+
+enum ÅrsakBarnepass {
+    TRENGER_MER_PASS_ENN_JEVNALDRENDE = 'TRENGER_MER_PASS_ENN_JEVNALDRENDE',
+    MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID = 'MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID',
+}
+
+export const årsakBarnepassTilTekst: Record<ÅrsakBarnepass, string> = {
+    TRENGER_MER_PASS_ENN_JEVNALDRENDE: 'Trenger mer pass enn jevnaldrende',
+    MYE_BORTE_ELLER_UVANLIG_ARBEIDSTID: 'Mye borte eller uvanlig arbeidstid',
+};

--- a/src/frontend/typer/behandling/behandlingFakta/faktaHovedytelse.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaHovedytelse.ts
@@ -1,0 +1,20 @@
+export interface FaktaHovedytelse {
+    søknadsgrunnlag?: SøknadsgrunnlagHovedytelse;
+}
+
+interface SøknadsgrunnlagHovedytelse {
+    hovedytelse: Hovedytelse;
+}
+
+enum Hovedytelse {
+    AAP = 'AAP',
+    OVERGANGSSTØNAD = 'OVERGANGSSTØNAD',
+    GJENLEVENDEPENSJON = 'GJENLEVENDEPENSJON',
+    DAGPENGER = 'DAGPENGER',
+    TILTAKSPENGER = 'TILTAKSPENGER',
+    KVALIFIKASJONSPROGRAMMET = 'KVALIFIKASJONSPROGRAMMET',
+    INTRODUKSJONSPROGRAMMET = 'INTRODUKSJONSPROGRAMMET',
+    SYKEPENGER = 'SYKEPENGER',
+    UFØRETRYGD = 'UFØRETRYGD',
+    INGEN_PENGESTØTTE = 'INGEN_PENGESTØTTE',
+}

--- a/src/frontend/typer/common.ts
+++ b/src/frontend/typer/common.ts
@@ -2,3 +2,8 @@
 export type PartialRecord<K extends keyof any, T> = {
     [P in K]?: T;
 };
+
+export enum JaNei {
+    JA = 'JA',
+    NEI = 'NEI',
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler skal se en oppsummering av fakta som tilhører en behandling i venstremeny. 

OBS: har lagt fanene i en liste for skal komme historikk senere

<img width="1710" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/e8149437-634d-442c-ba2b-0a2062c6e8eb">

### Mangler: 
Aktivitet mappes kun ut med "utdanning" dersom bruker er registrert med dette, fordi søknaden ikke tar inn noe annet enn dette nå. Må oppdateres til å mappe om når søknaden oppdateres. Bør vurdere mapping i backend