### PR TITLE
🐛 Småfix i vilkårperiode

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -4,6 +4,7 @@ import styled from 'styled-components';
 
 import { Button, Table } from '@navikt/ds-react';
 
+import { KildeIkon } from './KildeIkon';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
 import DateInput from '../../../../komponenter/Skjema/DateInput';
@@ -86,7 +87,9 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                     feil={periodeFeil?.tom}
                 />
             </Table.DataCell>
-            <Table.DataCell>{vilkårperiode?.kilde || KildeVilkårsperiode.MANUELL}</Table.DataCell>
+            <Table.DataCell>
+                <KildeIkon kilde={vilkårperiode?.kilde || KildeVilkårsperiode.MANUELL} />
+            </Table.DataCell>
             <Table.DataCell>
                 <KnappeRad>
                     <Button size="small" onClick={lagre}>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -48,7 +48,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
     periodeFeil,
 }) => {
     return (
-        <TabellRad $feilmeldingVises={!!periodeFeil}>
+        <TabellRad $feilmeldingVises={!!periodeFeil} shadeOnHover={false}>
             <Table.DataCell width="max-content">
                 <VilkårsresultatIkon
                     vilkårsresultat={vilkårperiode?.resultat || VilkårPeriodeResultat.IKKE_VURDERT}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -14,10 +14,10 @@ import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
 import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
 import { KildeVilkårsperiode, VilkårPeriode, VilkårPeriodeResultat } from '../typer/vilkårperiode';
 
-const TabellRad = styled(Table.Row)`
+const TabellRad = styled(Table.Row)<{ $feilmeldingVises: boolean }>`
     .navds-table__data-cell {
         border-color: transparent;
-        vertical-align: top;
+        vertical-align: ${(props) => (props.$feilmeldingVises ? 'top' : 'center')};
     }
 `;
 
@@ -48,7 +48,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
     periodeFeil,
 }) => {
     return (
-        <TabellRad>
+        <TabellRad $feilmeldingVises={!!periodeFeil}>
             <Table.DataCell width="max-content">
                 <VilkårsresultatIkon
                     vilkårsresultat={vilkårperiode?.resultat || VilkårPeriodeResultat.IKKE_VURDERT}
@@ -87,7 +87,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                     feil={periodeFeil?.tom}
                 />
             </Table.DataCell>
-            <Table.DataCell>
+            <Table.DataCell align="center">
                 <KildeIkon kilde={vilkårperiode?.kilde || KildeVilkårsperiode.MANUELL} />
             </Table.DataCell>
             <Table.DataCell>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -92,11 +92,11 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
             </Table.DataCell>
             <Table.DataCell>
                 <KnappeRad>
-                    <Button size="small" onClick={lagre}>
+                    <Button size="xsmall" onClick={lagre}>
                         Lagre
                     </Button>
 
-                    <Button onClick={avbrytRedigering} variant="secondary" size="small">
+                    <Button onClick={avbrytRedigering} variant="secondary" size="xsmall">
                         Avbryt
                     </Button>
                 </KnappeRad>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/KildeIkon.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/KildeIkon.tsx
@@ -1,0 +1,29 @@
+import React, { FC } from 'react';
+
+import { DatabaseIcon, PersonIcon } from '@navikt/aksel-icons';
+import { HStack } from '@navikt/ds-react';
+
+import { KildeVilkårsperiode } from '../typer/vilkårperiode';
+
+const utledIkon = (kilde: KildeVilkårsperiode) => {
+    switch (kilde) {
+        case KildeVilkårsperiode.MANUELL:
+            return <PersonIcon />;
+
+        case KildeVilkårsperiode.SYSTEM:
+            return <DatabaseIcon />;
+        default:
+            return null;
+    }
+};
+
+export const KildeIkon: FC<{
+    kilde: KildeVilkårsperiode;
+    className?: string;
+}> = ({ kilde }) => {
+    return (
+        <HStack justify="center" align="center">
+            {utledIkon(kilde)}
+        </HStack>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/KildeIkon.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/KildeIkon.tsx
@@ -1,11 +1,13 @@
 import React, { FC } from 'react';
 
 import { DatabaseIcon, PersonIcon } from '@navikt/aksel-icons';
-import { HStack } from '@navikt/ds-react';
 
 import { KildeVilkårsperiode } from '../typer/vilkårperiode';
 
-const utledIkon = (kilde: KildeVilkårsperiode) => {
+export const KildeIkon: FC<{
+    kilde: KildeVilkårsperiode;
+    className?: string;
+}> = ({ kilde }) => {
     switch (kilde) {
         case KildeVilkårsperiode.MANUELL:
             return <PersonIcon />;
@@ -15,15 +17,4 @@ const utledIkon = (kilde: KildeVilkårsperiode) => {
         default:
             return null;
     }
-};
-
-export const KildeIkon: FC<{
-    kilde: KildeVilkårsperiode;
-    className?: string;
-}> = ({ kilde }) => {
-    return (
-        <HStack justify="center" align="center">
-            {utledIkon(kilde)}
-        </HStack>
-    );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
@@ -9,8 +9,8 @@ import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsres
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../typer/ressurs';
 import { formaterIsoDato } from '../../../../utils/dato';
-import { AktivitetType } from '../typer/aktivitet';
-import { MålgruppeType } from '../typer/målgruppe';
+import { Aktivitet, AktivitetType } from '../typer/aktivitet';
+import { Målgruppe, MålgruppeType } from '../typer/målgruppe';
 import { SlettVilkårperiode, VilkårPeriode } from '../typer/vilkårperiode';
 
 const SlettVilkårperiodeModal: React.FC<{
@@ -21,7 +21,7 @@ const SlettVilkårperiodeModal: React.FC<{
 }> = ({ vilkårperiode, visModal, settVisModal, type }) => {
     const { request } = useApp();
     const { behandling } = useBehandling();
-    const { hentVilkårperioder } = useInngangsvilkår();
+    const { oppdaterAktivitet, oppdaterMålgruppe } = useInngangsvilkår();
 
     const [feil, settFeil] = useState('');
     const [laster, settLaster] = useState(false);
@@ -43,7 +43,11 @@ const SlettVilkårperiodeModal: React.FC<{
         )
             .then((res: RessursSuksess<VilkårPeriode> | RessursFeilet) => {
                 if (res.status === RessursStatus.SUKSESS) {
-                    hentVilkårperioder.rerun();
+                    if (type in MålgruppeType) {
+                        oppdaterMålgruppe(res.data as Målgruppe);
+                    } else {
+                        oppdaterAktivitet(res.data as Aktivitet);
+                    }
                     settVisModal(false);
                 } else {
                     settFeil(`Feil ved sletting av vilkårperiode: ${res.frontendFeilmelding}`);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -6,6 +6,7 @@ import { ChatIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
 import { Button, Detail, HStack, Popover, Spacer, Table, VStack } from '@navikt/ds-react';
 import { ABgSubtle } from '@navikt/ds-tokens/dist/tokens';
 
+import { KildeIkon } from './KildeIkon';
 import SlettVilkRperiodeModal from './SlettVilkårperiodeModal';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
@@ -93,7 +94,9 @@ const VilkårperiodeRad: React.FC<{
             </Table.DataCell>
             <Table.DataCell>{formaterIsoDato(vilkårperiode.fom)}</Table.DataCell>
             <Table.DataCell>{formaterIsoDato(vilkårperiode.tom)}</Table.DataCell>
-            <Table.DataCell>{vilkårperiode.kilde}</Table.DataCell>
+            <Table.DataCell>
+                <KildeIkon kilde={vilkårperiode.kilde} />
+            </Table.DataCell>
             <Table.DataCell>
                 {visRedigerKnapper && (
                     <>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -42,6 +42,7 @@ const VilkårperiodeRad: React.FC<{
         <TabellRad
             key={vilkårperiode.id}
             disabled={vilkårperiode.resultat === VilkårPeriodeResultat.SLETTET}
+            shadeOnHover={false}
         >
             <Table.DataCell width="max-content">
                 <HStack align="center">

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -94,7 +94,7 @@ const VilkårperiodeRad: React.FC<{
             </Table.DataCell>
             <Table.DataCell>{formaterIsoDato(vilkårperiode.fom)}</Table.DataCell>
             <Table.DataCell>{formaterIsoDato(vilkårperiode.tom)}</Table.DataCell>
-            <Table.DataCell>
+            <Table.DataCell align="center">
                 <KildeIkon kilde={vilkårperiode.kilde} />
             </Table.DataCell>
             <Table.DataCell>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -99,18 +99,18 @@ const VilkårperiodeRad: React.FC<{
             </Table.DataCell>
             <Table.DataCell>
                 {visRedigerKnapper && (
-                    <>
+                    <HStack gap="2">
                         <Button
                             onClick={startRedigering}
                             variant="secondary"
-                            size="small"
+                            size="xsmall"
                             icon={<PencilIcon />}
                         >
                             Endre
                         </Button>
                         <Button
                             icon={<TrashIcon />}
-                            size={'small'}
+                            size="xsmall"
                             variant={'tertiary'}
                             onClick={() => settVisSlettModal(true)}
                         />
@@ -120,7 +120,7 @@ const VilkårperiodeRad: React.FC<{
                             vilkårperiode={vilkårperiode}
                             type={type}
                         />
-                    </>
+                    </HStack>
                 )}
             </Table.DataCell>
         </TabellRad>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -7,7 +7,7 @@ import { Button, Detail, HStack, Popover, Spacer, Table, VStack } from '@navikt/
 import { ABgSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import { KildeIkon } from './KildeIkon';
-import SlettVilkRperiodeModal from './SlettVilkårperiodeModal';
+import SlettVilkårperiodeModal from './SlettVilkårperiodeModal';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
 import Lesefelt from '../../../../komponenter/Skjema/Lesefelt';
@@ -114,7 +114,7 @@ const VilkårperiodeRad: React.FC<{
                             variant={'tertiary'}
                             onClick={() => settVisSlettModal(true)}
                         />
-                        <SlettVilkRperiodeModal
+                        <SlettVilkårperiodeModal
                             visModal={visSlettModal}
                             settVisModal={settVisSlettModal}
                             vilkårperiode={vilkårperiode}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Knapper i tabell skal være `xsmall`
- Ikon skal brukes for å vise kilde (ikke tekst)
- Sletting av vilkårsperioder kan ikke trigge rerun av hentVilkårsperioder om vi ikke oppdaterer state i context. Fordi vi ikke har kontroll på redigering på tvers av målgrupper/aktivitet bør disse oppdatere state i context direkte og ikke hente alt på nytt. 
    - Eksisterende bug var at man ikke så at en periode var slettet med mindre man refreshet siden 

_Les commit for commit_

<img width="1035" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/fbd87329-920c-470e-9450-947b9f2016b2">
