### PR TITLE
Stegflyt 2 - Fjerner rendering av tabs hvis fanen er låst

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -6,12 +6,14 @@ import styled from 'styled-components';
 import { Button, Tabs } from '@navikt/ds-react';
 import { ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 
-import { FanePath, hentBehandlingfaner, isFanePath } from './faner';
+import { FanePath, faneTilSteg, hentBehandlingfaner, isFanePath } from './faner';
 import SettPåVentContainer from './SettPåVent/SettPåVentContainer';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
 import { StegProvider } from '../../context/StegContext';
 import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
+import { Behandling } from '../../typer/behandling/behandling';
+import { stegErLåstForBehandling } from '../../typer/behandling/steg';
 import { Toast } from '../../typer/toast';
 
 const StickyTablistContainer = styled(Sticky)`
@@ -30,11 +32,19 @@ const Tabsknapp = styled.div`
 
 const DisabledTab = styled(Tabs.Tab)`
     color: ${ATextSubtle};
+
     &:hover {
         box-shadow: none;
         cursor: default;
     }
 `;
+
+const faneErLåst = (behandling: Behandling, fanePath: FanePath) => {
+    if (fanePath === FanePath.SIMULERING) {
+        return true;
+    }
+    return stegErLåstForBehandling(behandling, faneTilSteg[fanePath]);
+};
 
 const BehandlingTabsInnhold = () => {
     const navigate = useNavigate();
@@ -47,15 +57,11 @@ const BehandlingTabsInnhold = () => {
     const aktivFane = isFanePath(path) ? path : FanePath.INNGANGSVILKÅR;
 
     const håndterFaneBytte = (nyFane: FanePath) => {
-        if (!faneErLåst(nyFane)) {
+        if (!faneErLåst(behandling, nyFane)) {
             navigate(`/behandling/${behandling.id}/${nyFane}`, { replace: true });
         } else {
             settToast(Toast.DISABLED_FANE);
         }
-    };
-
-    const faneErLåst = (fanePath: FanePath) => {
-        return fanePath === FanePath.SIMULERING;
     };
 
     const behandlingFaner = hentBehandlingfaner(behandling.stønadstype);
@@ -65,7 +71,7 @@ const BehandlingTabsInnhold = () => {
                 <StickyTablistContainer>
                     <TabsList>
                         {behandlingFaner.map((tab) =>
-                            faneErLåst(tab.path) ? (
+                            faneErLåst(behandling, tab.path) ? (
                                 <DisabledTab
                                     key={tab.path}
                                     value={tab.path}

--- a/src/frontend/Sider/Behandling/faner.tsx
+++ b/src/frontend/Sider/Behandling/faner.tsx
@@ -12,6 +12,7 @@ import Inngangsvilkår from './Inngangsvilkår/Inngangsvilkår';
 import Stønadsvilkår from './Stønadsvilkår/Stønadsvilkår';
 import VedtakOgBeregningBarnetilsyn from './VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn';
 import { Stønadstype } from '../../typer/behandling/behandlingTema';
+import { Steg } from '../../typer/behandling/steg';
 
 export type FanerMedRouter = {
     navn: FaneNavn | StønadsvilkårFaneNavn;
@@ -42,6 +43,14 @@ export enum FanePath {
     SIMULERING = 'simulering',
     BREV = 'brev',
 }
+
+export const faneTilSteg: Record<FanePath, Steg> = {
+    inngangsvilkar: Steg.INNGANGSVILKÅR,
+    stonadsvilkar: Steg.VILKÅR,
+    'vedtak-og-beregning': Steg.BEREGNE_YTELSE,
+    simulering: Steg.SEND_TIL_BESLUTTER,
+    brev: Steg.SEND_TIL_BESLUTTER,
+};
 
 export const isFanePath = (path: string): path is FanePath => {
     switch (path) {

--- a/src/frontend/Sider/Behandling/faner.tsx
+++ b/src/frontend/Sider/Behandling/faner.tsx
@@ -11,14 +11,16 @@ import Brev from './Brev/Brev';
 import Inngangsvilkår from './Inngangsvilkår/Inngangsvilkår';
 import Stønadsvilkår from './Stønadsvilkår/Stønadsvilkår';
 import VedtakOgBeregningBarnetilsyn from './VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn';
+import { Behandling } from '../../typer/behandling/behandling';
 import { Stønadstype } from '../../typer/behandling/behandlingTema';
-import { Steg } from '../../typer/behandling/steg';
+import { Steg, stegErLåstForBehandling } from '../../typer/behandling/steg';
 
 export type FanerMedRouter = {
     navn: FaneNavn | StønadsvilkårFaneNavn;
     path: FanePath;
     komponent: (behandlingId: string) => React.ReactNode | undefined;
     ikon?: React.ReactNode;
+    erLåst?: boolean;
 };
 
 export enum FaneNavn {
@@ -65,7 +67,14 @@ export const isFanePath = (path: string): path is FanePath => {
     }
 };
 
-export const hentBehandlingfaner = (stønadstype: Stønadstype): FanerMedRouter[] => {
+export const faneErLåst = (behandling: Behandling, fanePath: FanePath) => {
+    if (fanePath === FanePath.SIMULERING) {
+        return true;
+    }
+    return stegErLåstForBehandling(behandling, faneTilSteg[fanePath]);
+};
+
+export const hentBehandlingfaner = (behandling: Behandling): FanerMedRouter[] => {
     return [
         {
             navn: FaneNavn.INNGANGSVILKÅR,
@@ -74,7 +83,7 @@ export const hentBehandlingfaner = (stønadstype: Stønadstype): FanerMedRouter[
             ikon: <PersonRectangleIcon />,
         },
         {
-            navn: faneNavnStønadsvilkår[stønadstype],
+            navn: faneNavnStønadsvilkår[behandling.stønadstype],
             path: FanePath.STØNADSVILKÅR,
             komponent: () => <Stønadsvilkår />,
             ikon: <HouseHeartIcon />,
@@ -84,17 +93,20 @@ export const hentBehandlingfaner = (stønadstype: Stønadstype): FanerMedRouter[
             path: FanePath.VEDTAK_OG_BEREGNING,
             komponent: () => <VedtakOgBeregningBarnetilsyn />,
             ikon: <CalculatorIcon />,
+            erLåst: faneErLåst(behandling, FanePath.VEDTAK_OG_BEREGNING),
         },
         {
             navn: FaneNavn.SIMULERING,
             path: FanePath.SIMULERING,
             komponent: () => <p>Simulering</p>,
+            erLåst: faneErLåst(behandling, FanePath.SIMULERING),
         },
         {
             navn: FaneNavn.BREV,
             path: FanePath.BREV,
             komponent: () => <Brev />,
             ikon: <EnvelopeClosedIcon />,
+            erLåst: faneErLåst(behandling, FanePath.BREV),
         },
     ];
 };

--- a/src/frontend/context/StegContext.ts
+++ b/src/frontend/context/StegContext.ts
@@ -1,17 +1,8 @@
 import constate from 'constate';
 
-import { FanePath } from '../Sider/Behandling/faner';
+import { FanePath, faneTilSteg } from '../Sider/Behandling/faner';
 import { Behandling } from '../typer/behandling/behandling';
 import { erBehandlingRedigerbar } from '../typer/behandling/behandlingStatus';
-import { Steg } from '../typer/behandling/steg';
-
-const faneTilSteg: Record<FanePath, Steg> = {
-    inngangsvilkar: Steg.INNGANGSVILKÅR,
-    stonadsvilkar: Steg.VILKÅR,
-    'vedtak-og-beregning': Steg.BEREGNE_YTELSE,
-    simulering: Steg.SEND_TIL_BESLUTTER,
-    brev: Steg.SEND_TIL_BESLUTTER,
-};
 
 interface Props {
     fane: FanePath | undefined;

--- a/src/frontend/typer/behandling/steg.ts
+++ b/src/frontend/typer/behandling/steg.ts
@@ -1,3 +1,5 @@
+import { Behandling } from './behandling';
+
 export enum Steg {
     INNGANGSVILKÅR = 'INNGANGSVILKÅR',
     VILKÅR = 'VILKÅR',
@@ -10,3 +12,18 @@ export enum Steg {
     LAG_SAKSBEHANDLINGSBLANKETT = 'LAG_SAKSBEHANDLINGSBLANKETT',
     PUBLISER_VEDTAKSHENDELSE = 'PUBLISER_VEDTAKSHENDELSE',
 }
+
+const rekkefølgeSteg = Object.values(Steg).reduce(
+    (acc, curr, indeks) => {
+        acc[curr] = indeks;
+        return acc;
+    },
+    {} as Record<Steg, number>
+);
+
+export const stegErEtterAnnetSteg = (steg: Steg, annetSteg: Steg) =>
+    rekkefølgeSteg[steg] > rekkefølgeSteg[annetSteg];
+
+export const stegErLåstForBehandling = (behandling: Behandling, faneSteg: Steg) =>
+    [Steg.BEREGNE_YTELSE, Steg.SEND_TIL_BESLUTTER].includes(faneSteg) &&
+    stegErEtterAnnetSteg(faneSteg, behandling.steg);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis man går inn på brevfanen når den er låst, med URL eller klikker, så renderes brevsiden og feiler beroende på state. 
Gjennom å ikke rendere komponentene hvis behandlingen er i feil state hentes ikke data i unødvendige tilfeller og man unngår ev. feil. 

Flytter låsing av tabs til hentBehandlingfaner for å ha det på et sted.

Låser vedtakssiden og brev hvis behandlingen er på et steg før disse - då man ikke burde endre på hverken vedtaket eller brev(?).
❗ Denne delen kan diskuteres om den skal være med/fjernes. 


Denne henger sammen med alle andre PR's koblet til stegflyt.
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/270
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/271
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/272
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/273
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/274
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/275
