### PR TITLE
Stegflyt 3 - Forbedrer stegknapp

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -28,7 +28,7 @@ const Container = styled(VStack).attrs({ gap: '8' })`
 
 const Inngangsvilkår = () => {
     const { request } = useApp();
-    const { behandling, behandlingErRedigerbar } = useBehandling();
+    const { behandling } = useBehandling();
 
     const [vilkårperioder, settVilkårperioder] =
         useState<Ressurs<Vilkårperioder>>(byggTomRessurs());
@@ -77,11 +77,9 @@ const Inngangsvilkår = () => {
                     </>
                 )}
             </DataViewer>
-            {behandlingErRedigerbar && (
-                <StegKnapp steg={Steg.INNGANGSVILKÅR} nesteFane={FanePath.STØNADSVILKÅR}>
-                    Ferdigstill inngangsvilkår og gå videre
-                </StegKnapp>
-            )}
+            <StegKnapp steg={Steg.INNGANGSVILKÅR} nesteFane={FanePath.STØNADSVILKÅR}>
+                Ferdigstill inngangsvilkår og gå videre
+            </StegKnapp>
         </Container>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -15,7 +15,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import { InngangsvilkårProvider } from '../../../context/InngangsvilkårContext';
 import { useRerunnableEffect } from '../../../hooks/useRerunnableEffect';
 import DataViewer from '../../../komponenter/DataViewer';
-import { NesteStegKnapp } from '../../../komponenter/NesteStegKnapp/NesteStegKnapp';
+import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Steg } from '../../../typer/behandling/steg';
 import { byggTomRessurs, Ressurs } from '../../../typer/ressurs';
 import { features } from '../../../utils/features';
@@ -78,9 +78,9 @@ const Inngangsvilkår = () => {
                 )}
             </DataViewer>
             {behandlingErRedigerbar && (
-                <NesteStegKnapp steg={Steg.INNGANGSVILKÅR} nesteFane={FanePath.STØNADSVILKÅR}>
+                <StegKnapp steg={Steg.INNGANGSVILKÅR} nesteFane={FanePath.STØNADSVILKÅR}>
                     Ferdigstill inngangsvilkår og gå videre
-                </NesteStegKnapp>
+                </StegKnapp>
             )}
         </Container>
     );

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -5,7 +5,6 @@ import { styled } from 'styled-components';
 import { VStack } from '@navikt/ds-react';
 
 import PassBarn from './PassBarn/PassBarn';
-import { useBehandling } from '../../../context/BehandlingContext';
 import { useVilkår } from '../../../context/VilkårContext';
 import { useRegler } from '../../../hooks/useRegler';
 import DataViewer from '../../../komponenter/DataViewer';
@@ -20,7 +19,6 @@ const Container = styled(VStack).attrs({ gap: '8' })`
 const Stønadsvilkår = () => {
     const { regler, hentRegler } = useRegler();
     const { vilkårsvurdering } = useVilkår();
-    const { behandlingErRedigerbar } = useBehandling();
 
     useEffect(() => {
         hentRegler();
@@ -41,11 +39,9 @@ const Stønadsvilkår = () => {
                     />
                 )}
             </DataViewer>
-            {behandlingErRedigerbar && (
-                <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
-                    Fullfør vilkårsvurdering og gå videre
-                </StegKnapp>
-            )}
+            <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
+                Fullfør vilkårsvurdering og gå videre
+            </StegKnapp>
         </Container>
     );
 };

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -9,7 +9,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import { useVilkår } from '../../../context/VilkårContext';
 import { useRegler } from '../../../hooks/useRegler';
 import DataViewer from '../../../komponenter/DataViewer';
-import { NesteStegKnapp } from '../../../komponenter/NesteStegKnapp/NesteStegKnapp';
+import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Steg } from '../../../typer/behandling/steg';
 import { FanePath } from '../faner';
 
@@ -42,9 +42,9 @@ const Stønadsvilkår = () => {
                 )}
             </DataViewer>
             {behandlingErRedigerbar && (
-                <NesteStegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
+                <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
                     Fullfør vilkårsvurdering og gå videre
-                </NesteStegKnapp>
+                </StegKnapp>
             )}
         </Container>
     );

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -7,7 +7,7 @@ import { Button, VStack } from '@navikt/ds-react';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
 import { FanePath } from '../../Sider/Behandling/faner';
-import { Steg } from '../../typer/behandling/steg';
+import { Steg, stegErEtterAnnetSteg } from '../../typer/behandling/steg';
 import { RessursStatus } from '../../typer/ressurs';
 import { Feilmelding } from '../Feil/Feilmelding';
 
@@ -59,11 +59,12 @@ export const StegKnapp: FC<{
 
     return (
         <VStack align={'start'}>
-            {behandling.steg === steg ? (
+            {behandling.steg === steg && (
                 <Button variant="primary" size="small" onClick={gåtTilNesteSteg}>
                     {children}
                 </Button>
-            ) : (
+            )}
+            {stegErEtterAnnetSteg(behandling.steg, steg) && (
                 <Button variant="secondary" size="small" onClick={redigerSteg}>
                     Rediger steg
                 </Button>

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -11,7 +11,7 @@ import { Steg } from '../../typer/behandling/steg';
 import { RessursStatus } from '../../typer/ressurs';
 import { Feilmelding } from '../Feil/Feilmelding';
 
-export const NesteStegKnapp: FC<{
+export const StegKnapp: FC<{
     nesteFane: FanePath;
     steg: Steg;
     children: React.ReactNode;

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -19,7 +19,7 @@ export const StegKnapp: FC<{
     const navigate = useNavigate();
     const { request } = useApp();
 
-    const { behandling, hentBehandling } = useBehandling();
+    const { behandling, behandlingErRedigerbar, hentBehandling } = useBehandling();
     const [feilmelding, settFeilmelding] = useState<string>();
 
     const redigerSteg = () => {
@@ -52,6 +52,10 @@ export const StegKnapp: FC<{
             }
         });
     };
+
+    if (!behandlingErRedigerbar) {
+        return null;
+    }
 
     return (
         <VStack align={'start'}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Idag vises "Rediger steg" på eks "Tilsyn Barn"-siden, når man er i inngangsvilkår. Klikker man på den så får man opp
> Kunne ikke redigere steg: Ukjent feil. Feilkode: ff5c5a65-bb2d-4132-ad91-79f756b3da97

Se commit for commit
* [Endrer navn på NesteStegKnapp til StegKnapp då den håndterer redigeri…](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/88db9efc4084ba869543f0fb0c33bcd9ec9d961b)
* [Lar StegKnapp håndtere om den skal vises eller ikke](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/d44fa21b3541b7c54e22d0c37e095718863971c1)
* [Skal kun vise rediger steg hvis steget på behandlingen er etter stege…](https://github.com/navikt/tilleggsstonader-sak-frontend/commit/be2d1deb231cb38e7ed0d968a8e42f7ff9a756f1)


Denne henger sammen med alle andre PR's koblet til stegflyt.
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/270
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/271
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/272
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/273
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/274
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/275