### PR TITLE
✨ ♻️ Stønadsperioder - nytt design med tilhørende funksjonalitet

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -35,12 +35,10 @@ const Inngangsvilkår = () => {
     const { regler, hentRegler } = useRegler();
     const { vilkårsvurdering } = useVilkår();
 
-    const [vilkårperioder, settVilkårperioder] = useState<Ressurs<Vilkårperioder>>(
-        byggTomRessurs()
-    );
-    const [stønadsperioder, settStønadsperioder] = useState<Ressurs<Stønadsperiode[]>>(
-        byggTomRessurs()
-    );
+    const [vilkårperioder, settVilkårperioder] =
+        useState<Ressurs<Vilkårperioder>>(byggTomRessurs());
+    const [stønadsperioder, settStønadsperioder] =
+        useState<Ressurs<Stønadsperiode[]>>(byggTomRessurs());
 
     const hentVilkårperioderCallback = useCallback(() => {
         request<Vilkårperioder, null>(`/api/sak/vilkarperiode/behandling/${behandling.id}`).then(
@@ -50,11 +48,13 @@ const Inngangsvilkår = () => {
 
     const hentVilkårperioder = useRerunnableEffect(hentVilkårperioderCallback, [behandling.id]);
 
-    useEffect(() => {
+    const hentStønadsperioderCallback = useCallback(() => {
         request<Stønadsperiode[], null>(`/api/sak/stonadsperiode/${behandling.id}`).then(
             settStønadsperioder
         );
-    }, [behandling.id, request]);
+    }, [request, behandling.id]);
+
+    const hentStønadsperioder = useRerunnableEffect(hentStønadsperioderCallback, [behandling.id]);
 
     useEffect(() => {
         hentRegler();
@@ -70,10 +70,12 @@ const Inngangsvilkår = () => {
                             <InngangsvilkårProvider
                                 vilkårperioder={vilkårperioder}
                                 hentVilkårperioder={hentVilkårperioder}
+                                stønadsperioder={stønadsperioder}
+                                hentStønadsperioder={hentStønadsperioder}
                             >
                                 <Målgruppe />
                                 <Aktivitet />
-                                <Stønadsperioder eksisterendeStønadsperioder={stønadsperioder} />
+                                <Stønadsperioder />
                             </InngangsvilkårProvider>
                         )}
                         <MålgruppeGammel

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -37,7 +37,7 @@ const Inngangsvilkår = () => {
 
     const [vilkårperioder, settVilkårperioder] =
         useState<Ressurs<Vilkårperioder>>(byggTomRessurs());
-    const [stønadsperioder, settStønadsperioder] =
+    const [stønadsperioderRessurs, settStønadsperioderRessurs] =
         useState<Ressurs<Stønadsperiode[]>>(byggTomRessurs());
 
     const hentVilkårperioderCallback = useCallback(() => {
@@ -50,7 +50,7 @@ const Inngangsvilkår = () => {
 
     const hentStønadsperioderCallback = useCallback(() => {
         request<Stønadsperiode[], null>(`/api/sak/stonadsperiode/${behandling.id}`).then(
-            settStønadsperioder
+            settStønadsperioderRessurs
         );
     }, [request, behandling.id]);
 
@@ -63,14 +63,21 @@ const Inngangsvilkår = () => {
     return (
         <Container>
             {!erProd() && <FyllUtVilkårKnapp />}
-            <DataViewer response={{ regler, vilkårsvurdering, vilkårperioder, stønadsperioder }}>
+            <DataViewer
+                response={{
+                    regler,
+                    vilkårsvurdering,
+                    vilkårperioder,
+                    stønadsperioder: stønadsperioderRessurs,
+                }}
+            >
                 {({ regler, vilkårsvurdering, vilkårperioder, stønadsperioder }) => (
                     <>
                         {features.nyeInngangsvilkår && (
                             <InngangsvilkårProvider
                                 vilkårperioder={vilkårperioder}
                                 hentVilkårperioder={hentVilkårperioder}
-                                stønadsperioder={stønadsperioder}
+                                hentedeStønadsperioder={stønadsperioder}
                                 hentStønadsperioder={hentStønadsperioder}
                             >
                                 <Målgruppe />

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
@@ -66,7 +66,14 @@ export const Aksjonsknapper: React.FC<{
 
 export const LeggTilStønadsperiodeKnapp: React.FC<{ onClick: () => void }> = ({ onClick }) => {
     return (
-        <Button icon={<PlusCircleIcon />} size="small" onClick={onClick}>
+        <Button
+            icon={<PlusCircleIcon />}
+            size="small"
+            onClick={(e) => {
+                e.preventDefault();
+                onClick();
+            }}
+        >
             Legg til stønadsperiode
         </Button>
     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { PencilIcon, PlusCircleIcon } from '@navikt/aksel-icons';
-import { Button } from '@navikt/ds-react';
+import { Button, HStack } from '@navikt/ds-react';
 
 export const Aksjonsknapper: React.FC<{
     redigerer: boolean;
@@ -20,31 +20,51 @@ export const Aksjonsknapper: React.FC<{
 }) => {
     if (redigerer) {
         return (
-            <>
-                <Button size="small" type="submit" disabled={laster}>
-                    Lagre
-                </Button>
+            <HStack justify="space-between">
+                <HStack gap="2">
+                    <Button size="small" type="submit" disabled={laster}>
+                        Lagre
+                    </Button>
+                    <Button
+                        type="button"
+                        disabled={laster}
+                        onClick={avbrytRedigering}
+                        size="small"
+                        variant="secondary"
+                    >
+                        Avbryt
+                    </Button>
+                </HStack>
                 <Button
-                    type="button"
-                    disabled={laster}
-                    onClick={avbrytRedigering}
+                    icon={<PlusCircleIcon />}
                     size="small"
+                    onClick={(e) => {
+                        e.preventDefault();
+                        initierFormMedTomRad();
+                        startRedigering();
+                    }}
                     variant="tertiary"
                 >
-                    Avbryt
+                    Legg til periode
                 </Button>
-            </>
+            </HStack>
         );
     }
 
     if (!finnesStønadsperioder) {
         return (
-            <LeggTilStønadsperiodeKnapp
-                onClick={() => {
+            <Button
+                icon={<PlusCircleIcon />}
+                size="small"
+                onClick={(e) => {
+                    e.preventDefault();
                     initierFormMedTomRad();
                     startRedigering();
                 }}
-            />
+                style={{ maxWidth: 'fit-content' }}
+            >
+                Legg til stønadsperiode
+            </Button>
         );
     } else {
         return (
@@ -56,7 +76,7 @@ export const Aksjonsknapper: React.FC<{
                     e.preventDefault();
                     startRedigering();
                 }}
-                type="button"
+                style={{ maxWidth: 'fit-content' }}
             >
                 Endre stønadsperioder
             </Button>
@@ -68,11 +88,13 @@ export const LeggTilStønadsperiodeKnapp: React.FC<{ onClick: () => void }> = ({
     return (
         <Button
             icon={<PlusCircleIcon />}
-            size="small"
+            size="xsmall"
             onClick={(e) => {
                 e.preventDefault();
                 onClick();
             }}
+            style={{ maxWidth: 'fit-content' }}
+            variant="secondary"
         >
             Legg til stønadsperiode
         </Button>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
@@ -1,0 +1,73 @@
+import React from 'react';
+
+import { PencilIcon, PlusCircleIcon } from '@navikt/aksel-icons';
+import { Button } from '@navikt/ds-react';
+
+export const Aksjonsknapper: React.FC<{
+    redigerer: boolean;
+    finnesStønadsperioder: boolean;
+    laster: boolean;
+    avbrytRedigering: () => void;
+    initierFormMedTomRad: () => void;
+    startRedigering: () => void;
+}> = ({
+    redigerer,
+    finnesStønadsperioder,
+    laster,
+    avbrytRedigering,
+    initierFormMedTomRad,
+    startRedigering,
+}) => {
+    if (redigerer) {
+        return (
+            <>
+                <Button size="small" type="submit" disabled={laster}>
+                    Lagre
+                </Button>
+                <Button
+                    type="button"
+                    disabled={laster}
+                    onClick={avbrytRedigering}
+                    size="small"
+                    variant="tertiary"
+                >
+                    Avbryt
+                </Button>
+            </>
+        );
+    }
+
+    if (!finnesStønadsperioder) {
+        return (
+            <LeggTilStønadsperiodeKnapp
+                onClick={() => {
+                    initierFormMedTomRad();
+                    startRedigering();
+                }}
+            />
+        );
+    } else {
+        return (
+            <Button
+                icon={<PencilIcon />}
+                size="small"
+                disabled={laster}
+                onClick={(e) => {
+                    e.preventDefault();
+                    startRedigering();
+                }}
+                type="button"
+            >
+                Endre stønadsperioder
+            </Button>
+        );
+    }
+};
+
+export const LeggTilStønadsperiodeKnapp: React.FC<{ onClick: () => void }> = ({ onClick }) => {
+    return (
+        <Button icon={<PlusCircleIcon />} size="small" onClick={onClick}>
+            Legg til stønadsperiode
+        </Button>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { PencilIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, HStack } from '@navikt/ds-react';
 
-export const Aksjonsknapper: React.FC<{
+const Aksjonsknapper: React.FC<{
     redigerer: boolean;
     finnesStønadsperioder: boolean;
     laster: boolean;
@@ -84,19 +84,4 @@ export const Aksjonsknapper: React.FC<{
     }
 };
 
-export const LeggTilStønadsperiodeKnapp: React.FC<{ onClick: () => void }> = ({ onClick }) => {
-    return (
-        <Button
-            icon={<PlusCircleIcon />}
-            size="xsmall"
-            onClick={(e) => {
-                e.preventDefault();
-                onClick();
-            }}
-            style={{ maxWidth: 'fit-content' }}
-            variant="secondary"
-        >
-            Legg til stønadsperiode
-        </Button>
-    );
-};
+export default Aksjonsknapper;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
+import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Table } from '@navikt/ds-react';
 
 import { FormErrors } from '../../../../hooks/felles/useFormState';
@@ -14,7 +14,6 @@ interface Props {
     stønadsperide: Stønadsperiode;
     feilmeldinger: FormErrors<Stønadsperiode>;
     oppdaterStønadsperiode: (property: keyof Stønadsperiode, value: string | undefined) => void;
-    leggTilTomRadUnder: () => void;
     slettPeriode: () => void;
     erLeservisning: boolean;
 }
@@ -23,7 +22,6 @@ const StønadsperiodeRad: React.FC<Props> = ({
     stønadsperide,
     feilmeldinger,
     oppdaterStønadsperiode,
-    leggTilTomRadUnder,
     slettPeriode,
     erLeservisning,
 }) => {
@@ -79,22 +77,15 @@ const StønadsperiodeRad: React.FC<Props> = ({
                 />
             </Table.DataCell>
             <Table.DataCell>
-                <div>
-                    <Button
-                        type="button"
-                        onClick={leggTilTomRadUnder}
-                        variant="tertiary"
-                        icon={<PlusCircleIcon />}
-                        size="small"
-                    />
+                {!erLeservisning && (
                     <Button
                         type="button"
                         onClick={slettPeriode}
                         variant="tertiary"
                         icon={<TrashIcon />}
-                        size="small"
+                        size="xsmall"
                     />
-                </div>
+                )}
             </Table.DataCell>
         </Table.Row>
     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -16,7 +16,6 @@ interface Props {
     oppdaterStønadsperiode: (property: keyof Stønadsperiode, value: string | undefined) => void;
     leggTilTomRadUnder: () => void;
     slettPeriode: () => void;
-    radKanSlettes: boolean;
     erLeservisning: boolean;
 }
 
@@ -26,7 +25,6 @@ const StønadsperiodeRad: React.FC<Props> = ({
     oppdaterStønadsperiode,
     leggTilTomRadUnder,
     slettPeriode,
-    radKanSlettes,
     erLeservisning,
 }) => {
     const finnFeilmelding = (property: keyof Stønadsperiode) =>
@@ -89,15 +87,13 @@ const StønadsperiodeRad: React.FC<Props> = ({
                         icon={<PlusCircleIcon />}
                         size="small"
                     />
-                    {radKanSlettes && (
-                        <Button
-                            type="button"
-                            onClick={slettPeriode}
-                            variant="tertiary"
-                            icon={<TrashIcon />}
-                            size="small"
-                        />
-                    )}
+                    <Button
+                        type="button"
+                        onClick={slettPeriode}
+                        variant="tertiary"
+                        icon={<TrashIcon />}
+                        size="small"
+                    />
                 </div>
             </Table.DataCell>
         </Table.Row>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 
 import { PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
-import { Button, Select, Table } from '@navikt/ds-react';
+import { Button, Table } from '@navikt/ds-react';
 
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import DateInput from '../../../../komponenter/Skjema/DateInput';
-import { AktivitetType } from '../typer/aktivitet';
-import { MålgruppeType } from '../typer/målgruppe';
+import SelectMedOptions from '../../../../komponenter/Skjema/SelectMedOptions';
+import { AktivitetTypeOptions } from '../typer/aktivitet';
+import { MålgruppeTypeOptions } from '../typer/målgruppe';
 import { Stønadsperiode } from '../typer/stønadsperiode';
 
 interface Props {
@@ -16,6 +17,7 @@ interface Props {
     leggTilTomRadUnder: () => void;
     slettPeriode: () => void;
     radKanSlettes: boolean;
+    erLeservisning: boolean;
 }
 
 const StønadsperiodeRad: React.FC<Props> = ({
@@ -25,6 +27,7 @@ const StønadsperiodeRad: React.FC<Props> = ({
     leggTilTomRadUnder,
     slettPeriode,
     radKanSlettes,
+    erLeservisning,
 }) => {
     const finnFeilmelding = (property: keyof Stønadsperiode) =>
         feilmeldinger && feilmeldinger[property];
@@ -32,38 +35,28 @@ const StønadsperiodeRad: React.FC<Props> = ({
     return (
         <Table.Row>
             <Table.DataCell>
-                <Select
+                <SelectMedOptions
+                    erLesevisning={erLeservisning}
+                    valg={MålgruppeTypeOptions}
                     label={'Målgruppe'}
                     hideLabel
                     value={stønadsperide.målgruppe}
                     onChange={(e) => oppdaterStønadsperiode('målgruppe', e.target.value)}
                     size="small"
                     error={finnFeilmelding('målgruppe')}
-                >
-                    <option value="">Velg</option>
-                    {Object.keys(MålgruppeType).map((type) => (
-                        <option key={type} value={type}>
-                            {type}
-                        </option>
-                    ))}
-                </Select>
+                />
             </Table.DataCell>
             <Table.DataCell>
-                <Select
+                <SelectMedOptions
+                    erLesevisning={erLeservisning}
+                    valg={AktivitetTypeOptions}
                     label={'Aktivitet'}
                     hideLabel
                     value={stønadsperide.aktivitet}
                     onChange={(e) => oppdaterStønadsperiode('aktivitet', e.target.value)}
                     size="small"
                     error={finnFeilmelding('aktivitet')}
-                >
-                    <option value="">Velg</option>
-                    {Object.keys(AktivitetType).map((type) => (
-                        <option key={type} value={type}>
-                            {type}
-                        </option>
-                    ))}
-                </Select>
+                />
             </Table.DataCell>
             <Table.DataCell>
                 <DateInput

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -60,6 +60,7 @@ const StønadsperiodeRad: React.FC<Props> = ({
             </Table.DataCell>
             <Table.DataCell>
                 <DateInput
+                    erLesevisning={erLeservisning}
                     label={'Fra'}
                     hideLabel
                     value={stønadsperide.fom}
@@ -70,6 +71,7 @@ const StønadsperiodeRad: React.FC<Props> = ({
             </Table.DataCell>
             <Table.DataCell>
                 <DateInput
+                    erLesevisning={erLeservisning}
                     label={'Til'}
                     hideLabel
                     value={stønadsperide.tom}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { PencilIcon } from '@navikt/aksel-icons';
+import { PencilIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, HStack, Table, VStack } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
@@ -192,6 +192,17 @@ const Stønadsperioder: React.FC = () => {
                                 ))}
                             </Table.Body>
                         </HvitTabell>
+                    )}
+                    {stønadsperioderState.value.length === 0 && redigerer === true && (
+                        <Button
+                            icon={<PlusCircleIcon />}
+                            size="small"
+                            onClick={() => {
+                                stønadsperioderState.setValue([tomStønadsperiodeRad()]);
+                            }}
+                        >
+                            Legg til stønadsperiode
+                        </Button>
                     )}
 
                     <Feilmelding>{feilmelding}</Feilmelding>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -100,10 +100,10 @@ const Stønadsperioder: React.FC = () => {
     const slettPeriode = (indeks: number) => {
         stønadsperioderState.remove(indeks);
 
-        formState.setErrors((prevState: FormErrors<StønadsperiodeForm>) => {
-            const stønadsperioder = (prevState.stønadsperioder ?? []).splice(indeks, 1);
-            return { ...prevState, stønadsperioder };
-        });
+        formState.setErrors((prevState: FormErrors<StønadsperiodeForm>) => ({
+            ...prevState,
+            stønadsperioder: prevState.stønadsperioder.filter((_, i) => i !== indeks),
+        }));
     };
 
     const oppdaterStønadsperiode = (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -70,7 +70,9 @@ const Stønadsperioder: React.FC = () => {
 
     useEffect(() => {
         stønadsperioderState.setValue(stønadsperioder);
-    }, [stønadsperioder, stønadsperioderState]);
+        formState.nullstillErrors();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [stønadsperioder]);
 
     const handleSubmit = (form: FormState<StønadsperiodeForm>) => {
         if (laster) return;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -1,8 +1,9 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Button, Table } from '@navikt/ds-react';
+import { PencilIcon } from '@navikt/aksel-icons';
+import { Button, HStack, Table, VStack } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
 import StønadsperiodeRad from './StønadsperiodeRad';
@@ -20,11 +21,6 @@ import { Stønadsperiode } from '../typer/stønadsperiode';
 
 const HvitTabell = styled(Table)`
     background-color: ${AWhite};
-`;
-
-const Knapp = styled(Button)`
-    max-width: fit-content;
-    margin-top: 1rem;
 `;
 
 export type StønadsperiodeForm = {
@@ -46,11 +42,12 @@ const initFormState = (
 
 const Stønadsperioder: React.FC = () => {
     const { request } = useApp();
-    const { behandling } = useBehandling();
-    const { målgrupper, aktiviteter, stønadsperioder } = useInngangsvilkår();
+    const { behandling, behandlingErRedigerbar } = useBehandling();
+    const { målgrupper, aktiviteter, stønadsperioder, hentStønadsperioder } = useInngangsvilkår();
 
     const [feilmelding, settFeilmelding] = useState<string>();
     const [laster, settLaster] = useState<boolean>(false);
+    const [redigerer, settRedigerer] = useState<boolean>(false);
 
     const validerForm = (formState: StønadsperiodeForm): FormErrors<StønadsperiodeForm> => {
         return {
@@ -114,54 +111,92 @@ const Stønadsperioder: React.FC = () => {
         );
     };
 
-    // Hvis målgrupper eller aktiviteter endrer seg, valider at stønadsperioder fortsatt er gyldige
-    useEffect(() => {
-        if (stønadsperioderState.value[0].målgruppe !== '') {
-            formState.validateForm();
+    const avbrytRedigering = () => {
+        settRedigerer(false);
+        hentStønadsperioder.rerun();
+    };
+
+    const utledAksjonsknapper = () => {
+        if (redigerer) {
+            return (
+                <>
+                    <Button size="small" type="submit" disabled={laster}>
+                        Lagre
+                    </Button>
+                    <Button
+                        disabled={laster}
+                        onClick={avbrytRedigering}
+                        size="small"
+                        variant="tertiary"
+                    >
+                        Avbryt
+                    </Button>
+                </>
+            );
+        } else {
+            return (
+                <Button
+                    icon={<PencilIcon />}
+                    size="small"
+                    disabled={laster}
+                    onClick={() => settRedigerer(true)}
+                >
+                    Endre stønadsperioder
+                </Button>
+            );
         }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [målgrupper, aktiviteter]);
+    };
+
+    // Hvis målgrupper eller aktiviteter endrer seg, valider at stønadsperioder fortsatt er gyldige
+    // useEffect(() => {
+    //     if (stønadsperioderState.value[0].målgruppe !== '') {
+    //         formState.validateForm();
+    //     }
+    //     // eslint-disable-next-line react-hooks/exhaustive-deps
+    // }, [målgrupper, aktiviteter]);
 
     return (
         <EkspanderbartPanel tittel="Stønadsperioder">
             <form onSubmit={formState.onSubmit(handleSubmit)}>
-                <HvitTabell>
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.HeaderCell>Målgruppe</Table.HeaderCell>
-                            <Table.HeaderCell>Aktivitet</Table.HeaderCell>
-                            <Table.HeaderCell>Fra</Table.HeaderCell>
-                            <Table.HeaderCell>Til</Table.HeaderCell>
-                            <Table.HeaderCell />
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {stønadsperioderState.value.map((periode, indeks) => (
-                            <StønadsperiodeRad
-                                key={periode.id || indeks}
-                                stønadsperide={periode}
-                                oppdaterStønadsperiode={(
-                                    property: keyof Stønadsperiode,
-                                    value: string | undefined
-                                ) => oppdaterStønadsperiode(indeks, property, value)}
-                                leggTilTomRadUnder={() => leggTilTomRadUnder(indeks)}
-                                slettPeriode={() => slettPeriode(indeks)}
-                                feilmeldinger={
-                                    formState.errors.stønadsperioder &&
-                                    formState.errors.stønadsperioder[indeks]
-                                }
-                                radKanSlettes={indeks !== 0}
-                                erLeservisning={false}
-                            />
-                        ))}
-                    </Table.Body>
-                </HvitTabell>
-
-                <Feilmelding>{feilmelding}</Feilmelding>
-                <Knapp size="small" type="submit" disabled={laster}>
-                    Lagre
-                </Knapp>
-                <Feilmelding>{feilmelding}</Feilmelding>
+                <VStack gap="4">
+                    {stønadsperioderState.value.length !== 0 && (
+                        <HvitTabell size="small">
+                            <Table.Header>
+                                <Table.Row>
+                                    <Table.HeaderCell>Målgruppe</Table.HeaderCell>
+                                    <Table.HeaderCell>Aktivitet</Table.HeaderCell>
+                                    <Table.HeaderCell>Fra</Table.HeaderCell>
+                                    <Table.HeaderCell>Til</Table.HeaderCell>
+                                    <Table.HeaderCell />
+                                </Table.Row>
+                            </Table.Header>
+                            <Table.Body>
+                                {stønadsperioderState.value.map((periode, indeks) => (
+                                    <StønadsperiodeRad
+                                        key={periode.id || indeks}
+                                        stønadsperide={periode}
+                                        oppdaterStønadsperiode={(
+                                            property: keyof Stønadsperiode,
+                                            value: string | undefined
+                                        ) => oppdaterStønadsperiode(indeks, property, value)}
+                                        leggTilTomRadUnder={() => leggTilTomRadUnder(indeks)}
+                                        slettPeriode={() => slettPeriode(indeks)}
+                                        feilmeldinger={
+                                            formState.errors.stønadsperioder &&
+                                            formState.errors.stønadsperioder[indeks]
+                                        }
+                                        radKanSlettes={indeks !== 0}
+                                        erLeservisning={
+                                            !behandlingErRedigerbar || redigerer === false
+                                        }
+                                    />
+                                ))}
+                            </Table.Body>
+                        </HvitTabell>
+                    )}
+                    <Feilmelding>{feilmelding}</Feilmelding>
+                    {behandlingErRedigerbar && <HStack gap="4">{utledAksjonsknapper()}</HStack>}
+                </VStack>
             </form>
         </EkspanderbartPanel>
     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -41,10 +41,7 @@ const tomStønadsperiodeRad = (): Stønadsperiode => ({
 const initFormState = (
     eksisterendeStønadsperioder: Stønadsperiode[]
 ): FormState<StønadsperiodeForm> => ({
-    stønadsperioder:
-        eksisterendeStønadsperioder.length !== 0
-            ? eksisterendeStønadsperioder
-            : [tomStønadsperiodeRad()],
+    stønadsperioder: eksisterendeStønadsperioder,
 });
 
 const Stønadsperioder: React.FC = () => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -102,7 +102,7 @@ const Stønadsperioder: React.FC = () => {
 
         formState.setErrors((prevState: FormErrors<StønadsperiodeForm>) => ({
             ...prevState,
-            stønadsperioder: prevState.stønadsperioder.filter((_, i) => i !== indeks),
+            stønadsperioder: (prevState.stønadsperioder ?? []).filter((_, i) => i !== indeks),
         }));
     };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -185,7 +185,6 @@ const Stønadsperioder: React.FC = () => {
                                             formState.errors.stønadsperioder &&
                                             formState.errors.stønadsperioder[indeks]
                                         }
-                                        radKanSlettes={indeks !== 0}
                                         erLeservisning={
                                             !behandlingErRedigerbar || redigerer === false
                                         }
@@ -194,7 +193,9 @@ const Stønadsperioder: React.FC = () => {
                             </Table.Body>
                         </HvitTabell>
                     )}
+
                     <Feilmelding>{feilmelding}</Feilmelding>
+
                     {behandlingErRedigerbar && <HStack gap="4">{utledAksjonsknapper()}</HStack>}
                 </VStack>
             </form>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -47,12 +47,10 @@ const initFormState = (
             : [tomStønadsperiodeRad()],
 });
 
-const Stønadsperioder: React.FC<{
-    eksisterendeStønadsperioder: Stønadsperiode[];
-}> = ({ eksisterendeStønadsperioder }) => {
+const Stønadsperioder: React.FC = () => {
     const { request } = useApp();
     const { behandling } = useBehandling();
-    const { målgrupper, aktiviteter } = useInngangsvilkår();
+    const { målgrupper, aktiviteter, stønadsperioder } = useInngangsvilkår();
 
     const [feilmelding, settFeilmelding] = useState<string>();
     const [laster, settLaster] = useState<boolean>(false);
@@ -66,10 +64,8 @@ const Stønadsperioder: React.FC<{
             ),
         };
     };
-    const formState = useFormState<StønadsperiodeForm>(
-        initFormState(eksisterendeStønadsperioder),
-        validerForm
-    );
+
+    const formState = useFormState<StønadsperiodeForm>(initFormState(stønadsperioder), validerForm);
 
     const stønadsperioderState = formState.getProps('stønadsperioder') as ListState<Stønadsperiode>;
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { PencilIcon, PlusCircleIcon } from '@navikt/aksel-icons';
-import { Button, HStack, Table, VStack } from '@navikt/ds-react';
+import { HStack, Table, VStack } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
+import { Aksjonsknapper, LeggTilStønadsperiodeKnapp } from './Aksjonsknapper';
 import StønadsperiodeRad from './StønadsperiodeRad';
 import { validerStønadsperioder } from './validering';
 import { useApp } from '../../../../context/AppContext';
@@ -85,6 +85,7 @@ const Stønadsperioder: React.FC = () => {
         )
             .then((res) => {
                 if (res.status === RessursStatus.SUKSESS) {
+                    settRedigerer(false);
                     oppdaterStønadsperioder(res.data);
                 } else {
                     settFeilmelding(`Feilet legg til periode:${res.frontendFeilmelding}`);
@@ -131,53 +132,6 @@ const Stønadsperioder: React.FC = () => {
         stønadsperioderState.setValue([tomStønadsperiodeRad()]);
     };
 
-    const utledAksjonsknapper = () => {
-        if (redigerer) {
-            return (
-                <>
-                    <Button size="small" type="submit" disabled={laster}>
-                        Lagre
-                    </Button>
-                    <Button
-                        disabled={laster}
-                        onClick={avbrytRedigering}
-                        size="small"
-                        variant="tertiary"
-                    >
-                        Avbryt
-                    </Button>
-                </>
-            );
-        } else {
-            if (stønadsperioderState.value.length === 0) {
-                return (
-                    <Button
-                        icon={<PlusCircleIcon />}
-                        size="small"
-                        disabled={laster}
-                        onClick={() => {
-                            settRedigerer(true);
-                            initierFormMedTomRad();
-                        }}
-                    >
-                        Legg til stønadsperiode
-                    </Button>
-                );
-            } else {
-                return (
-                    <Button
-                        icon={<PencilIcon />}
-                        size="small"
-                        disabled={laster}
-                        onClick={() => settRedigerer(true)}
-                    >
-                        Endre stønadsperioder
-                    </Button>
-                );
-            }
-        }
-    };
-
     return (
         <EkspanderbartPanel tittel="Stønadsperioder">
             <form onSubmit={formState.onSubmit(handleSubmit)}>
@@ -217,20 +171,23 @@ const Stønadsperioder: React.FC = () => {
                         </HvitTabell>
                     )}
                     {stønadsperioderState.value.length === 0 && redigerer === true && (
-                        <Button
-                            icon={<PlusCircleIcon />}
-                            size="small"
-                            onClick={() => {
-                                initierFormMedTomRad;
-                            }}
-                        >
-                            Legg til stønadsperiode
-                        </Button>
+                        <LeggTilStønadsperiodeKnapp onClick={initierFormMedTomRad} />
                     )}
 
                     <Feilmelding>{feilmelding}</Feilmelding>
 
-                    {behandlingErRedigerbar && <HStack gap="4">{utledAksjonsknapper()}</HStack>}
+                    {behandlingErRedigerbar && (
+                        <HStack gap="4">
+                            <Aksjonsknapper
+                                redigerer={redigerer}
+                                finnesStønadsperioder={stønadsperioderState.value.length !== 0}
+                                laster={laster}
+                                avbrytRedigering={avbrytRedigering}
+                                initierFormMedTomRad={initierFormMedTomRad}
+                                startRedigering={() => settRedigerer(true)}
+                            />
+                        </HStack>
+                    )}
                 </VStack>
             </form>
         </EkspanderbartPanel>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -139,6 +139,7 @@ const Stønadsperioder: React.FC<{
                             <Table.HeaderCell>Aktivitet</Table.HeaderCell>
                             <Table.HeaderCell>Fra</Table.HeaderCell>
                             <Table.HeaderCell>Til</Table.HeaderCell>
+                            <Table.HeaderCell />
                         </Table.Row>
                     </Table.Header>
                     <Table.Body>
@@ -157,6 +158,7 @@ const Stønadsperioder: React.FC<{
                                     formState.errors.stønadsperioder[indeks]
                                 }
                                 radKanSlettes={indeks !== 0}
+                                erLeservisning={false}
                             />
                         ))}
                     </Table.Body>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -144,7 +144,7 @@ const Stønadsperioder: React.FC<{
                     <Table.Body>
                         {stønadsperioderState.value.map((periode, indeks) => (
                             <StønadsperiodeRad
-                                key={periode.id}
+                                key={periode.id || indeks}
                                 stønadsperide={periode}
                                 oppdaterStønadsperiode={(
                                     property: keyof Stønadsperiode,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Table, VStack } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
-import { Aksjonsknapper } from './Aksjonsknapper';
+import Aksjonsknapper from './Aksjonsknapper';
 import StønadsperiodeRad from './StønadsperiodeRad';
 import { validerStønadsperioder } from './validering';
 import { useApp } from '../../../../context/AppContext';

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -2,10 +2,10 @@ import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { HStack, Table, VStack } from '@navikt/ds-react';
+import { Table, VStack } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
-import { Aksjonsknapper, LeggTilStønadsperiodeKnapp } from './Aksjonsknapper';
+import { Aksjonsknapper } from './Aksjonsknapper';
 import StønadsperiodeRad from './StønadsperiodeRad';
 import { validerStønadsperioder } from './validering';
 import { useApp } from '../../../../context/AppContext';
@@ -162,23 +162,18 @@ const Stønadsperioder: React.FC = () => {
                             </Table.Body>
                         </HvitTabell>
                     )}
-                    {redigerer === true && (
-                        <LeggTilStønadsperiodeKnapp onClick={leggTilNyPeriode} />
-                    )}
 
                     <Feilmelding>{feilmelding}</Feilmelding>
 
                     {behandlingErRedigerbar && (
-                        <HStack gap="4">
-                            <Aksjonsknapper
-                                redigerer={redigerer}
-                                finnesStønadsperioder={stønadsperioderState.value.length !== 0}
-                                laster={laster}
-                                avbrytRedigering={avbrytRedigering}
-                                initierFormMedTomRad={leggTilNyPeriode}
-                                startRedigering={() => settRedigerer(true)}
-                            />
-                        </HStack>
+                        <Aksjonsknapper
+                            redigerer={redigerer}
+                            finnesStønadsperioder={stønadsperioderState.value.length !== 0}
+                            laster={laster}
+                            avbrytRedigering={avbrytRedigering}
+                            initierFormMedTomRad={leggTilNyPeriode}
+                            startRedigering={() => settRedigerer(true)}
+                        />
                     )}
                 </VStack>
             </form>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -16,7 +16,6 @@ import { ListState } from '../../../../hooks/felles/useListState';
 import EkspanderbartPanel from '../../../../komponenter/EkspanderbartPanel/EkspanderbartPanel';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import { RessursStatus } from '../../../../typer/ressurs';
-import { leggTilTomRadUnderIListe } from '../../VedtakOgBeregning/Barnetilsyn/utils';
 import { Stønadsperiode } from '../typer/stønadsperiode';
 
 const HvitTabell = styled(Table)`
@@ -94,10 +93,8 @@ const Stønadsperioder: React.FC = () => {
             .finally(() => settLaster(false));
     };
 
-    const leggTilTomRadUnder = (indeks: number) => {
-        stønadsperioderState.setValue((prevState) =>
-            leggTilTomRadUnderIListe(prevState, tomStønadsperiodeRad(), indeks)
-        );
+    const leggTilNyPeriode = () => {
+        stønadsperioderState.setValue((prevState) => [...prevState, tomStønadsperiodeRad()]);
     };
 
     const slettPeriode = (indeks: number) => {
@@ -128,10 +125,6 @@ const Stønadsperioder: React.FC = () => {
         hentStønadsperioder.rerun();
     };
 
-    const initierFormMedTomRad = () => {
-        stønadsperioderState.setValue([tomStønadsperiodeRad()]);
-    };
-
     return (
         <EkspanderbartPanel tittel="Stønadsperioder">
             <form onSubmit={formState.onSubmit(handleSubmit)}>
@@ -156,7 +149,6 @@ const Stønadsperioder: React.FC = () => {
                                             property: keyof Stønadsperiode,
                                             value: string | undefined
                                         ) => oppdaterStønadsperiode(indeks, property, value)}
-                                        leggTilTomRadUnder={() => leggTilTomRadUnder(indeks)}
                                         slettPeriode={() => slettPeriode(indeks)}
                                         feilmeldinger={
                                             formState.errors.stønadsperioder &&
@@ -170,8 +162,8 @@ const Stønadsperioder: React.FC = () => {
                             </Table.Body>
                         </HvitTabell>
                     )}
-                    {stønadsperioderState.value.length === 0 && redigerer === true && (
-                        <LeggTilStønadsperiodeKnapp onClick={initierFormMedTomRad} />
+                    {redigerer === true && (
+                        <LeggTilStønadsperiodeKnapp onClick={leggTilNyPeriode} />
                     )}
 
                     <Feilmelding>{feilmelding}</Feilmelding>
@@ -183,7 +175,7 @@ const Stønadsperioder: React.FC = () => {
                                 finnesStønadsperioder={stønadsperioderState.value.length !== 0}
                                 laster={laster}
                                 avbrytRedigering={avbrytRedigering}
-                                initierFormMedTomRad={initierFormMedTomRad}
+                                initierFormMedTomRad={leggTilNyPeriode}
                                 startRedigering={() => settRedigerer(true)}
                             />
                         </HStack>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -43,7 +43,13 @@ const initFormState = (
 const Stønadsperioder: React.FC = () => {
     const { request } = useApp();
     const { behandling, behandlingErRedigerbar } = useBehandling();
-    const { målgrupper, aktiviteter, stønadsperioder, hentStønadsperioder } = useInngangsvilkår();
+    const {
+        målgrupper,
+        aktiviteter,
+        stønadsperioder,
+        oppdaterStønadsperioder,
+        hentStønadsperioder,
+    } = useInngangsvilkår();
 
     const [feilmelding, settFeilmelding] = useState<string>();
     const [laster, settLaster] = useState<boolean>(false);
@@ -60,8 +66,11 @@ const Stønadsperioder: React.FC = () => {
     };
 
     const formState = useFormState<StønadsperiodeForm>(initFormState(stønadsperioder), validerForm);
-
     const stønadsperioderState = formState.getProps('stønadsperioder') as ListState<Stønadsperiode>;
+
+    useEffect(() => {
+        stønadsperioderState.setValue(stønadsperioder);
+    }, [stønadsperioder, stønadsperioderState]);
 
     const handleSubmit = (form: FormState<StønadsperiodeForm>) => {
         if (laster) return;
@@ -74,7 +83,7 @@ const Stønadsperioder: React.FC = () => {
         )
             .then((res) => {
                 if (res.status === RessursStatus.SUKSESS) {
-                    stønadsperioderState.setValue(res.data);
+                    oppdaterStønadsperioder(res.data);
                 } else {
                     settFeilmelding(`Feilet legg til periode:${res.frontendFeilmelding}`);
                 }
@@ -166,14 +175,6 @@ const Stønadsperioder: React.FC = () => {
             }
         }
     };
-
-    // Hvis målgrupper eller aktiviteter endrer seg, valider at stønadsperioder fortsatt er gyldige
-    // useEffect(() => {
-    //     if (stønadsperioderState.value[0].målgruppe !== '') {
-    //         formState.validateForm();
-    //     }
-    //     // eslint-disable-next-line react-hooks/exhaustive-deps
-    // }, [målgrupper, aktiviteter]);
 
     return (
         <EkspanderbartPanel tittel="Stønadsperioder">

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -116,6 +116,10 @@ const Stønadsperioder: React.FC = () => {
         hentStønadsperioder.rerun();
     };
 
+    const initierFormMedTomRad = () => {
+        stønadsperioderState.setValue([tomStønadsperiodeRad()]);
+    };
+
     const utledAksjonsknapper = () => {
         if (redigerer) {
             return (
@@ -134,16 +138,32 @@ const Stønadsperioder: React.FC = () => {
                 </>
             );
         } else {
-            return (
-                <Button
-                    icon={<PencilIcon />}
-                    size="small"
-                    disabled={laster}
-                    onClick={() => settRedigerer(true)}
-                >
-                    Endre stønadsperioder
-                </Button>
-            );
+            if (stønadsperioderState.value.length === 0) {
+                return (
+                    <Button
+                        icon={<PlusCircleIcon />}
+                        size="small"
+                        disabled={laster}
+                        onClick={() => {
+                            settRedigerer(true);
+                            initierFormMedTomRad();
+                        }}
+                    >
+                        Legg til stønadsperiode
+                    </Button>
+                );
+            } else {
+                return (
+                    <Button
+                        icon={<PencilIcon />}
+                        size="small"
+                        disabled={laster}
+                        onClick={() => settRedigerer(true)}
+                    >
+                        Endre stønadsperioder
+                    </Button>
+                );
+            }
         }
     };
 
@@ -198,7 +218,7 @@ const Stønadsperioder: React.FC = () => {
                             icon={<PlusCircleIcon />}
                             size="small"
                             onClick={() => {
-                                stønadsperioderState.setValue([tomStønadsperiodeRad()]);
+                                initierFormMedTomRad;
                             }}
                         >
                             Legg til stønadsperiode

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -42,13 +42,8 @@ const initFormState = (
 const Stønadsperioder: React.FC = () => {
     const { request } = useApp();
     const { behandling, behandlingErRedigerbar } = useBehandling();
-    const {
-        målgrupper,
-        aktiviteter,
-        stønadsperioder,
-        oppdaterStønadsperioder,
-        hentStønadsperioder,
-    } = useInngangsvilkår();
+    const { målgrupper, aktiviteter, stønadsperioder, oppdaterStønadsperioder } =
+        useInngangsvilkår();
 
     const [feilmelding, settFeilmelding] = useState<string>();
     const [laster, settLaster] = useState<boolean>(false);
@@ -122,7 +117,7 @@ const Stønadsperioder: React.FC = () => {
 
     const avbrytRedigering = () => {
         settRedigerer(false);
-        hentStønadsperioder.rerun();
+        stønadsperioderState.setValue(stønadsperioder);
     };
 
     return (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/validering.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/validering.ts
@@ -73,8 +73,8 @@ export const validerStønadsperioder = (
             };
         }
 
-        const aktivitetInnenfor = relevanteAktiviteter.some((målgruppe) =>
-            erPeriodeInnenforAnnenPeriode(periode, målgruppe)
+        const aktivitetInnenfor = relevanteAktiviteter.some((aktivitet) =>
+            erPeriodeInnenforAnnenPeriode(periode, aktivitet)
         );
 
         if (!aktivitetInnenfor) {

--- a/src/frontend/context/InngangsvilkårContext.ts
+++ b/src/frontend/context/InngangsvilkårContext.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import constate from 'constate';
 
@@ -42,6 +42,10 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             useState<Stønadsperiode[]>(hentedeStønadsperioder);
 
         // const [vilkårFeilmeldinger, settVilkårfeilmeldinger] = useState<Vurderingsfeilmelding>({});
+
+        useEffect(() => {
+            settStønadsperioder(hentedeStønadsperioder);
+        }, [hentedeStønadsperioder]);
 
         const leggTilMålgruppe = (nyPeriode: Målgruppe) => {
             settMålgrupper((prevState) => [...prevState, nyPeriode]);

--- a/src/frontend/context/InngangsvilkårContext.ts
+++ b/src/frontend/context/InngangsvilkårContext.ts
@@ -5,6 +5,7 @@ import constate from 'constate';
 import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
 import { Aktivitet } from '../Sider/Behandling/Inngangsvilkår/typer/aktivitet';
 import { Målgruppe } from '../Sider/Behandling/Inngangsvilkår/typer/målgruppe';
+import { Stønadsperiode } from '../Sider/Behandling/Inngangsvilkår/typer/stønadsperiode';
 import { Vilkårperioder } from '../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode';
 
 interface UseInngangsvilkår {
@@ -16,15 +17,24 @@ interface UseInngangsvilkår {
     oppdaterAktivitet: (oppdatertPeriode: Aktivitet) => void;
     hentVilkårperioder: RerrunnableEffect;
     // vilkårFeilmeldinger: Vurderingsfeilmelding;
+    stønadsperioder: Stønadsperiode[];
+    hentStønadsperioder: RerrunnableEffect;
 }
 
 interface Props {
     vilkårperioder: Vilkårperioder;
     hentVilkårperioder: RerrunnableEffect;
+    stønadsperioder: Stønadsperiode[];
+    hentStønadsperioder: RerrunnableEffect;
 }
 
 export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
-    ({ vilkårperioder, hentVilkårperioder }: Props): UseInngangsvilkår => {
+    ({
+        vilkårperioder,
+        hentVilkårperioder,
+        stønadsperioder,
+        hentStønadsperioder,
+    }: Props): UseInngangsvilkår => {
         const [målgrupper, settMålgrupper] = useState<Målgruppe[]>(vilkårperioder.målgrupper);
         const [aktiviteter, settAktiviteter] = useState<Aktivitet[]>(vilkårperioder.aktiviteter);
 
@@ -63,6 +73,8 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             oppdaterAktivitet,
             hentVilkårperioder,
             // vilkårFeilmeldinger,
+            stønadsperioder,
+            hentStønadsperioder,
         };
     }
 );

--- a/src/frontend/context/InngangsvilkårContext.ts
+++ b/src/frontend/context/InngangsvilkårContext.ts
@@ -18,13 +18,14 @@ interface UseInngangsvilkår {
     hentVilkårperioder: RerrunnableEffect;
     // vilkårFeilmeldinger: Vurderingsfeilmelding;
     stønadsperioder: Stønadsperiode[];
+    oppdaterStønadsperioder: (oppdaterteStønadsperioder: Stønadsperiode[]) => void;
     hentStønadsperioder: RerrunnableEffect;
 }
 
 interface Props {
     vilkårperioder: Vilkårperioder;
     hentVilkårperioder: RerrunnableEffect;
-    stønadsperioder: Stønadsperiode[];
+    hentedeStønadsperioder: Stønadsperiode[];
     hentStønadsperioder: RerrunnableEffect;
 }
 
@@ -32,11 +33,13 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
     ({
         vilkårperioder,
         hentVilkårperioder,
-        stønadsperioder,
+        hentedeStønadsperioder,
         hentStønadsperioder,
     }: Props): UseInngangsvilkår => {
         const [målgrupper, settMålgrupper] = useState<Målgruppe[]>(vilkårperioder.målgrupper);
         const [aktiviteter, settAktiviteter] = useState<Aktivitet[]>(vilkårperioder.aktiviteter);
+        const [stønadsperioder, settStønadsperioder] =
+            useState<Stønadsperiode[]>(hentedeStønadsperioder);
 
         // const [vilkårFeilmeldinger, settVilkårfeilmeldinger] = useState<Vurderingsfeilmelding>({});
 
@@ -74,6 +77,8 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             hentVilkårperioder,
             // vilkårFeilmeldinger,
             stønadsperioder,
+            oppdaterStønadsperioder: (oppdaterteStønadsperioder: Stønadsperiode[]) =>
+                settStønadsperioder(oppdaterteStønadsperioder),
             hentStønadsperioder,
         };
     }

--- a/src/frontend/hooks/felles/useFormState.ts
+++ b/src/frontend/hooks/felles/useFormState.ts
@@ -35,7 +35,7 @@ export type Valideringsfunksjon<T extends Record<string, any | undefined>> = (
     state: FormState<T>
 ) => FormErrors<T>;
 
-function tomtErrorState<T extends Record<string, unknown>>(initialState: FormState<T>) {
+const tomtErrorState = <T extends Record<string, unknown>>(initialState: FormState<T>) => {
     return Object.keys(initialState).reduce(
         (acc, key) => ({
             ...acc,
@@ -43,7 +43,7 @@ function tomtErrorState<T extends Record<string, unknown>>(initialState: FormSta
         }),
         {} as FormErrors<T>
     ) as FormErrors<T>;
-}
+};
 
 export default function useFormState<T extends Record<string, unknown>>(
     initialState: FormState<T>,

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from 'react';
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
 import Lesefelt from './Lesefelt';
-import { nullableTilDato, tilLocaleDateString } from '../../utils/dato';
+import { formaterNullableIsoDato, nullableTilDato, tilLocaleDateString } from '../../utils/dato';
 
 export interface Props {
     className?: string;
@@ -36,7 +36,7 @@ const DateInput: React.FC<Props> = ({
             className={className}
             label={label}
             hideLabel={hideLabel}
-            verdi={selectedDay?.toDateString()}
+            verdi={formaterNullableIsoDato(selectedDay?.toISOString())}
         />
     ) : (
         <DatePicker {...datepickerProps}>

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -3,7 +3,7 @@ import React, { ReactNode } from 'react';
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
 import Lesefelt from './Lesefelt';
-import { formaterNullableIsoDato, nullableTilDato, tilLocaleDateString } from '../../utils/dato';
+import { formaterDato, nullableTilDato, tilLocaleDateString } from '../../utils/dato';
 
 export interface Props {
     className?: string;
@@ -36,7 +36,7 @@ const DateInput: React.FC<Props> = ({
             className={className}
             label={label}
             hideLabel={hideLabel}
-            verdi={formaterNullableIsoDato(selectedDay?.toISOString())}
+            verdi={formaterDato(selectedDay)}
         />
     ) : (
         <DatePicker {...datepickerProps}>

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -30,6 +30,10 @@ export const nullableTilDato = (dato: string | Date | undefined): Date | undefin
     }
 };
 
+export const formaterDato = (dato?: string | Date): string | undefined => {
+    return dato && format(tilDato(dato), 'dd.MM.yyyy');
+};
+
 export const dagensDatoFormatert = (): string => {
     return new Date().toLocaleDateString('no-NO', {
         day: '2-digit',

--- a/src/frontend/utils/periode.ts
+++ b/src/frontend/utils/periode.ts
@@ -8,7 +8,7 @@ export type Periode = {
 
 export const erPeriodeInnenforAnnenPeriode = (periode: Periode, annenPeriode: Periode): boolean => {
     return (
-        erDatoEtterEllerLik(periode.fom, annenPeriode.fom) &&
+        erDatoEtterEllerLik(annenPeriode.fom, periode.fom) &&
         erDatoFørEllerLik(periode.tom, annenPeriode.tom)
     );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Hvordan stønadsperioder ser ut varierer basert på hvilken state man er i: 
- Ikke redigering (lik visning for beslutter minus knapper)
   - [1] Det finnes ingen stønadsperioder
      -  Man ser kun en knapp med "Legg til stønadsperioder". Ved trykk på denne legges det til en tom rad og redigeringsmodus aktiveres
    - [2] Det finnes stønadsperioder
      -  Stønadsperioder vises i lesemodus (kun verdier)
- Redigering
   - [3] Stønadsperioder finnes
       - Alle verdier kan redigeres (alle rader samtidig)
       - Man kan slette og legge til rader 
   - [4] Ingen stønadsperioder finnes 
       - Knapp for å legge til ny vises (dette skjer kun om man sletter alle eksisterende perioder)

### Nytt
- Det er nå mulig å slette alle rader
- Man legger til rader i bunnen hver gang

### Mangler
- Knapp for å si "ingen gyldige stønadsperioder". Trenger vi egentlig dette?
- Trigge ny validering av stønadsperioder ved oppdatering av  målgruppe og aktivitet
- Generell validering: besluttet å holde validering for det meste i backend og holde valideringen i frontend enkel

### Bilder
[1] Ikke redigering - Stønadsperioder finnes ikke
<img width="946" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/659f556d-e96a-487f-aab8-c11eb5ce8c8a">

[2] Ikke redigering - Stønadsperioder finnes
<img width="946" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/25569a5f-35b5-428e-bcd2-3f710fdb8c85">

[3] Redigering - Stønadsperioder finnes
<img width="946" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/a2791b05-567b-4901-bea7-3a5f315f5940">


[4] Redigering - Alle stønadsperioder fjernet
<img width="946" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/e8ab0cd5-eaaa-4bfd-a7cc-480a75bb2e2c">
