### PR TITLE
Skal sette aktiv fane til Inngangsvilkår som default

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -41,7 +41,7 @@ const BehandlingTabsInnhold = () => {
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
 
     useEffect(() => {
-        settAktivFane(path);
+        settAktivFane(path || FanePath.INNGANGSVILKÅR);
     }, [path]);
 
     const håndterFaneBytte = (nyFane: FanePath) => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Likt statet
`const [aktivFane, settAktivFane] = useState<string>(path || FanePath.INNGANGSVILKÅR);`

Hvis ikke får man en tom side når man klikker på noe som lenker til behandlingen :-) 