### PR TITLE
Stegflyt 1 - AktivFane trenger ikke å være en egen state.

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
@@ -42,19 +42,12 @@ const BehandlingTabsInnhold = () => {
     const { behandling, behandlingErRedigerbar } = useBehandling();
 
     const path = useLocation().pathname.split('/')[3];
-
-    const [aktivFane, settAktivFane] = useState<FanePath>(
-        isFanePath(path) ? path : FanePath.INNGANGSVILKÅR
-    );
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
 
-    useEffect(() => {
-        settAktivFane(isFanePath(path) ? path : FanePath.INNGANGSVILKÅR);
-    }, [path]);
+    const aktivFane = isFanePath(path) ? path : FanePath.INNGANGSVILKÅR;
 
     const håndterFaneBytte = (nyFane: FanePath) => {
         if (!faneErLåst(nyFane)) {
-            settAktivFane(nyFane);
             navigate(`/behandling/${behandling.id}/${nyFane}`, { replace: true });
         } else {
             settToast(Toast.DISABLED_FANE);


### PR DESCRIPTION
Når den er en egen state og bruker useEffect så endres aktivFane en redering etter at man har endret steg - i tilfelle når man går fra inngangsvilkår til stønadsvilkår

### Hvorfor er denne endringen nødvendig? ✨

Ser ingen god grunn til at det skal være en egen state som oppdateres samtidig som man bruker navigate. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20321

Denne henger sammen med alle andre PR's koblet til stegflyt.
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/270
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/271
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/272
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/273
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/274
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/275