### PR TITLE
Deaktivert begrunnelse når vilkårsverdi ikke er valgt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@ Lag en `.env` fil i `src/backend` og legg inn:
 AZURE_APP_CLIENT_ID=<clientId>
 AZURE_APP_CLIENT_SECRET=<clientSecret>
 ```
+# Feilsøking
+Feilmelding ved oppstart av app: 
+```
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<...>/src/backend/build/auth/attachToken' imported from <...>/src/backend/build/server.js 
+```
+Løsning: Du trenger Node-versjon 18. 
+
 
 ## Kode generert av GitHub Copilot
 

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/Begrunnelse.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/Begrunnelse.tsx
@@ -6,19 +6,20 @@ import { styled } from 'styled-components';
 import { Textarea, VStack } from '@navikt/ds-react';
 
 import { BegrunnelseRegel, Regel } from '../../../typer/regel';
+import { harIkkeVerdi } from '../../../utils/utils';
 import { Vurdering } from '../vilkår';
 
 interface Props {
     vurdering: Vurdering;
     regel: Regel;
-    onChange: (tekst: string) => void;
+    oppdaterBegrunnelse: (tekst: string) => void;
 }
 
 const BegrunnelseContainer = styled(VStack)`
     width: 250px;
 `;
 
-const Begrunnelse: FC<Props> = ({ vurdering, onChange, regel }) => {
+const Begrunnelse: FC<Props> = ({ vurdering, oppdaterBegrunnelse, regel }) => {
     const typeBegrunnelse = vurdering.svar && regel.svarMapping[vurdering.svar].begrunnelseType;
     const skjulBegrunnelse = typeBegrunnelse === BegrunnelseRegel.UTEN;
 
@@ -26,8 +27,14 @@ const Begrunnelse: FC<Props> = ({ vurdering, onChange, regel }) => {
         return null;
     }
 
+    const erDeaktivert = harIkkeVerdi(vurdering.svar);
+
     const begrunnelsestekst = 'Begrunnelse '.concat(
-        typeBegrunnelse !== BegrunnelseRegel.PÅKREVD ? '(valgfri)' : '(obligatorisk)'
+        erDeaktivert
+            ? ''
+            : typeBegrunnelse !== BegrunnelseRegel.PÅKREVD
+              ? '(valgfri)'
+              : '(obligatorisk)'
     );
 
     return (
@@ -38,7 +45,8 @@ const Begrunnelse: FC<Props> = ({ vurdering, onChange, regel }) => {
                 size="small"
                 minRows={3}
                 value={vurdering.begrunnelse || ''}
-                onChange={(e) => onChange(e.target.value)}
+                onChange={(e) => oppdaterBegrunnelse(e.target.value)}
+                disabled={harIkkeVerdi(vurdering.svar)}
             />
         </BegrunnelseContainer>
     );

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreDelvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreDelvilkår.tsx
@@ -65,17 +65,17 @@ const EndreDelvilkår: FC<{
         nyttSvar: Vurdering
     ) => {
         const { begrunnelse } = nyttSvar;
-        const svarsalternativ: Svaralternativ | undefined = hentSvaralternativ(regler, nyttSvar);
-        if (!svarsalternativ) {
+        const svaralternativ: Svaralternativ | undefined = hentSvaralternativ(regler, nyttSvar);
+        if (!svaralternativ) {
             return;
         }
 
         const oppdaterteSvar = oppdaterSvarIListe(nyttSvar, vurderinger, true);
 
         const oppdaterteSvarMedNesteRegel = leggTilNesteIdHvis(
-            svarsalternativ.regelId,
+            svaralternativ.regelId,
             oppdaterteSvar,
-            () => begrunnelseErPåkrevdOgUtfyllt(svarsalternativ, begrunnelse)
+            () => begrunnelseErPåkrevdOgUtfyllt(svaralternativ, begrunnelse)
         );
         oppdaterVilkårsvar(delvilkårIndex, oppdaterteSvarMedNesteRegel);
     };
@@ -162,7 +162,7 @@ const EndreDelvilkår: FC<{
                                         nullstillFeilmelding={nullstillFeilmelding}
                                     />
                                     <Begrunnelse
-                                        onChange={(begrunnelse) =>
+                                        oppdaterBegrunnelse={(begrunnelse) =>
                                             oppdaterBegrunnelse(
                                                 delvikår.vurderinger,
                                                 delvilkårIndex,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Gikk for `disabled` framfor `readOnly`, fordi førstnevnte ikke lar seg fokusere med tastatur.

![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/17157469/d93b4333-178b-43aa-9ef0-eff7b8de7bb2)
