### PR TITLE
Skal vise informasjon om en opphold fra søknaden

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -3,13 +3,23 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { VStack } from '@navikt/ds-react';
 
 import BarnDetaljer from './BarnDetaljer';
-import { InfoSeksjon, Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
+import { Informasjonskilde, Informasjonsrad, InfoSeksjon } from './Visningskomponenter';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import DataViewer from '../../../../komponenter/DataViewer';
 import { BehandlingFakta } from '../../../../typer/behandling/behandlingFakta/behandlingFakta';
 import { JaNei } from '../../../../typer/common';
-import { Ressurs, byggTomRessurs } from '../../../../typer/ressurs';
+import { byggTomRessurs, Ressurs } from '../../../../typer/ressurs';
+
+const boddSammenhengendeMapping: Record<JaNei, string> = {
+    JA: 'Bodd sammenhengende i Norge siste 12 mnd',
+    NEI: 'Ikke sammenhengende i Norge siste 12 mnd',
+};
+
+const planleggerBoINorgeNeste12mndMapping: Record<JaNei, string> = {
+    JA: 'Planlegger å bo i Norge neste 12 mnd',
+    NEI: 'Ikke planlagt å bo i Norge neste 12 mnd',
+};
 
 const Oppsummering: React.FC = () => {
     const { request } = useApp();
@@ -37,6 +47,29 @@ const Oppsummering: React.FC = () => {
                                 ', '
                             )}
                         />
+                        {behandlingFakta.hovedytelse.søknadsgrunnlag?.boddSammenhengende && (
+                            <Informasjonsrad
+                                kilde={Informasjonskilde.SØKNAD}
+                                verdi={
+                                    boddSammenhengendeMapping[
+                                        behandlingFakta.hovedytelse.søknadsgrunnlag
+                                            .boddSammenhengende
+                                    ]
+                                }
+                            />
+                        )}
+                        {behandlingFakta.hovedytelse.søknadsgrunnlag
+                            ?.planleggerBoINorgeNeste12mnd && (
+                            <Informasjonsrad
+                                kilde={Informasjonskilde.SØKNAD}
+                                verdi={
+                                    planleggerBoINorgeNeste12mndMapping[
+                                        behandlingFakta.hovedytelse.søknadsgrunnlag
+                                            .planleggerBoINorgeNeste12mnd
+                                    ]
+                                }
+                            />
+                        )}
                     </InfoSeksjon>
 
                     <InfoSeksjon label="Aktivitet">

--- a/src/frontend/typer/behandling/behandlingFakta/faktaHovedytelse.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaHovedytelse.ts
@@ -1,9 +1,13 @@
+import { JaNei } from '../../common';
+
 export interface FaktaHovedytelse {
     søknadsgrunnlag?: SøknadsgrunnlagHovedytelse;
 }
 
 interface SøknadsgrunnlagHovedytelse {
     hovedytelse: Hovedytelse[];
+    boddSammenhengende?: JaNei;
+    planleggerBoINorgeNeste12mnd?: JaNei;
 }
 
 enum Hovedytelse {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Har lagt til felter i søknaden som skal vises i saksbehandlingen. Disse er foreløpig liknende det finnes skisser for. 
https://favro.com/organization/98c34fb974ce445eac854de0/8a5276563da0f059dccd52a0?card=NAV-18093

❗ Teksten havner nedanfor ikonet for kilden. Hvis jeg prøver å endre styling, så blir ikonet en annen størrelse. Noen som har noen tanker på hvordan dette skal løses? Gjelder noe ikke kun disse tekstene men generellt for Informasjonsrad

* https://github.com/navikt/tilleggsstonader-sak/pull/201

<img width="312" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/c2c9411e-ca72-4141-90ef-1568a0ef9f56">
