### PR TITLE
🐛 Fjern spacing/margin mellom valgfelt i brev

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Sanity/ValgfeltSerializer.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/ValgfeltSerializer.tsx
@@ -23,6 +23,9 @@ export const ValgfeltSerializer =
             <PortableText
                 value={valg.innhold}
                 components={{
+                    block: {
+                        normal: ({ children }) => <div>{children}</div>,
+                    },
                     marks: {
                         variabel: VariabelSerializer(variabler),
                     },


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Block content blir pr. default wrappet i en p-tagger av `<PortableText />`, som medfører litt margin over og under. Valgfelt skal kunne brukes uten spacing mellom nye linjer, etter ønske fra Hilde (De to første setningene i brevet under skal ikke ha spacing mellom). 

**Før**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/7cb5f76a-4ca5-4ae1-ade1-c3801fe8dd68)

**Etter**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/8fa9cb4f-d673-481b-96bc-4e847366a4fc)
