### PR TITLE
💄 Tekst i vilkårperiodetabeller

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -12,7 +12,12 @@ import SelectMedOptions, { SelectOption } from '../../../../komponenter/Skjema/S
 import { Periode } from '../../../../utils/periode';
 import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
 import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
-import { KildeVilkårsperiode, VilkårPeriode, VilkårPeriodeResultat } from '../typer/vilkårperiode';
+import {
+    KildeVilkårsperiode,
+    VilkårPeriode,
+    VilkårPeriodeResultat,
+    vilkårperiodeTypeTilTekst,
+} from '../typer/vilkårperiode';
 
 const TabellRad = styled(Table.Row)<{ $feilmeldingVises: boolean }>`
     .navds-table__data-cell {
@@ -60,6 +65,9 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                     hideLabel
                     erLesevisning={vilkårperiode !== undefined}
                     value={form.type}
+                    lesevisningVerdi={
+                        form.type !== '' ? vilkårperiodeTypeTilTekst[form.type] : undefined
+                    }
                     valg={typeOptions}
                     onChange={(e) => oppdaterType(e.target.value)}
                     size="small"

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -14,7 +14,11 @@ import Lesefelt from '../../../../komponenter/Skjema/Lesefelt';
 import { formaterIsoDato, formaterIsoDatoTidMedSekunder } from '../../../../utils/dato';
 import { AktivitetType } from '../typer/aktivitet';
 import { MålgruppeType } from '../typer/målgruppe';
-import { VilkårPeriode, VilkårPeriodeResultat } from '../typer/vilkårperiode';
+import {
+    VilkårPeriode,
+    VilkårPeriodeResultat,
+    vilkårperiodeTypeTilTekst,
+} from '../typer/vilkårperiode';
 
 const TabellRad = styled(Table.Row)<{ disabled?: boolean }>`
     background: ${(props) => (props.disabled ? ABgSubtle : '')};
@@ -51,7 +55,7 @@ const VilkårperiodeRad: React.FC<{
             </Table.DataCell>
             <Table.DataCell>
                 <HStack align="center">
-                    {type}
+                    {vilkårperiodeTypeTilTekst[type]}
                     {vilkårperiode.begrunnelse && (
                         <>
                             <Spacer />

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -3,7 +3,16 @@ import React, { useRef, useState } from 'react';
 import { styled } from 'styled-components';
 
 import { ChatIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
-import { Button, Detail, HStack, Popover, Spacer, Table, VStack } from '@navikt/ds-react';
+import {
+    BodyShort,
+    Button,
+    Detail,
+    HStack,
+    Popover,
+    Spacer,
+    Table,
+    VStack,
+} from '@navikt/ds-react';
 import { ABgSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import { KildeIkon } from './KildeIkon';
@@ -55,7 +64,7 @@ const VilkårperiodeRad: React.FC<{
             </Table.DataCell>
             <Table.DataCell>
                 <HStack align="center">
-                    {vilkårperiodeTypeTilTekst[type]}
+                    <BodyShort size="small">{vilkårperiodeTypeTilTekst[type]}</BodyShort>
                     {vilkårperiode.begrunnelse && (
                         <>
                             <Spacer />
@@ -97,8 +106,12 @@ const VilkårperiodeRad: React.FC<{
                     )}
                 </HStack>
             </Table.DataCell>
-            <Table.DataCell>{formaterIsoDato(vilkårperiode.fom)}</Table.DataCell>
-            <Table.DataCell>{formaterIsoDato(vilkårperiode.tom)}</Table.DataCell>
+            <Table.DataCell>
+                <BodyShort size="small">{formaterIsoDato(vilkårperiode.fom)}</BodyShort>
+            </Table.DataCell>
+            <Table.DataCell>
+                <BodyShort size="small">{formaterIsoDato(vilkårperiode.tom)}</BodyShort>
+            </Table.DataCell>
             <Table.DataCell align="center">
                 <KildeIkon kilde={vilkårperiode.kilde} />
             </Table.DataCell>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
@@ -1,5 +1,5 @@
-import { Aktivitet } from './aktivitet';
-import { Målgruppe } from './målgruppe';
+import { Aktivitet, AktivitetType, AktivitetTypeTilTekst } from './aktivitet';
+import { Målgruppe, MålgruppeType, MålgruppeTypeTilTekst } from './målgruppe';
 import { Periode } from '../../../../utils/periode';
 
 export interface Vilkårperioder {
@@ -49,3 +49,8 @@ export interface SlettVilkårperiode {
     behandlingId: string;
     kommentar: string;
 }
+
+export const vilkårperiodeTypeTilTekst: Record<MålgruppeType | AktivitetType, string> = {
+    ...MålgruppeTypeTilTekst,
+    ...AktivitetTypeTilTekst,
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Bruke enumTilTekst for å slippe capslock på alle typer
- Wrappe tekst i tabell med `<BodyShort small>` så teksten når man har redigering med leservisning er lik teksten for kun visning. 

Før: 
<img width="768" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/af215cae-ca8a-4693-ae6b-1fc4981e28c1">

Etter:
<img width="742" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/8ce2e1ef-6b8d-4b14-af45-f1f84e4cced4">

Må fortsatt finne en løsning for at "slettet" ikonet tar mye mer plass enn resten
<img width="616" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/c6003ba2-2932-4f54-b777-1c08e316b95d">
