### PR TITLE
Datoinput skill ut leservisning

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -4,7 +4,7 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { Button, Table } from '@navikt/ds-react';
 
 import { FormErrors } from '../../../../hooks/felles/useFormState';
-import DateInput from '../../../../komponenter/Skjema/DateInput';
+import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
 import SelectMedOptions from '../../../../komponenter/Skjema/SelectMedOptions';
 import { AktivitetTypeOptions } from '../typer/aktivitet';
 import { MålgruppeTypeOptions } from '../typer/målgruppe';
@@ -55,7 +55,7 @@ const StønadsperiodeRad: React.FC<Props> = ({
                 />
             </Table.DataCell>
             <Table.DataCell>
-                <DateInput
+                <DateInputMedLeservisning
                     erLesevisning={erLeservisning}
                     label={'Fra'}
                     hideLabel
@@ -66,7 +66,7 @@ const StønadsperiodeRad: React.FC<Props> = ({
                 />
             </Table.DataCell>
             <Table.DataCell>
-                <DateInput
+                <DateInputMedLeservisning
                     erLesevisning={erLeservisning}
                     label={'Til'}
                     hideLabel

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -7,7 +7,7 @@ import { Button, Table } from '@navikt/ds-react';
 import { KildeIkon } from './KildeIkon';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
-import DateInput from '../../../../komponenter/Skjema/DateInput';
+import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
 import SelectMedOptions, { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Periode } from '../../../../utils/periode';
 import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
@@ -66,7 +66,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                 />
             </Table.DataCell>
             <Table.DataCell>
-                <DateInput
+                <DateInputMedLeservisning
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Fra'}
                     hideLabel
@@ -77,7 +77,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                 />
             </Table.DataCell>
             <Table.DataCell>
-                <DateInput
+                <DateInputMedLeservisning
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Til'}
                     hideLabel

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Stønadsperiode/StønadsperiodeValg.tsx
@@ -8,7 +8,7 @@ import { Button, Heading, Label } from '@navikt/ds-react';
 import { useBehandling } from '../../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import { ListState } from '../../../../../../hooks/felles/useListState';
-import DateInput from '../../../../../../komponenter/Skjema/DateInput';
+import DateInputMedLeservisning from '../../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import { Stønadsperiode, StønadsperiodeProperty } from '../../../../../../typer/vedtak';
 import { leggTilTomRadUnderIListe, tomStønadsperiodeRad } from '../../utils';
 import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
@@ -76,7 +76,7 @@ const StønadsperiodeValg: React.FC<Props> = ({
                 <Label size="small">Til</Label>
                 {stønadsperioderState.value.map((stønadsperiode, indeks) => (
                     <React.Fragment key={stønadsperiode.endretKey}>
-                        <DateInput
+                        <DateInputMedLeservisning
                             label="Fra"
                             hideLabel
                             erLesevisning={!behandlingErRedigerbar}
@@ -87,7 +87,7 @@ const StønadsperiodeValg: React.FC<Props> = ({
                             size="small"
                             feil={errorState && errorState[indeks]?.fom}
                         />
-                        <DateInput
+                        <DateInputMedLeservisning
                             label="Til"
                             hideLabel
                             erLesevisning={!behandlingErRedigerbar}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -7,7 +7,7 @@ import { Button, Heading, Label } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../../hooks/felles/useFormState';
-import DateInput from '../../../../../../komponenter/Skjema/DateInput';
+import DateInputMedLeservisning from '../../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import TextField from '../../../../../../komponenter/Skjema/TextField';
 import { Utgift, UtgifterProperty } from '../../../../../../typer/vedtak';
 import { tilÅrMåned } from '../../../../../../utils/dato';
@@ -111,7 +111,7 @@ const UtgifterValg: React.FC<Props> = ({
                                 error={errorState && errorState[indeks]?.utgift}
                                 size="small"
                             />
-                            <DateInput
+                            <DateInputMedLeservisning
                                 label="Fra"
                                 hideLabel
                                 erLesevisning={!behandlingErRedigerbar}
@@ -126,7 +126,7 @@ const UtgifterValg: React.FC<Props> = ({
                                 feil={errorState && errorState[indeks]?.fom}
                                 size="small"
                             />
-                            <DateInput
+                            <DateInputMedLeservisning
                                 label="Til"
                                 hideLabel
                                 erLesevisning={!behandlingErRedigerbar}

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -2,43 +2,24 @@ import React, { ReactNode } from 'react';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
-import Lesefelt from './Lesefelt';
-import { formaterDato, nullableTilDato, tilLocaleDateString } from '../../utils/dato';
+import { nullableTilDato, tilLocaleDateString } from '../../utils/dato';
 
-export interface Props {
-    className?: string;
-    erLesevisning?: boolean;
+export interface DateInputProps {
     feil?: ReactNode;
     hideLabel?: boolean;
-    label?: string;
+    label: string;
     onChange: (dato?: string) => void;
     size?: 'small' | 'medium';
     value?: string;
 }
 
-const DateInput: React.FC<Props> = ({
-    className,
-    erLesevisning = false,
-    feil,
-    hideLabel,
-    label,
-    onChange,
-    size,
-    value,
-}) => {
-    const { datepickerProps, inputProps, selectedDay } = useDatepicker({
+const DateInput: React.FC<DateInputProps> = ({ feil, hideLabel, label, onChange, size, value }) => {
+    const { datepickerProps, inputProps } = useDatepicker({
         defaultSelected: nullableTilDato(value),
         onDateChange: (val) => onChange(val ? tilLocaleDateString(val) : val),
     });
 
-    return erLesevisning ? (
-        <Lesefelt
-            className={className}
-            label={label}
-            hideLabel={hideLabel}
-            verdi={formaterDato(selectedDay)}
-        />
-    ) : (
+    return (
         <DatePicker {...datepickerProps}>
             <DatePicker.Input
                 {...inputProps}

--- a/src/frontend/komponenter/Skjema/DateInputMedLeservisning.tsx
+++ b/src/frontend/komponenter/Skjema/DateInputMedLeservisning.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import DateInput, { DateInputProps } from './DateInput';
+import Lesefelt from './Lesefelt';
+import { formaterDato } from '../../utils/dato';
+
+export interface Props extends DateInputProps {
+    className?: string;
+    erLesevisning?: boolean;
+}
+
+const DateInputMedLeservisning: React.FC<Props> = ({
+    className,
+    erLesevisning = false,
+    hideLabel,
+    label,
+    size,
+    value,
+    ...props
+}) => {
+    return erLesevisning ? (
+        <Lesefelt
+            className={className}
+            label={label}
+            hideLabel={hideLabel}
+            verdi={formaterDato(value)}
+            size={size}
+        />
+    ) : (
+        <DateInput {...props} label={label} hideLabel={hideLabel} value={value} size={size} />
+    );
+};
+
+export default DateInputMedLeservisning;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lag egen komponent som sørger for at datofelt rendres på nytt ved switch mellom leservisning og redigering av dato. Dette gjøres for å håndtere at innsendt verdi kan være annerledes og vil trigge en ny rendring av `defaultValue`.

Alternativet er å bruke `setSelected` hver gang input endrer seg, men det blir en liten loop :(