### PR TITLE
✨ Skal kune vise knapp for å henlegge behandling dersom behandlingen er…

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
@@ -6,6 +6,7 @@ import { Button, Table } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { Behandling } from '../../../typer/behandling/behandling';
+import { erBehandlingRedigerbar } from '../../../typer/behandling/behandlingStatus';
 import { PartialRecord } from '../../../typer/common';
 import { formaterIsoDatoTid, formaterNullableIsoDatoTid } from '../../../utils/dato';
 import { formaterEnumVerdi } from '../../../utils/tekstformatering';
@@ -64,14 +65,15 @@ const BehandlingTabell: React.FC<{
                             </Link>
                         </Table.DataCell>
                         <Table.DataCell>
-                            {/* TODO: Må gås opp hvordan henlegg skal fungere */}
-                            <Button
-                                variant="secondary"
-                                size="small"
-                                onClick={() => henleggBehandling(behandling.id)}
-                            >
-                                Henlegg
-                            </Button>
+                            {erBehandlingRedigerbar(behandling) && (
+                                <Button
+                                    variant="secondary"
+                                    size="small"
+                                    onClick={() => henleggBehandling(behandling.id)}
+                                >
+                                    Henlegg
+                                </Button>
+                            )}
                         </Table.DataCell>
                     </Table.Row>
                 ))}


### PR DESCRIPTION
… åpen

### Hvorfor er denne endringen nødvendig? ✨
Skal ikke vise knapp for henleggelse for behandlinger som ikke er redigerbare.

**Før**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/c0ea4880-9f31-47d6-85e0-08c46ba5c300)

**Etter**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/f0986250-74c6-4942-a10d-47bd1803e25c)
