### PR TITLE
Man får nå en liste med hovedytelser

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -15,9 +15,8 @@ const Oppsummering: React.FC = () => {
     const { request } = useApp();
     const { behandling } = useBehandling();
 
-    const [behandlingFakta, settBehandlingFakta] = useState<Ressurs<BehandlingFakta>>(
-        byggTomRessurs()
-    );
+    const [behandlingFakta, settBehandlingFakta] =
+        useState<Ressurs<BehandlingFakta>>(byggTomRessurs());
 
     const hentBehandlingFaktaCallback = useCallback(() => {
         request<BehandlingFakta, null>(`/api/sak/behandling/${behandling.id}/fakta`).then(
@@ -34,7 +33,9 @@ const Oppsummering: React.FC = () => {
                     <InfoSeksjon label="Ytelse/situasjon">
                         <Informasjonsrad
                             kilde={Informasjonskilde.SØKNAD}
-                            verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse}
+                            verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse?.join(
+                                ', '
+                            )}
                         />
                     </InfoSeksjon>
 

--- a/src/frontend/typer/behandling/behandlingFakta/faktaHovedytelse.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaHovedytelse.ts
@@ -3,7 +3,7 @@ export interface FaktaHovedytelse {
 }
 
 interface SøknadsgrunnlagHovedytelse {
-    hovedytelse: Hovedytelse;
+    hovedytelse: Hovedytelse[];
 }
 
 enum Hovedytelse {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Liten quickfix på at fikse at man får flere ytelser. M sa at hon hade skisser som var sånn her et sted, med komma. Tenker det er greit nå. Senere trenger vi mapping til tekst.

Koblet til/se beskrivelse
* https://github.com/navikt/tilleggsstonader-sak/pull/194


<img width="288" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/4ee4e7f4-6357-47b7-a692-45dce97c6aca">
