### PR TITLE
✨ Skal kunne navigere til neste steg i bunnen av inngangsvilkår

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -75,6 +75,10 @@ const BehandlingInnhold: React.FC<{
         }
         return false;
     };
+
+    useEffect(() => {
+        settAktivFane(path);
+    }, [path]);
 
     const behandlingFaner = hentBehandlingfaner(behandling.stønadstype);
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -1,8 +1,9 @@
 import React, { useCallback, useState } from 'react';
 
+import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { VStack } from '@navikt/ds-react';
+import { Button, HStack, VStack } from '@navikt/ds-react';
 
 import Aktivitet from './Aktivitet/Aktivitet';
 import FyllUtVilkårKnapp from './FyllUtVilkårKnapp';
@@ -18,12 +19,14 @@ import DataViewer from '../../../komponenter/DataViewer';
 import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
 import { features } from '../../../utils/features';
 import { erProd } from '../../../utils/miljø';
+import { FanePath } from '../faner';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
     margin: 2rem;
 `;
 
 const Inngangsvilkår = () => {
+    const navigate = useNavigate();
     const { request } = useApp();
     const { behandling } = useBehandling();
 
@@ -74,6 +77,20 @@ const Inngangsvilkår = () => {
                     </>
                 )}
             </DataViewer>
+            <HStack gap="4">
+                <Button
+                    variant="primary"
+                    size="small"
+                    onClick={() =>
+                        navigate(`/behandling/${behandling.id}/${FanePath.STØNADSVILKÅR}`)
+                    }
+                >
+                    Neste steg
+                </Button>
+                <Button variant="secondary" size="small" onClick={() => navigate('/')}>
+                    Forsett senere
+                </Button>
+            </HStack>
         </Container>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -77,7 +77,7 @@ const Inngangsvilkår = () => {
                     </>
                 )}
             </DataViewer>
-            <HStack gap="4">
+            <HStack>
                 <Button
                     variant="primary"
                     size="small"
@@ -86,9 +86,6 @@ const Inngangsvilkår = () => {
                     }
                 >
                     Neste steg
-                </Button>
-                <Button variant="secondary" size="small" onClick={() => navigate('/')}>
-                    Forsett senere
                 </Button>
             </HStack>
         </Container>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Man skal kunne navigere i bunnen av inngangsvilkår.

<img width="957" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/c15f4651-5159-4154-8d20-174c778058f1">

Håndterer ikke sjekk om ting er lagret. 
"Fortsett senere" betyr egt bare "gå ut av behandlingsvinduet", men senere burde det kanskje være "sett på vent" inkludert