### PR TITLE
skal vise panel med informasjon om avsender i journalføringsbildet

### DIFF
--- a/src/frontend/Sider/Journalføring/Standard/AvsenderPanel.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/AvsenderPanel.tsx
@@ -1,0 +1,127 @@
+import React, { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { EnvelopeClosedFillIcon, EnvelopeClosedIcon } from '@navikt/aksel-icons';
+import {
+    Box,
+    Checkbox,
+    CopyButton,
+    ExpansionCard,
+    HStack,
+    Label,
+    TextField,
+    VStack,
+} from '@navikt/ds-react';
+import { ABlue500 } from '@navikt/ds-tokens/dist/tokens';
+
+import { PanelHeader, PanelHeaderType } from './PanelHeader';
+import { JournalføringState } from '../../../hooks/useJournalføringState';
+import { JournalpostResponse } from '../../../typer/journalpost';
+
+const ExpansionCardHeader = styled(ExpansionCard.Header)`
+    padding-bottom: 0.35rem;
+`;
+
+const ExpansionCardContent = styled(VStack).attrs({ gap: '4' })`
+    padding-bottom: 1rem;
+`;
+
+const IkonContainer = styled.div`
+    color: ${ABlue500};
+`;
+
+const KopierPersonIdent = styled(CopyButton)`
+    z-index: 2;
+`;
+
+interface Props {
+    journalpostResponse: JournalpostResponse;
+    journalpostState: JournalføringState;
+}
+
+const AvsenderPanel: React.FC<Props> = ({ journalpostResponse, journalpostState }) => {
+    const { journalpost, navn, personIdent } = journalpostResponse;
+    const { nyAvsender, settNyAvsender } = journalpostState;
+    const { journalpostId, avsenderMottaker } = journalpost;
+
+    const [erPanelEkspandert, settErPanelEkspandert] = useState<boolean>(true);
+
+    const harAvsender = !!avsenderMottaker && !!avsenderMottaker.navn && !!avsenderMottaker.id;
+    const erBrukerAvsender = !!nyAvsender?.erBruker;
+
+    return (
+        <>
+            {harAvsender ? (
+                <Box padding="4" borderWidth="1" borderRadius="small" borderColor="border-default">
+                    <PanelHeader
+                        navn={avsenderMottaker?.navn || 'Ukjent navn'}
+                        personIdent={avsenderMottaker?.id || 'Ukjent ident'}
+                        type={PanelHeaderType.Avsender}
+                    />
+                </Box>
+            ) : (
+                <ExpansionCard
+                    id={journalpostId}
+                    size="small"
+                    aria-label="journalpost"
+                    defaultOpen={erPanelEkspandert}
+                    onToggle={() => settErPanelEkspandert((prevState) => !prevState)}
+                >
+                    <ExpansionCardHeader>
+                        <HStack gap="4">
+                            <IkonContainer>
+                                {erPanelEkspandert ? (
+                                    <EnvelopeClosedFillIcon fontSize={'3.5rem'} />
+                                ) : (
+                                    <EnvelopeClosedIcon fontSize={'3.5rem'} />
+                                )}
+                            </IkonContainer>
+                            <HStack align="center">
+                                {erBrukerAvsender ? (
+                                    <>
+                                        <Label as={'p'}>{`${navn} - ${personIdent}`}</Label>
+                                        <KopierPersonIdent
+                                            copyText={personIdent}
+                                            variant="action"
+                                        />
+                                    </>
+                                ) : (
+                                    <Label as={'p'}>{nyAvsender?.navn ?? 'Ukjent avsender'}</Label>
+                                )}
+                            </HStack>
+                        </HStack>
+                    </ExpansionCardHeader>
+                    <ExpansionCard.Content>
+                        <ExpansionCardContent>
+                            <Checkbox
+                                onChange={(event) => {
+                                    settNyAvsender({
+                                        erBruker: event.target.checked,
+                                        navn: navn,
+                                        personIdent: personIdent,
+                                    });
+                                }}
+                                value={erBrukerAvsender}
+                                checked={erBrukerAvsender}
+                            >
+                                Avsender er bruker
+                            </Checkbox>
+                            <TextField
+                                disabled={erBrukerAvsender}
+                                label={'Navn'}
+                                onChange={(event) => {
+                                    settNyAvsender({ erBruker: false, navn: event.target.value });
+                                }}
+                                size={'small'}
+                                value={nyAvsender?.navn || ''}
+                            />
+                        </ExpansionCardContent>
+                    </ExpansionCard.Content>
+                </ExpansionCard>
+            )}
+        </>
+    );
+};
+
+export default AvsenderPanel;

--- a/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 
 import { Heading } from '@navikt/ds-react';
 
+import AvsenderPanel from './AvsenderPanel';
 import BrukerPanel from './BrukerPanel';
 import Dokumenter from './Dokumenter';
 import { useQueryParams } from '../../../hooks/felles/useQueryParams';
@@ -98,6 +99,15 @@ const JournalføringSide: React.FC<Props> = ({ journalResponse }) => {
                             Bruker
                         </Heading>
                         <BrukerPanel journalpostResponse={journalResponse} />
+                    </section>
+                    <section>
+                        <Heading spacing size={'small'} level={'2'}>
+                            Avsender
+                        </Heading>
+                        <AvsenderPanel
+                            journalpostResponse={journalResponse}
+                            journalpostState={journalpostState}
+                        />
                     </section>
                 </InnerContainer>
             </Venstrekolonne>

--- a/src/frontend/hooks/useJournalføringState.ts
+++ b/src/frontend/hooks/useJournalføringState.ts
@@ -11,6 +11,14 @@ export interface JournalføringState {
     settLogiskeVedleggPåDokument: Dispatch<SetStateAction<LogiskeVedleggPåDokument>>;
     valgtDokumentPanel: string;
     settValgtDokumentPanel: Dispatch<SetStateAction<string>>;
+    nyAvsender: NyAvsender | undefined;
+    settNyAvsender: Dispatch<SetStateAction<NyAvsender | undefined>>;
+}
+
+interface NyAvsender {
+    erBruker: boolean;
+    navn?: string;
+    personIdent?: string;
 }
 
 export const useJournalføringState = (journalResponse: JournalpostResponse): JournalføringState => {
@@ -33,6 +41,7 @@ export const useJournalføringState = (journalResponse: JournalpostResponse): Jo
     const [valgtDokumentPanel, settValgtDokumentPanel] = useState<string>(
         utledFørsteDokument(journalpost.dokumenter)
     );
+    const [nyAvsender, settNyAvsender] = useState<NyAvsender>();
 
     return {
         dokumentTitler,
@@ -42,5 +51,7 @@ export const useJournalføringState = (journalResponse: JournalpostResponse): Jo
         settLogiskeVedleggPåDokument,
         valgtDokumentPanel,
         settValgtDokumentPanel,
+        nyAvsender,
+        settNyAvsender,
     };
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal vise panel med informasjon om avsender på journalføringssiden. Dersom avsender er satt skal panelet ikke være redigerbart. Dersom avsender ikke er satt skal saksbehandler kunne skrive inn navn på avsender selv, eller huke av for at avsender er bruker.

Avsender satt fra før:
![Skjermbilde 2024-04-02 kl  13 29 23](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/32769446/f4948129-6332-43c7-bc6f-95d9a77ddf2d)

Avsender ikke satt fra før:
![Skjermbilde 2024-04-02 kl  13 29 50](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/32769446/fac34e84-880c-4bc4-b98e-ea58b5e17194)
