### PR TITLE
🐛  Skal kunne velge fritekst som valg i valgtfelt

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
+++ b/src/frontend/Sider/Behandling/Brev/DelmalMeny.tsx
@@ -4,10 +4,10 @@ import styled from 'styled-components';
 
 import { Switch } from '@navikt/ds-react';
 
+import { idEllerFritekst } from './brevUtils';
 import Fritekst, { lagTomtAvsnitt } from './Fritekst';
 import { Delmal as DelmalType, FritekstAvsnitt, Valg } from './typer';
 import Valgfelt from './Valgfelt';
-import valgfelt from './Valgfelt';
 import Variabler from './Variabler';
 
 interface Props {
@@ -53,7 +53,7 @@ export const DelmalMeny: React.FC<Props> = ({
                     case 'valgfelt':
                         return (
                             <Valgfelt
-                                valgtVerdi={(valgfelt[val._id] as unknown as valgfelt)?._id}
+                                valgtVerdi={idEllerFritekst(valgfelt[val._id])}
                                 valgfelt={val}
                                 settValgfelt={settValgfelt}
                                 variabler={variabler}

--- a/src/frontend/Sider/Behandling/Brev/brevUtils.ts
+++ b/src/frontend/Sider/Behandling/Brev/brevUtils.ts
@@ -1,0 +1,10 @@
+import { Valg } from './typer';
+
+export const idEllerFritekst = (valg: Valg): string => {
+    switch (valg._type) {
+        case 'tekst':
+            return valg._id;
+        case 'fritekst':
+            return 'fritekst';
+    }
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Forsøkte tidligere å bare ta _id fra valg, men fritekst har ikke _id og ble derfor feil.

<img src="https://media4.giphy.com/media/LdB31FeHFkK4rK8Hfv/giphy.gif"/>
