### PR TITLE
♻️ Flytt valg av type til felles komponent

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -6,10 +6,14 @@ import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
-import Select from '../../../../komponenter/Skjema/Select';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode, validerPeriodeForm } from '../../../../utils/periode';
-import { Aktivitet, AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
+import {
+    Aktivitet,
+    AktivitetType,
+    AktivitetTypeOptions,
+    DelvilkårAktivitet,
+} from '../typer/aktivitet';
 import { Vurdering } from '../typer/vilkårperiode';
 import EndreVilkårPeriodeInnhold from '../Vilkårperioder/EndreVilkårperiodeInnhold';
 import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiodeRad';
@@ -39,7 +43,6 @@ const EndreAktivitetRad: React.FC<{
         initaliserForm(behandling.id, aktivitet)
     );
     const [laster, settLaster] = useState<boolean>(false);
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const [feilmelding, settFeilmelding] = useState<string>();
     const [periodeFeil, settPeriodeFeil] = useState<FormErrors<Periode>>();
 
@@ -88,30 +91,17 @@ const EndreAktivitetRad: React.FC<{
         <>
             <EndreVilkårperiodeRad
                 vilkårperiode={aktivitet}
-                periodeForm={aktivitetForm}
+                form={aktivitetForm}
                 lagre={lagre}
                 avbrytRedigering={avbrytRedigering}
                 oppdaterPeriode={oppdaterPeriode}
                 periodeFeil={periodeFeil}
-                typeSelect={
-                    <Select
-                        label="Type"
-                        hideLabel
-                        erLesevisning={aktivitet !== undefined}
-                        value={aktivitetForm.type}
-                        onChange={(e) =>
-                            settAktivitetForm((prevState) => ({
-                                ...prevState,
-                                type: e.target.value as AktivitetType,
-                            }))
-                        }
-                        size="small"
-                    >
-                        <option value="">Velg</option>
-                        {Object.keys(AktivitetType).map((type) => (
-                            <option value={type}>{type}</option>
-                        ))}
-                    </Select>
+                typeOptions={AktivitetTypeOptions}
+                oppdaterType={(nyttValg) =>
+                    settAktivitetForm((prevState) => ({
+                        ...prevState,
+                        type: nyttValg as AktivitetType,
+                    }))
                 }
             />
             <EndreVilkårPeriodeInnhold

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -6,10 +6,14 @@ import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
-import Select from '../../../../komponenter/Skjema/Select';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode, validerPeriodeForm } from '../../../../utils/periode';
-import { DelvilkårMålgruppe, Målgruppe, MålgruppeType } from '../typer/målgruppe';
+import {
+    DelvilkårMålgruppe,
+    Målgruppe,
+    MålgruppeType,
+    MålgruppeTypeOptions,
+} from '../typer/målgruppe';
 import { Vurdering } from '../typer/vilkårperiode';
 import EndreVilkårPeriodeInnhold from '../Vilkårperioder/EndreVilkårperiodeInnhold';
 import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiodeRad';
@@ -87,30 +91,17 @@ const EndreMålgruppeRad: React.FC<{
         <>
             <EndreVilkårperiodeRad
                 vilkårperiode={målgruppe}
-                periodeForm={målgruppeForm}
+                form={målgruppeForm}
                 lagre={lagre}
                 avbrytRedigering={avbrytRedigering}
                 oppdaterPeriode={oppdaterPeriode}
                 periodeFeil={periodeFeil}
-                typeSelect={
-                    <Select
-                        label="Type"
-                        hideLabel
-                        erLesevisning={målgruppe !== undefined}
-                        value={målgruppeForm.type}
-                        onChange={(e) =>
-                            settMålgruppeForm((prevState) => ({
-                                ...prevState,
-                                type: e.target.value as MålgruppeType,
-                            }))
-                        }
-                        size="small"
-                    >
-                        <option value="">Velg</option>
-                        {Object.keys(MålgruppeType).map((type) => (
-                            <option value={type}>{type}</option>
-                        ))}
-                    </Select>
+                typeOptions={MålgruppeTypeOptions}
+                oppdaterType={(nyttValg) =>
+                    settMålgruppeForm((prevState) => ({
+                        ...prevState,
+                        type: nyttValg as MålgruppeType,
+                    }))
                 }
             />
             <EndreVilkårPeriodeInnhold

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -7,7 +7,10 @@ import { Button, Table } from '@navikt/ds-react';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
 import DateInput from '../../../../komponenter/Skjema/DateInput';
+import SelectMedOptions, { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Periode } from '../../../../utils/periode';
+import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
+import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
 import { KildeVilkårsperiode, VilkårPeriode, VilkårPeriodeResultat } from '../typer/vilkårperiode';
 
 const TabellRad = styled(Table.Row)`
@@ -24,21 +27,23 @@ const KnappeRad = styled.div`
 
 interface Props {
     vilkårperiode?: VilkårPeriode;
-    periodeForm: Periode;
+    form: EndreMålgruppeForm | EndreAktivitetForm;
     avbrytRedigering: () => void;
     lagre: () => void;
     oppdaterPeriode: (key: keyof Periode, nyVerdi: string) => void;
-    typeSelect: React.ReactNode;
+    oppdaterType: (nyttvalg: string) => void;
+    typeOptions: SelectOption[];
     periodeFeil?: FormErrors<Periode>;
 }
 
 const EndreVilkårperiodeRad: React.FC<Props> = ({
     vilkårperiode,
-    periodeForm,
+    form,
     avbrytRedigering,
     lagre,
     oppdaterPeriode,
-    typeSelect,
+    oppdaterType,
+    typeOptions,
     periodeFeil,
 }) => {
     return (
@@ -48,13 +53,23 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                     vilkårsresultat={vilkårperiode?.resultat || VilkårPeriodeResultat.IKKE_VURDERT}
                 />
             </Table.DataCell>
-            <Table.DataCell>{typeSelect}</Table.DataCell>
+            <Table.DataCell>
+                <SelectMedOptions
+                    label="Type"
+                    hideLabel
+                    erLesevisning={vilkårperiode !== undefined}
+                    value={form.type}
+                    valg={typeOptions}
+                    onChange={(e) => oppdaterType(e.target.value)}
+                    size="small"
+                />
+            </Table.DataCell>
             <Table.DataCell>
                 <DateInput
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Fra'}
                     hideLabel
-                    value={periodeForm?.fom}
+                    value={form?.fom}
                     onChange={(dato) => oppdaterPeriode('fom', dato || '')}
                     size="small"
                     feil={periodeFeil?.fom}
@@ -65,7 +80,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Til'}
                     hideLabel
-                    value={periodeForm?.tom}
+                    value={form?.tom}
                     onChange={(dato) => oppdaterPeriode('tom', dato || '')}
                     size="small"
                     feil={periodeFeil?.tom}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
@@ -1,4 +1,5 @@
 import { VilkårPeriode, Vurdering } from './vilkårperiode';
+import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 
 export interface Aktivitet extends VilkårPeriode {
     id: string;
@@ -17,3 +18,16 @@ export enum AktivitetType {
     UTDANNING = 'UTDANNING',
     REEL_ARBEIDSSØKER = 'REEL_ARBEIDSSØKER',
 }
+
+export const AktivitetTypeTilTekst: Record<AktivitetType, string> = {
+    TILTAK: 'Tiltak',
+    UTDANNING: 'Utdanning',
+    REEL_ARBEIDSSØKER: 'Reell arbeidssøker',
+};
+
+export const AktivitetTypeOptions: SelectOption[] = Object.entries(AktivitetTypeTilTekst).map(
+    ([value, label]) => ({
+        value: value,
+        label: label,
+    })
+);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
@@ -1,4 +1,5 @@
 import { VilkårPeriode, Vurdering } from './vilkårperiode';
+import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 
 export interface Målgruppe extends VilkårPeriode {
     id: string;
@@ -18,3 +19,18 @@ export enum MålgruppeType {
     OVERGANGSSTØNAD = 'OVERGANGSSTØNAD',
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
 }
+
+export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
+    AAP: 'AAP',
+    UFØRETRYGD: 'Uføretrygd',
+    OMSTILLINGSSTØNAD: 'Omstillingsstønad',
+    OVERGANGSSTØNAD: 'Overgangsstønad',
+    NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
+};
+
+export const MålgruppeTypeOptions: SelectOption[] = Object.entries(MålgruppeTypeTilTekst).map(
+    ([value, label]) => ({
+        value: value,
+        label: label,
+    })
+);

--- a/src/frontend/komponenter/Skjema/Select.tsx
+++ b/src/frontend/komponenter/Skjema/Select.tsx
@@ -1,15 +1,15 @@
 import React, { FC } from 'react';
 
-import { Select as AkselSelect, SelectProps } from '@navikt/ds-react';
+import { Select as AkselSelect, SelectProps as AkselSelectProps } from '@navikt/ds-react';
 
 import Lesefelt from './Lesefelt';
 
-interface Props extends SelectProps {
+export interface SelectProps extends AkselSelectProps {
     erLesevisning: boolean;
     lesevisningVerdi?: string;
 }
 
-const Select: FC<Props> = ({
+const Select: FC<SelectProps> = ({
     children,
     className,
     erLesevisning = false,

--- a/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
+++ b/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
@@ -16,7 +16,9 @@ const SelectMedOptions: FC<Props> = ({ valg, ...props }) => {
         <Select {...props}>
             <option value="">Velg</option>
             {valg.map((v) => (
-                <option value={v.value}>{v.label}</option>
+                <option key={v.value} value={v.value}>
+                    {v.label}
+                </option>
             ))}
         </Select>
     );

--- a/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
+++ b/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
@@ -1,0 +1,25 @@
+import React, { FC } from 'react';
+
+import Select, { SelectProps } from './Select';
+
+export interface SelectOption {
+    value: string;
+    label: string;
+}
+
+interface Props extends Omit<SelectProps, 'children'> {
+    valg: SelectOption[];
+}
+
+const SelectMedOptions: FC<Props> = ({ valg, ...props }) => {
+    return (
+        <Select {...props}>
+            <option value="">Velg</option>
+            {valg.map((v) => (
+                <option value={v.value}>{v.label}</option>
+            ))}
+        </Select>
+    );
+};
+
+export default SelectMedOptions;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Aktivitet- og målgruppetype skal velges både i vilkårsperioder og i stønadsperioder. Lagde derfor en egen komponent som tar inn valg som mappes ut i en select. Denne kunne brukes for å slippe `typeSelect` som tidligere ble sendt til `EndreVilkårsperiodeRad`