### PR TITLE
🐛 Hent variabler med ny struktur i sanity og håndter at brev er slettet siden forrige mellomlagring

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
@@ -14,7 +14,7 @@ export const malQuery = (id: string, målform: 'bokmål' = 'bokmål') => groq`*[
                 _type == "block" => {
                      "markDefs": markDefs[]{
                         ...,
-                        _type == "reference" => @->{...}
+                        _type=="variabel" => variabelreferanse -> {...}    
                      }
                 },
                 _type == "fritekst" => { "parentId": ^._id },
@@ -31,7 +31,10 @@ export const malQuery = (id: string, målform: 'bokmål' = 'bokmål') => groq`*[
                                     _type == "reference" => @->{...}
                                  }
                             },
-                            "variabler": nb[].markDefs[]->
+                            "variabler": nb[].markDefs[]{
+                                ...,
+                                _type=="variabel" => variabelreferanse -> {...}        
+                            },
                         },
                         _type == "fritekst" => { "parentId": ^._id }
                     }

--- a/src/frontend/Sider/Behandling/Brev/useBrev.ts
+++ b/src/frontend/Sider/Behandling/Brev/useBrev.ts
@@ -43,7 +43,7 @@ const useBrev = (ytelse: Stønadstype, resultat: string, behandling?: Behandling
         brevmal &&
             sanityClient
                 .fetch<MalStruktur>(malQuery(brevmal))
-                .then((data) => settMalStruktur(byggRessursSuksess(data)))
+                .then((data) => data !== null && settMalStruktur(byggRessursSuksess(data)))
                 .catch((error) => settMalStruktur(byggRessursFeilet(error.message)));
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [brevmal]);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Etter [endring av hvordan man refererer til variabler i sanity ](https://github.com/navikt/tilleggsstonader-brev-sanity/pull/15) måtte spørringen for malstruktur oppdateres. Variabler ligger ikke lenger direkte som en referanse, men som et objekt som inneholder en referanse. 

Siden denne oppdateringen i sanity førte til at alle variabelreferanser ble ugyldige ble det derfor slettet mange brev. Har derfor lagt inn en liten sjekk på at brevmal faktisk ble funnet i sanity før man setter strukturen. Slik at ikke hele løsningen kræsjer om et mellomlagret brev blir slettet før man jobber videre