### PR TITLE
Stegflyt 6 - Skjul brev-fane hvis henlagt

### DIFF
--- a/src/frontend/Sider/Behandling/faner.tsx
+++ b/src/frontend/Sider/Behandling/faner.tsx
@@ -12,6 +12,7 @@ import Inngangsvilkår from './Inngangsvilkår/Inngangsvilkår';
 import Stønadsvilkår from './Stønadsvilkår/Stønadsvilkår';
 import VedtakOgBeregningBarnetilsyn from './VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn';
 import { Behandling } from '../../typer/behandling/behandling';
+import { BehandlingResultat } from '../../typer/behandling/behandlingResultat';
 import { Stønadstype } from '../../typer/behandling/behandlingTema';
 import { Steg, stegErLåstForBehandling } from '../../typer/behandling/steg';
 
@@ -74,6 +75,22 @@ export const faneErLåst = (behandling: Behandling, fanePath: FanePath) => {
     return stegErLåstForBehandling(behandling, faneTilSteg[fanePath]);
 };
 
+const brevfaneHvisIkkeHenlagt = (behandling: Behandling): FanerMedRouter[] => {
+    if (behandling.resultat !== BehandlingResultat.HENLAGT) {
+        return [
+            {
+                navn: FaneNavn.BREV,
+                path: FanePath.BREV,
+                komponent: () => <Brev />,
+                ikon: <EnvelopeClosedIcon />,
+                erLåst: faneErLåst(behandling, FanePath.BREV),
+            },
+        ];
+    } else {
+        return [];
+    }
+};
+
 export const hentBehandlingfaner = (behandling: Behandling): FanerMedRouter[] => {
     return [
         {
@@ -101,12 +118,6 @@ export const hentBehandlingfaner = (behandling: Behandling): FanerMedRouter[] =>
             komponent: () => <p>Simulering</p>,
             erLåst: faneErLåst(behandling, FanePath.SIMULERING),
         },
-        {
-            navn: FaneNavn.BREV,
-            path: FanePath.BREV,
-            komponent: () => <Brev />,
-            ikon: <EnvelopeClosedIcon />,
-            erLåst: faneErLåst(behandling, FanePath.BREV),
-        },
+        ...brevfaneHvisIkkeHenlagt(behandling),
     ];
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Burde ikke vise brevfanen hvis behandlingen er henlagt, då det vanligvis ikke finnes noe brev i et slik tilfelle.
Før:
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/a6ecb26a-f9f8-4a07-b176-e8d11000fb5c)


https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20317

Denne henger sammen med alle andre PR's koblet til stegflyt.
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/270
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/271
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/272
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/273
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/274
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/275