### PR TITLE
Opprett fagsakPerson hvis personen finnes i Arena

### DIFF
--- a/src/frontend/komponenter/PersonSøk.tsx
+++ b/src/frontend/komponenter/PersonSøk.tsx
@@ -3,7 +3,7 @@ import React, { FormEvent, useCallback, useRef, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { styled } from 'styled-components';
 
-import { Alert, Button, Popover, Search } from '@navikt/ds-react';
+import { Alert, Button, Popover, Search, VStack } from '@navikt/ds-react';
 import { ATextDefault } from '@navikt/ds-tokens/dist/tokens';
 
 import { useApp } from '../context/AppContext';
@@ -137,8 +137,12 @@ const PersonSøk: React.FC = () => {
                 >
                     {søkeresultat && søkeresultat.status === RessursStatus.SUKSESS && (
                         <StyledAlert variant="info">
-                            Person finnes i arena
-                            <Button onClick={opprettFagsakPerson}>Opprett person</Button>
+                            <VStack>
+                                <span>Personen finnes i Arena</span>
+                                <Button size={'small'} onClick={opprettFagsakPerson}>
+                                    Opprett personen
+                                </Button>
+                            </VStack>
                         </StyledAlert>
                     )}
                     {søkeresultat && søkeresultat.status !== RessursStatus.SUKSESS && (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å kunne opprette en fagsak-person for å få se personoversikten på en person, hvis personen finnes i Arena

Dette som en del av å hente tiltak på en person
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-19957

* Tekst er ikke avklart, og kan endres senere

Koblet til
* https://github.com/navikt/tilleggsstonader-sak/pull/240

Hvis personen finnes i Arena får man valget å opprette fagsak-person og blir videresendt til personoversikten
<img width="438" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/9b71d7e9-da8f-4107-8d06-0f3a9add775b">

