### PR TITLE
🐛 Skal bruke verdi fra mellomlager i select for valgfelt

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
+++ b/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
@@ -7,6 +7,7 @@ import { Switch } from '@navikt/ds-react';
 import Fritekst, { lagTomtAvsnitt } from './Fritekst';
 import { Delmal as DelmalType, FritekstAvsnitt, Valg } from './typer';
 import Valgfelt from './Valgfelt';
+import valgfelt from './Valgfelt';
 import Variabler from './Variabler';
 
 interface Props {
@@ -29,6 +30,7 @@ const FlexColumn = styled.div`
 
 export const DelmalMeny: React.FC<Props> = ({
     delmal,
+    valgfelt,
     settValgfelt,
     variabler,
     settVariabler,
@@ -51,6 +53,7 @@ export const DelmalMeny: React.FC<Props> = ({
                     case 'valgfelt':
                         return (
                             <Valgfelt
+                                valgtVerdi={(valgfelt[val._id] as unknown as valgfelt)?._id}
                                 valgfelt={val}
                                 settValgfelt={settValgfelt}
                                 variabler={variabler}

--- a/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
@@ -1,4 +1,4 @@
-import React, { SetStateAction, useState } from 'react';
+import React, { SetStateAction } from 'react';
 
 import { Select } from '@navikt/ds-react';
 
@@ -7,6 +7,7 @@ import { FritekstAvsnitt, Valg, Valgfelt } from './typer';
 import Variabler from './Variabler';
 
 interface Props {
+    valgtVerdi: string | undefined;
     valgfelt: Valgfelt;
     settValgfelt: React.Dispatch<SetStateAction<Record<string, Valg>>>;
     variabler: Record<string, string>;
@@ -16,6 +17,7 @@ interface Props {
 }
 
 const Valgfelt: React.FC<Props> = ({
+    valgtVerdi,
     valgfelt,
     settValgfelt,
     variabler,
@@ -23,8 +25,6 @@ const Valgfelt: React.FC<Props> = ({
     settFritekst,
     settVariabler,
 }) => {
-    const [valgt, settValgt] = useState<string>();
-
     const finnValgtBlock = (id: string | undefined) =>
         valgfelt.valg.find(
             (valg) =>
@@ -32,15 +32,14 @@ const Valgfelt: React.FC<Props> = ({
                 (valg._type === 'fritekst' && id === 'fritekst')
         );
 
-    const valgtBlock = finnValgtBlock(valgt);
+    const valgtBlock = finnValgtBlock(valgtVerdi);
 
     return (
         <>
             <Select
                 label={valgfelt.visningsnavn}
-                value={valgt || ''}
+                value={valgtVerdi || ''}
                 onChange={(e) => {
-                    settValgt(e.target.value);
                     settValgfelt((prevState) => {
                         const valgtBlock = finnValgtBlock(e.target.value);
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Så man faktisk ser hvilke valg som er tatt tidligere. Den mellomlagrede verdien ble brukt i brevgenereringen, men ikke vist i brevmenyen.

**Før**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/0b653ff6-3cd4-4080-baf0-962e0cc3a11d)
**Etter**
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/d4e6e08a-80d5-4264-a5b7-794b6b63355e)
