### PR TITLE
Skal ikke vise tabell før den har innhold

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -16,7 +16,7 @@ import VilkårperiodeRad from '../Vilkårperioder/VilkårperiodeRad';
 
 const HvitTabell = styled(Table)`
     background-color: ${AWhite};
-    max-width: fit-content;
+    max-width: 750px;
 `;
 
 const Aktivitet: React.FC = () => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -7,6 +7,7 @@ import { Button, Table } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
 import EndreAktivitetRad from './EndreAktivitetRad';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { VilkårPanel } from '../../../../komponenter/EkspanderbartPanel/VilkårPanel';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
@@ -21,6 +22,7 @@ const HvitTabell = styled(Table)`
 
 const Aktivitet: React.FC = () => {
     const { aktiviteter } = useInngangsvilkår();
+    const { behandlingErRedigerbar } = useBehandling();
 
     const [leggerTilNyPeriode, settLeggerTilNyPeriode] = useState<boolean>(false);
     const [radIRedigeringsmodus, settRadIRedigeringsmodus] = useState<string>();
@@ -92,7 +94,7 @@ const Aktivitet: React.FC = () => {
                 </HvitTabell>
             )}
             <Feilmelding>{feilmelding}</Feilmelding>
-            {kanSetteNyRadIRedigeringsmodus && (
+            {kanSetteNyRadIRedigeringsmodus && behandlingErRedigerbar && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode((prevState) => !prevState)}
                     size="small"

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -35,6 +35,8 @@ const Aktivitet: React.FC = () => {
     const kanSetteNyRadIRedigeringsmodus =
         radIRedigeringsmodus === undefined && !leggerTilNyPeriode;
 
+    const skalViseTabell = aktiviteter.length > 0 || leggerTilNyPeriode;
+
     const settNyRadIRedigeringsmodus = (id: string) => {
         if (kanSetteNyRadIRedigeringsmodus) {
             settFeilmelding(undefined);
@@ -52,46 +54,50 @@ const Aktivitet: React.FC = () => {
             paragrafLenker={lovverkslenkerAktivitet}
             rundskrivLenke={rundskrivAktivitet}
         >
-            <HvitTabell size="small">
-                <Table.Header>
-                    <Table.Row>
-                        <Table.HeaderCell style={{ width: '20px' }} />
-                        <Table.HeaderCell>Type</Table.HeaderCell>
-                        <Table.HeaderCell>Fra</Table.HeaderCell>
-                        <Table.HeaderCell>Til</Table.HeaderCell>
-                        <Table.HeaderCell>Kilde</Table.HeaderCell>
-                        <Table.HeaderCell />
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {aktiviteter.map((aktivitet) => (
-                        <React.Fragment key={aktivitet.id}>
-                            {aktivitet.id === radIRedigeringsmodus ? (
-                                <EndreAktivitetRad
-                                    aktivitet={aktivitet}
-                                    avbrytRedigering={fjernRadIRedigeringsmodus}
-                                />
-                            ) : (
-                                <VilkårperiodeRad
-                                    vilkårperiode={aktivitet}
-                                    type={aktivitet.type}
-                                    startRedigering={() => settNyRadIRedigeringsmodus(aktivitet.id)}
-                                />
-                            )}
-                        </React.Fragment>
-                    ))}
-                    {leggerTilNyPeriode && (
-                        <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
-                    )}
-                </Table.Body>
-            </HvitTabell>
+            {skalViseTabell && (
+                <HvitTabell size="small">
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.HeaderCell style={{ width: '20px' }} />
+                            <Table.HeaderCell>Type</Table.HeaderCell>
+                            <Table.HeaderCell>Fra</Table.HeaderCell>
+                            <Table.HeaderCell>Til</Table.HeaderCell>
+                            <Table.HeaderCell>Kilde</Table.HeaderCell>
+                            <Table.HeaderCell />
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {aktiviteter.map((aktivitet) => (
+                            <React.Fragment key={aktivitet.id}>
+                                {aktivitet.id === radIRedigeringsmodus ? (
+                                    <EndreAktivitetRad
+                                        aktivitet={aktivitet}
+                                        avbrytRedigering={fjernRadIRedigeringsmodus}
+                                    />
+                                ) : (
+                                    <VilkårperiodeRad
+                                        vilkårperiode={aktivitet}
+                                        type={aktivitet.type}
+                                        startRedigering={() =>
+                                            settNyRadIRedigeringsmodus(aktivitet.id)
+                                        }
+                                    />
+                                )}
+                            </React.Fragment>
+                        ))}
+                        {leggerTilNyPeriode && (
+                            <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
+                        )}
+                    </Table.Body>
+                </HvitTabell>
+            )}
             <Feilmelding>{feilmelding}</Feilmelding>
             {kanSetteNyRadIRedigeringsmodus && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode((prevState) => !prevState)}
                     size="small"
                     style={{ maxWidth: 'fit-content' }}
-                    variant="secondary"
+                    variant={skalViseTabell ? 'secondary' : 'primary'}
                     icon={<PlusCircleIcon />}
                 >
                     Legg til ny aktivitet

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -7,6 +7,7 @@ import { Button, Table } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
 import EndreMålgruppeRad from './EndreMålgruppeRad';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { VilkårPanel } from '../../../../komponenter/EkspanderbartPanel/VilkårPanel';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
@@ -21,6 +22,7 @@ const HvitTabell = styled(Table)`
 
 const Målgruppe: React.FC = () => {
     const { målgrupper } = useInngangsvilkår();
+    const { behandlingErRedigerbar } = useBehandling();
 
     const [leggerTilNyPeriode, settLeggerTilNyPeriode] = useState<boolean>(false);
     const [radIRedigeringsmodus, settRadIRedigeringsmodus] = useState<string>();
@@ -92,7 +94,7 @@ const Målgruppe: React.FC = () => {
                 </HvitTabell>
             )}
             <Feilmelding>{feilmelding}</Feilmelding>
