### PR TITLE
Flytter oppdatering av DateInput til egen hook for å kunne kommentere…

### DIFF
--- a/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
+++ b/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 
 import styled from 'styled-components';
-import { v4 as uuid } from 'uuid';
 
 import { Button, Heading, HStack, Textarea, UNSAFE_Combobox, VStack } from '@navikt/ds-react';
 
@@ -19,6 +18,7 @@ import { harValgtAnnet, validerSettPåVent } from './validerSettPåVent';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { FormErrors, isValid } from '../../../hooks/felles/useFormState';
+import { useTriggRerendringAvDateInput } from '../../../hooks/useTriggRerendringAvDateInput';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
 import DateInput from '../../../komponenter/Skjema/DateInput';
 import { Ressurs, RessursStatus } from '../../../typer/ressurs';
@@ -44,8 +44,7 @@ const SettPåVentForm: React.FC<{
         oppgaveVersjon: status?.oppgaveVersjon,
     });
 
-    // Brukes for å nullstille DateInput då DatePicker ellers må nullstilled fra useDatepicker
-    const [datoKey, settDatoKey] = useState<string>(uuid());
+    const { keyDato, oppdaterDatoKey } = useTriggRerendringAvDateInput();
 
     const [formErrors, settFormErrors] = useState<FormErrors<SettPåVentError>>();
 
@@ -59,7 +58,7 @@ const SettPåVentForm: React.FC<{
                 : prevState.årsaker.filter((o) => o !== årsak);
             return { ...prevState, årsaker: årsaker, frist: finnNyFrist(årsaker) };
         });
-        settDatoKey(uuid());
+        oppdaterDatoKey();
     };
 
     const settPåVentClick = () => {
@@ -113,7 +112,7 @@ const SettPåVentForm: React.FC<{
                     />
                 </ÅrsakContainer>
                 <DateInput
-                    key={datoKey}
+                    key={keyDato}
                     label={'Frist for svar'}
                     onChange={(dato) =>
                         settSettPåVent((prevState) => ({ ...prevState, frist: dato || '' }))

--- a/src/frontend/hooks/useTriggRerendringAvDateInput.ts
+++ b/src/frontend/hooks/useTriggRerendringAvDateInput.ts
@@ -1,0 +1,18 @@
+import { useState } from 'react';
+
+import { v4 as uuid } from 'uuid';
+
+/**
+ * Vi bruker [DateInput] for å fjerne litt støy for hvordan man skal bruke DatePicker
+ * useDatepicker har setSelected for å kunne endre komponenten utenfor, men den er ikke tilgjengelig når vi bruker DateInput
+ *
+ * Hvis man har behov for å nullstille eller endre den utenfor komponenten så må man då endre key for å ikke ha en skummel useEffect inne i DateInput
+ */
+export const useTriggRerendringAvDateInput = () => {
+    const [keyDato, settKeyDato] = useState<string>();
+
+    return {
+        keyDato,
+        oppdaterDatoKey: () => settKeyDato(uuid()),
+    };
+};


### PR DESCRIPTION
… den på et sted i tilfelle det er behov for den på andre steder og

### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å oppdatere DateInput utenfra selve komponenten

Etter https://github.com/navikt/tilleggsstonader-sak-frontend/pull/221#discussion_r1517574163
Å bruke key var en løsning for å ikke ha en useEffect inne i DateInput
En annen løsning var å kopiere ut det fra DateInput til `SettPåVentForm` men Sara og jeg ble enige om at det var ryddigere med et hack med key i dette tilfelle.