### PR TITLE
Stegflyt 4- Stegflyt vedtak og beregning

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -9,6 +9,7 @@ import Utgifter from './Utgifter/Utgifter';
 import { validerInnvilgetVedtakForm, validerPerioder } from './vedtaksvalidering';
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
+import { useSteg } from '../../../../../context/StegContext';
 import useFormState from '../../../../../hooks/felles/useFormState';
 import { RecordState } from '../../../../../hooks/felles/useRecordState';
 import DataViewer from '../../../../../komponenter/DataViewer';
@@ -56,7 +57,8 @@ interface Props {
 
 export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnIBehandling }) => {
     const { request } = useApp();
-    const { behandlingErRedigerbar, behandling } = useBehandling();
+    const { behandling } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
     // TODO: Prøve å slippe denne castingen
     const lagretInnvilgetVedtak = lagretVedtak as InnvilgeVedtakForBarnetilsyn;
 
@@ -129,7 +131,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnIBehand
                         settValideringsFeil={formState.setErrors}
                     />
                     <Skillelinje />
-                    {behandlingErRedigerbar && (
+                    {erStegRedigerbart && (
                         <Knapp
                             type="button"
                             variant="primary"

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
 import { Button, Heading, Label } from '@navikt/ds-react';
 
-import { useBehandling } from '../../../../../../context/BehandlingContext';
+import { useSteg } from '../../../../../../context/StegContext';
 import { FormErrors } from '../../../../../../hooks/felles/useFormState';
 import DateInputMedLeservisning from '../../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import TextField from '../../../../../../komponenter/Skjema/TextField';
@@ -42,7 +42,7 @@ const UtgifterValg: React.FC<Props> = ({
     oppdaterUtgiter,
     settValideringsFeil,
 }) => {
-    const { behandlingErRedigerbar } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
 
     const oppdaterUtgift = (utgiftIndex: number, oppdatertUtgift: Utgift) => {
         const oppdaterteUtgifter = utgifter.map((utgift, indeks) =>
@@ -87,7 +87,7 @@ const UtgifterValg: React.FC<Props> = ({
                 {barn.registergrunnlag.navn}
             </Heading>
             {utgifter && utgifter.length > 0 && (
-                <Grid $lesevisning={!behandlingErRedigerbar}>
+                <Grid $lesevisning={!erStegRedigerbart}>
                     <Label size="small">Månedlig utgift</Label>
                     <Label size="small">Fra</Label>
                     <Label size="small">Til</Label>
@@ -95,7 +95,7 @@ const UtgifterValg: React.FC<Props> = ({
                     {utgifter.map((utgiftsperiode, indeks) => (
                         <React.Fragment key={utgiftsperiode.endretKey}>
                             <TextField
-                                erLesevisning={!behandlingErRedigerbar}
+                                erLesevisning={!erStegRedigerbart}
                                 label="Utgifter"
                                 hideLabel
                                 value={
@@ -114,7 +114,7 @@ const UtgifterValg: React.FC<Props> = ({
                             <DateInputMedLeservisning
                                 label="Fra"
                                 hideLabel
-                                erLesevisning={!behandlingErRedigerbar}
+                                erLesevisning={!erStegRedigerbart}
                                 value={utgiftsperiode.fom}
                                 onChange={(dato?: string) =>
                                     oppdaterUtgiftFelt(
@@ -129,7 +129,7 @@ const UtgifterValg: React.FC<Props> = ({
                             <DateInputMedLeservisning
                                 label="Til"
                                 hideLabel
-                                erLesevisning={!behandlingErRedigerbar}
+                                erLesevisning={!erStegRedigerbart}
                                 value={utgiftsperiode.tom}
                                 onChange={(dato?: string) =>
                                     oppdaterUtgiftFelt(
@@ -141,24 +141,26 @@ const UtgifterValg: React.FC<Props> = ({
                                 feil={errorState && errorState[indeks]?.tom}
                                 size="small"
                             />
-                            <div>
-                                <Button
-                                    type="button"
-                                    onClick={() => leggTilTomRadUnder(indeks)}
-                                    variant="tertiary"
-                                    icon={<PlusCircleIcon />}
-                                    size="small"
-                                />
-                                {indeks !== 0 && (
+                            {erStegRedigerbart && (
+                                <div>
                                     <Button
                                         type="button"
-                                        onClick={() => slettPeriode(barn.barnId, indeks)}
+                                        onClick={() => leggTilTomRadUnder(indeks)}
                                         variant="tertiary"
-                                        icon={<TrashIcon />}
+                                        icon={<PlusCircleIcon />}
                                         size="small"
                                     />
-                                )}
-                            </div>
+                                    {indeks !== 0 && (
+                                        <Button
+                                            type="button"
+                                            onClick={() => slettPeriode(barn.barnId, indeks)}
+                                            variant="tertiary"
+                                            icon={<TrashIcon />}
+                                            size="small"
+                                        />
+                                    )}
+                                </div>
+                            )}
                         </React.Fragment>
                     ))}
                 </Grid>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -4,7 +4,7 @@ import { styled } from 'styled-components';
 
 import { Heading } from '@navikt/ds-react';
 
-import { useBehandling } from '../../../../context/BehandlingContext';
+import { useSteg } from '../../../../context/StegContext';
 import Select from '../../../../komponenter/Skjema/Select';
 import {
     BehandlingResultat,
@@ -20,7 +20,7 @@ interface Props {
 }
 
 const SelectVedtaksresultat: FC<Props> = ({ resultatType, settResultatType }) => {
-    const { behandlingErRedigerbar } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
     // const { settIkkePersistertKomponent } = useApp();
 
     return (
@@ -29,7 +29,7 @@ const SelectVedtaksresultat: FC<Props> = ({ resultatType, settResultatType }) =>
                 Vedtaksresultat
             </Heading>
             <Select
-                erLesevisning={!behandlingErRedigerbar}
+                erLesevisning={!erStegRedigerbart}
                 label={'Vedtaksresultat'}
                 hideLabel
                 value={resultatType || ''}


### PR DESCRIPTION
…dtak

### Hvorfor er denne endringen nødvendig? ✨
Vedtaksiden er ikke påkoblet stegflytet.
Jeg tenker det er fint hvis vi bruker den samme type logikken som vi har på de 2 første stegene. 
Her brukes `StegKnapp` med egen metode for å kunne sende med en egen lagringsmetode til den. 

Denne fikser 2 av punktene i https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20313

<img width="635" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/6f3c41b2-50fb-4a5f-9c4b-9874d73280d6">

<img width="633" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/48cf1182-0f24-4288-9f53-6346b59d8031">


Denne henger sammen med alle andre PR's koblet til stegflyt.
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/270
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/271
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/272
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/273
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/274
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/275