### PR TITLE
🗑️  Fjern (noe) validering stønadsperioder

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -42,25 +42,15 @@ const initFormState = (
 const Stønadsperioder: React.FC = () => {
     const { request } = useApp();
     const { behandling, behandlingErRedigerbar } = useBehandling();
-    const {
-        målgrupper,
-        aktiviteter,
-        stønadsperioder,
-        oppdaterStønadsperioder,
-        stønadsperiodeFeil,
-        settStønadsperiodeFeil,
-    } = useInngangsvilkår();
+    const { stønadsperioder, oppdaterStønadsperioder, stønadsperiodeFeil, settStønadsperiodeFeil } =
+        useInngangsvilkår();
 
     const [laster, settLaster] = useState<boolean>(false);
     const [redigerer, settRedigerer] = useState<boolean>(false);
 
     const validerForm = (formState: StønadsperiodeForm): FormErrors<StønadsperiodeForm> => {
         return {
-            stønadsperioder: validerStønadsperioder(
-                formState.stønadsperioder,
-                målgrupper,
-                aktiviteter
-            ),
+            stønadsperioder: validerStønadsperioder(formState.stønadsperioder),
         };
     };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/validering.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/validering.ts
@@ -1,14 +1,9 @@
 import { FormErrors } from '../../../../hooks/felles/useFormState';
-import { erPeriodeInnenforAnnenPeriode, validerPeriode } from '../../../../utils/periode';
-import { Aktivitet } from '../typer/aktivitet';
-import { Målgruppe } from '../typer/målgruppe';
+import { validerPeriode } from '../../../../utils/periode';
 import { Stønadsperiode } from '../typer/stønadsperiode';
-import { VilkårPeriodeResultat } from '../typer/vilkårperiode';
 
 export const validerStønadsperioder = (
-    stønadsperioder: Stønadsperiode[],
-    målgrupper: Målgruppe[],
-    aktiviteter: Aktivitet[]
+    stønadsperioder: Stønadsperiode[]
 ): FormErrors<Stønadsperiode[]> => {
     const feilIStønadsperioder = stønadsperioder.map((periode) => {
         const stønadsperiodeFeil: FormErrors<Stønadsperiode> = {
@@ -31,56 +26,6 @@ export const validerStønadsperioder = (
             return {
                 ...stønadsperiodeFeil,
                 ...periodeValidering,
-            };
-        }
-
-        // TODO: Flytte validering under til backend?
-        // TODO valider at målgruppe og aktivitet sammen er gyldige
-        const relevanteMålgrupper = målgrupper.filter(
-            (målgruppe) =>
-                periode.målgruppe === målgruppe.type &&
-                målgruppe.resultat === VilkårPeriodeResultat.OPPFYLT
-        );
-
-        if (relevanteMålgrupper.length === 0) {
-            return {
-                ...stønadsperiodeFeil,
-                målgruppe: 'Finnes ingen periode for målgruppe hvor vilkår er oppfylt',
-            };
-        }
-
-        const målgrupperInnenfor = relevanteMålgrupper.some((målgruppe) =>
-            erPeriodeInnenforAnnenPeriode(periode, målgruppe)
-        );
-
-        if (!målgrupperInnenfor) {
-            return {
-                ...stønadsperiodeFeil,
-                målgruppe: 'Ingen relevante målgruppeperioder rommer stønadsperioden',
-            };
-        }
-
-        const relevanteAktiviteter = aktiviteter.filter(
-            (aktivitet) =>
-                periode.aktivitet === aktivitet.type &&
-                aktivitet.resultat === VilkårPeriodeResultat.OPPFYLT
-        );
-
-        if (relevanteAktiviteter.length === 0) {
-            return {
-                ...stønadsperiodeFeil,
-                aktivitet: 'Finnes ingen periode for aktivitet hvor vilkår er oppfylt',
-            };
-        }
-
-        const aktivitetInnenfor = relevanteAktiviteter.some((aktivitet) =>
-            erPeriodeInnenforAnnenPeriode(periode, aktivitet)
-        );
-
-        if (!aktivitetInnenfor) {
-            return {
-                ...stønadsperiodeFeil,
-                aktivitet: 'Ingen relevante aktivitetperioder rommer stønadsperioden',
             };
         }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Backend skal være ansvarlig for validering på tvers av vilkårsperioder og stønadsperioder