### PR TITLE
✨ Skal vise om begrunnelse er obligatorisk eller ikke ved vurdering av medlemskap

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -4,7 +4,7 @@ import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
 import { DelvilkårMålgruppe, MålgruppeType } from '../typer/målgruppe';
-import { Vurdering } from '../typer/vilkårperiode';
+import { BegrunnelseObligatorisk, Vurdering } from '../typer/vilkårperiode';
 
 const MålgruppeVilkår: React.FC<{
     målgruppeForm: EndreMålgruppeForm;
@@ -28,6 +28,7 @@ const MålgruppeVilkår: React.FC<{
                     }
                     svarJa="Ja (vurdert etter første ledd)"
                     svarNei="Nei (vurdert etter andre ledd)"
+                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI}
                 />
             );
 
@@ -40,6 +41,7 @@ const MålgruppeVilkår: React.FC<{
                     oppdaterVurdering={(vurdering: Vurdering) =>
                         oppdaterDelvilkår('medlemskap', vurdering)
                     }
+                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI}
                 />
             );
         default:

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
@@ -45,6 +45,12 @@ export enum SvarJaNei {
     NEI = 'NEI',
 }
 
+export enum BegrunnelseObligatorisk {
+    OBLIGATORISK = 'OBLIGATORISK',
+    VALGFRI = 'VALGFRI',
+    OBLIGATORISK_HVIS_SVAR_NEI = 'OBLIGATORISK_HVIS_SVAR_NEI',
+}
+
 export const svarJaNeiMapping: Record<SvarJaNei, string> = {
     JA: 'Ja',
     JA_IMPLISITT: 'Ja',

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
@@ -2,7 +2,12 @@ import React from 'react';
 
 import { Radio, RadioGroup, Textarea } from '@navikt/ds-react';
 
-import { SvarJaNei, Vurdering, svarJaNeiMapping } from '../Inngangsvilkår/typer/vilkårperiode';
+import {
+    SvarJaNei,
+    Vurdering,
+    svarJaNeiMapping,
+    BegrunnelseObligatorisk,
+} from '../Inngangsvilkår/typer/vilkårperiode';
 
 const JaNeiVurdering: React.FC<{
     label: string;
@@ -10,13 +15,29 @@ const JaNeiVurdering: React.FC<{
     oppdaterVurdering: (vurdering: Vurdering) => void;
     svarJa?: string;
     svarNei?: string;
+    begrunnelsePåkrevd?: BegrunnelseObligatorisk;
 }> = ({
     vurdering,
     oppdaterVurdering,
     label,
     svarJa = svarJaNeiMapping[SvarJaNei.JA],
     svarNei = svarJaNeiMapping[SvarJaNei.NEI],
+    begrunnelsePåkrevd,
 }) => {
+    const begunnelseLabel = (påkrevd?: BegrunnelseObligatorisk, svar?: SvarJaNei): string => {
+        switch (påkrevd) {
+            case BegrunnelseObligatorisk.OBLIGATORISK:
+                return 'Begrunnelse (obligatorisk)';
+            case BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI:
+                return svar === SvarJaNei.NEI
+                    ? 'Begrunnelse (obligatorisk)'
+                    : 'Begrunnelse (valgfri)';
+            case BegrunnelseObligatorisk.VALGFRI:
+            default:
+                return 'Begrunnelse (valgfri)';
+        }
+    };
+
     return (
         <>
             <RadioGroup
@@ -31,7 +52,7 @@ const JaNeiVurdering: React.FC<{
             <Textarea
                 value={vurdering?.begrunnelse}
                 onChange={(e) => oppdaterVurdering({ ...vurdering, begrunnelse: e.target.value })}
-                label="Begrunnelse"
+                label={begunnelseLabel(begrunnelsePåkrevd, vurdering?.svar)}
                 size="small"
             />
         </>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ref [skissene](https://www.figma.com/file/T5lYk3vCOWiahrAs3jIaby/TILDE-~--TS-saksbehandling-pass-av-barn?type=design&node-id=3049-9889&mode=design&t=Y23J3J6XK2EWSk2N-4) er begrunnelse obligatorisk dersom medlemskap ikke oppfylt.

<img width="662" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/de267281-34b5-4e2a-b493-76801f5e49a6">
<img width="655" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/3f1df732-dad2-48c6-aed5-154cc42ff297">

Validering av begrunnelse kommer i annen PR.