-            {kanSetteNyRadIRedigeringsmodus && (
+            {kanSetteNyRadIRedigeringsmodus && behandlingErRedigerbar && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode(true)}
                     size="small"

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -35,6 +35,8 @@ const Målgruppe: React.FC = () => {
     const kanSetteNyRadIRedigeringsmodus =
         radIRedigeringsmodus === undefined && !leggerTilNyPeriode;
 
+    const skalViseTabell = målgrupper.length > 0 || leggerTilNyPeriode;
+
     const settNyRadIRedigeringsmodus = (id: string) => {
         if (kanSetteNyRadIRedigeringsmodus) {
             settFeilmelding(undefined);
@@ -52,49 +54,53 @@ const Målgruppe: React.FC = () => {
             paragrafLenker={lovverkslenkerMålgruppe}
             rundskrivLenke={rundskrivMålgruppe}
         >
-            <HvitTabell size="small">
-                <Table.Header>
-                    <Table.Row>
-                        <Table.HeaderCell style={{ width: '20px' }} />
-                        <Table.HeaderCell>Ytelse/situasjon</Table.HeaderCell>
-                        <Table.HeaderCell>Fra</Table.HeaderCell>
-                        <Table.HeaderCell>Til</Table.HeaderCell>
-                        <Table.HeaderCell>Kilde</Table.HeaderCell>
-                        <Table.HeaderCell />
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {målgrupper.map((målgruppe) => (
-                        <React.Fragment key={målgruppe.id}>
-                            {målgruppe.id === radIRedigeringsmodus ? (
-                                <EndreMålgruppeRad
-                                    målgruppe={målgruppe}
-                                    avbrytRedigering={fjernRadIRedigeringsmodus}
-                                />
-                            ) : (
-                                <VilkårperiodeRad
-                                    vilkårperiode={målgruppe}
-                                    type={målgruppe.type}
-                                    startRedigering={() => settNyRadIRedigeringsmodus(målgruppe.id)}
-                                />
-                            )}
-                        </React.Fragment>
-                    ))}
-                    {leggerTilNyPeriode && (
-                        <EndreMålgruppeRad avbrytRedigering={fjernRadIRedigeringsmodus} />
-                    )}
-                </Table.Body>
-            </HvitTabell>
+            {skalViseTabell && (
+                <HvitTabell size="small">
+                    <Table.Header>
+                        <Table.Row>
+                            <Table.HeaderCell style={{ width: '20px' }} />
+                            <Table.HeaderCell>Ytelse/situasjon</Table.HeaderCell>
+                            <Table.HeaderCell>Fra</Table.HeaderCell>
+                            <Table.HeaderCell>Til</Table.HeaderCell>
+                            <Table.HeaderCell>Kilde</Table.HeaderCell>
+                            <Table.HeaderCell />
+                        </Table.Row>
+                    </Table.Header>
+                    <Table.Body>
+                        {målgrupper.map((målgruppe) => (
+                            <React.Fragment key={målgruppe.id}>
+                                {målgruppe.id === radIRedigeringsmodus ? (
+                                    <EndreMålgruppeRad
+                                        målgruppe={målgruppe}
+                                        avbrytRedigering={fjernRadIRedigeringsmodus}
+                                    />
+                                ) : (
+                                    <VilkårperiodeRad
+                                        vilkårperiode={målgruppe}
+                                        type={målgruppe.type}
+                                        startRedigering={() =>
+                                            settNyRadIRedigeringsmodus(målgruppe.id)
+                                        }
+                                    />
+                                )}
+                            </React.Fragment>
+                        ))}
+                        {leggerTilNyPeriode && (
+                            <EndreMålgruppeRad avbrytRedigering={fjernRadIRedigeringsmodus} />
+                        )}
+                    </Table.Body>
+                </HvitTabell>
+            )}
             <Feilmelding>{feilmelding}</Feilmelding>
             {kanSetteNyRadIRedigeringsmodus && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode(true)}
                     size="small"
                     style={{ maxWidth: 'fit-content' }}
-                    variant="secondary"
+                    variant={skalViseTabell ? 'secondary' : 'primary'}
                     icon={<PlusCircleIcon />}
                 >
-                    Legg til ny målgruppeperiode
+                    Legg til ny målgruppe
                 </Button>
             )}
         </VilkårPanel>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -16,7 +16,7 @@ import VilkårperiodeRad from '../Vilkårperioder/VilkårperiodeRad';
 
 const HvitTabell = styled(Table)`
     background-color: ${AWhite};
-    max-width: fit-content;
+    max-width: 750px;
 `;
 
 const Målgruppe: React.FC = () => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hva er fikset: 
- Tabell skal ikke vises om ingen perioder finnes + knapp primary hvis tabell ikke vises
- Bredden på tabellen så den ikke endrer seg mellom redigering og visning
- Kun vise knapper for å legge til ny om behandling er redigerbar
- Samme bredde på venstremeny som høyre

Knapp skal være secondary + tabell om det finnes perioder (målgruppe) og primary + tabell ikke syntes ved ingen perioder (aktivitet): 
<img width="1725" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/4904cc75-bb0e-46ff-9b09-4437185503b1">

Før: 
<img width="1725" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/43fc5306-2901-4971-b05c-1c823731c18d">
