### PR TITLE
Fikset deler som prøvde å være sticky, og burde være sticky

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -10,7 +10,12 @@ import { FanePath, hentBehandlingfaner } from './faner';
 import SettPåVentContainer from './SettPåVent/SettPåVentContainer';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
+import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
 import { Toast } from '../../typer/toast';
+
+const StickyTablistContainer = styled(Sticky)`
+    top: 97px;
+`;
 
 const TabsList = styled(Tabs.List)`
     width: 100%;
@@ -60,32 +65,34 @@ const BehandlingTabsInnhold = () => {
     const behandlingFaner = hentBehandlingfaner(behandling.stønadstype);
     return (
         <Tabs value={aktivFane} onChange={(e) => håndterFaneBytte(e as FanePath)}>
-            <TabsList>
-                {behandlingFaner.map((tab) =>
-                    faneErLåst(tab.path) ? (
-                        <DisabledTab
-                            key={tab.path}
-                            value={tab.path}
-                            label={tab.navn}
-                            icon={tab.ikon}
-                        />
-                    ) : (
-                        <Tabs.Tab
-                            key={tab.path}
-                            value={tab.path}
-                            label={tab.navn}
-                            icon={tab.ikon}
-                        />
-                    )
-                )}
-                {behandlingErRedigerbar && !statusPåVentRedigering && (
-                    <Tabsknapp>
-                        <Button size={'small'} onClick={() => settStatusPåVentRedigering(true)}>
-                            Sett på vent
-                        </Button>
-                    </Tabsknapp>
-                )}
-            </TabsList>
+            <StickyTablistContainer>
+                <TabsList>
+                    {behandlingFaner.map((tab) =>
+                        faneErLåst(tab.path) ? (
+                            <DisabledTab
+                                key={tab.path}
+                                value={tab.path}
+                                label={tab.navn}
+                                icon={tab.ikon}
+                            />
+                        ) : (
+                            <Tabs.Tab
+                                key={tab.path}
+                                value={tab.path}
+                                label={tab.navn}
+                                icon={tab.ikon}
+                            />
+                        )
+                    )}
+                    {behandlingErRedigerbar && !statusPåVentRedigering && (
+                        <Tabsknapp>
+                            <Button size={'small'} onClick={() => settStatusPåVentRedigering(true)}>
+                                Sett på vent
+                            </Button>
+                        </Tabsknapp>
+                    )}
+                </TabsList>
+            </StickyTablistContainer>
 
             <SettPåVentContainer
                 statusPåVentRedigering={statusPåVentRedigering}

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -8,11 +8,15 @@ import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 import Oppsummering from './Oppsummering/Oppsummering';
 import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
 
-const Container = styled(Sticky)`
+const Container = styled.div`
+    border-right: 1px solid ${ABorderDefault};
+    width: 20rem;
+    min-height: calc(100vh - 97px);
+`;
+
+const StickyTablistContainer = styled(Sticky)`
     top: 97px;
     border-right: 1px solid ${ABorderDefault};
-    height: calc(100vh - 97px);
-    width: 20rem;
 `;
 
 const tabs = [
@@ -26,12 +30,14 @@ const tabs = [
 const VenstreMeny: React.FC = () => {
     return (
         <Container>
-            <Tabs defaultValue="oppsummering" style={{ width: 'inherit' }}>
-                <Tabs.List>
-                    {tabs.map((tab) => (
-                        <Tabs.Tab label={tab.label} value={tab.value} key={tab.value} />
-                    ))}
-                </Tabs.List>
+            <Tabs defaultValue="oppsummering" style={{ width: 'inherit', height: '100%' }}>
+                <StickyTablistContainer>
+                    <Tabs.List>
+                        {tabs.map((tab) => (
+                            <Tabs.Tab label={tab.label} value={tab.value} key={tab.value} />
+                        ))}
+                    </Tabs.List>
+                </StickyTablistContainer>
                 {tabs.map((tab) => (
                     <Tabs.Panel value={tab.value} key={tab.value}>
                         <Box padding="4">{tab.komponent}</Box>


### PR DESCRIPTION
<img width="300" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/0cb0915d-33f7-4496-ad5b-0e1ccf8ed685">

### Hvorfor er denne endringen nødvendig? ✨
* Endret tabs i VenstreMenyn til å være sticky, og ikke hele venstremenyn
* Tablist for behandling skal være sticky, for å kunne navigere uten å scrolle opp når man eks scrolled ned på siden på pass av barn

For at venstremenyn skal ha en border-right som dekker hele siden så er `min-height: calc(100vh - 97px);` lagt til.

Bygger videre på 
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/232

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-18559


## Tidligere:
### Scrolling
https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/591523ac-f070-4956-82aa-4e47f2216dc2
### Hvis venstrepanelet ble fyllt opp med for mye info
<img width="794" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/3fdf52d8-01ad-43db-ae2e-1037257f89f0">

## Nå
### Scrolling uten for mye i venstremenyn
https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/67806fba-78fa-416a-b59d-6eb2864becb9
### Scrolling med for mye i venstremenyn
https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/e004dded-187c-4fca-8e4d-699bfe297c80
