### PR TITLE
Oppdaterer sidtittel når man er i Behandling og Personoversikt

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingContainer.tsx
@@ -9,13 +9,13 @@ import DataViewer from '../../komponenter/DataViewer';
 import { Behandling } from '../../typer/behandling/behandling';
 import { Personopplysninger } from '../../typer/personopplysninger';
 import { byggTomRessurs, Ressurs } from '../../typer/ressurs';
+import { dokumenttittel } from '../../utils/env';
 
 const BehandlingContainer = () => {
     const { request } = useApp();
     const [behandling, settBehandling] = useState<Ressurs<Behandling>>(byggTomRessurs());
-    const [personopplysninger, settPersonopplysninger] = useState<Ressurs<Personopplysninger>>(
-        byggTomRessurs()
-    );
+    const [personopplysninger, settPersonopplysninger] =
+        useState<Ressurs<Personopplysninger>>(byggTomRessurs());
 
     const behandlingId = useParams<{
         behandlingId: string;
@@ -32,6 +32,10 @@ const BehandlingContainer = () => {
             settPersonopplysninger
         );
     }, [request, behandlingId]);
+
+    useEffect(() => {
+        document.title = dokumenttittel('Behandling');
+    }, []);
 
     return (
         <DataViewer response={{ behandling, personopplysninger }}>

--- a/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
@@ -14,6 +14,7 @@ import { useHentJournalpost } from '../../../hooks/useHentJournalpost';
 import { JournalføringState, useJournalføringState } from '../../../hooks/useJournalføringState';
 import DataViewer from '../../../komponenter/DataViewer';
 import { JournalpostResponse } from '../../../typer/journalpost';
+import { dokumenttittel } from '../../../utils/env';
 import { JOURNALPOST_QUERY_STRING, OPPGAVEID_QUERY_STRING } from '../../Oppgavebenk/oppgaveutils';
 import PdfVisning from '../Felles/PdfVisning';
 
@@ -54,7 +55,7 @@ export const Journalføring: React.FC = () => {
     const { hentJournalPost, journalResponse } = useHentJournalpost();
 
     useEffect(() => {
-        document.title = 'Journalpost';
+        document.title = dokumenttittel('Journalpost');
         hentJournalPost(journalpostId);
     }, [hentJournalPost, journalpostId]);
 

--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -11,6 +11,7 @@ import { useApp } from '../../context/AppContext';
 import { OppgaveProvider, useOppgave } from '../../context/OppgaveContext';
 import DataViewer from '../../komponenter/DataViewer';
 import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
+import { dokumenttittel } from '../../utils/env';
 import { erProd } from '../../utils/miljø';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
@@ -39,7 +40,7 @@ const Oppgavebenk: React.FC = () => {
     const { erSaksbehandler } = useApp();
 
     useEffect(() => {
-        document.title = 'Oppgavebenk';
+        document.title = dokumenttittel('Oppgavebenk');
     }, []);
 
     if (!erSaksbehandler) {

--- a/src/frontend/Sider/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Personoversikt.tsx
@@ -9,6 +9,7 @@ import DataViewer from '../../komponenter/DataViewer';
 import PersonHeader from '../../komponenter/PersonHeader/PersonHeader';
 import { Personopplysninger } from '../../typer/personopplysninger';
 import { byggTomRessurs, Ressurs } from '../../typer/ressurs';
+import { dokumenttittel } from '../../utils/env';
 
 const Personoversikt = () => {
     const { request } = useApp();
@@ -23,6 +24,10 @@ const Personoversikt = () => {
             `/api/sak/personopplysninger/fagsak-person/${fagsakPersonId}`
         ).then(settPersonopplysninger);
     }, [request, fagsakPersonId]);
+
+    useEffect(() => {
+        document.title = dokumenttittel('Personoversikt');
+    }, []);
 
     return (
         <DataViewer response={{ personopplysninger }}>

--- a/src/frontend/utils/env.ts
+++ b/src/frontend/utils/env.ts
@@ -19,3 +19,5 @@ export const hentEnv = (settEnv: (env: AppEnv | undefined) => void) => {
             console.log('Feilet henting av env', err);
         });
 };
+
+export const dokumenttittel = (tittel: string) => `TS: ${tittel}`;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Oppdaterer tittel på dokumentet. Vi har allerede liknende funksjonalitet i oppgavebenken og journalføring
Legger inn prefix "TS".

Snakket med Marie om dette alternativet eller kun å vise "Tilleggsstønader". Fordelen med denne at den gir litt mer kontekst, samtidig hvis man har mange faner åpne så vises "TS ..."

<img width="219" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/72c95d9f-edfc-4ed5-b697-f6bee19672b7">
