### PR TITLE
Fyll ut inngangsvilkår automatisk

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/FyllUtVilkårKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/FyllUtVilkårKnapp.tsx
@@ -2,42 +2,72 @@ import React, { useCallback, useState } from 'react';
 
 import { styled } from 'styled-components';
 
-import { Alert, Button } from '@navikt/ds-react';
+import { Button } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
+import { useInngangsvilkår } from '../../../context/InngangsvilkårContext';
 import { useVilkår } from '../../../context/VilkårContext';
+import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
 import { RessursStatus } from '../../../typer/ressurs';
 
 const Knapp = styled(Button)`
     width: max-content;
 `;
 
-const FyllUtVilkårKnapp: React.FC = () => {
+type Vilkårtype = 'inngangsvilkår' | 'vilår';
+
+const typeTilPath = (type: Vilkårtype): string => {
+    switch (type) {
+        case 'inngangsvilkår':
+            return 'oppfyll-inngangsvilkar';
+        case 'vilår':
+            return 'oppfyll-vilkar';
+        default:
+            return type satisfies never;
+    }
+};
+
+const FyllUtVilkårKnapp: React.FC<{ type: Vilkårtype }> = ({ type }) => {
     const { request } = useApp();
     const { hentBehandling, behandling } = useBehandling();
+    const { hentStønadsperioder, hentVilkårperioder } = useInngangsvilkår();
     const { hentVilkårsvurdering } = useVilkår();
 
-    const [feilmelding, settFeilmelding] = useState<string>('');
+    const [feilmelding, settFeilmelding] = useState<string>();
+
+    const hentVilkår = useCallback(() => {
+        switch (type) {
+            case 'inngangsvilkår':
+                hentVilkårperioder.rerun();
+                hentStønadsperioder.rerun();
+                return;
+            case 'vilår':
+                hentVilkårsvurdering();
+                return;
+            default:
+                return type satisfies never;
+        }
+    }, [hentStønadsperioder, hentVilkårperioder, hentVilkårsvurdering, type]);
 
     const automatiskFyllUtVilkår = useCallback(() => {
-        request<string, null>(`/api/sak/test/${behandling.id}/oppfyll-vilkar`, 'POST').then(
+        request<string, null>(`/api/sak/test/${behandling.id}/${typeTilPath(type)}`, 'POST').then(
             (res) => {
                 if (res.status === RessursStatus.SUKSESS) {
-                    settFeilmelding('');
-                    hentVilkårsvurdering();
+                    settFeilmelding(undefined);
+                    hentVilkår();
                     hentBehandling.rerun();
                 } else {
                     settFeilmelding(res.frontendFeilmelding);
                 }
             }
         );
-    }, [behandling, hentBehandling, hentVilkårsvurdering, request]);
+    }, [behandling, hentBehandling, hentVilkår, request, type]);
 
     return (
         <>
             <Knapp onClick={automatiskFyllUtVilkår}>Fyll ut vilkår automatisk</Knapp>
-            {feilmelding && <Alert variant={'error'}>{feilmelding}</Alert>}
+            <Feilmelding>{feilmelding}</Feilmelding>
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -13,6 +13,7 @@ import { Vilkårperioder } from './typer/vilkårperiode';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { InngangsvilkårProvider } from '../../../context/InngangsvilkårContext';
+import { useSteg } from '../../../context/StegContext';
 import { useRerunnableEffect } from '../../../hooks/useRerunnableEffect';
 import DataViewer from '../../../komponenter/DataViewer';
 import { NesteStegKnapp } from '../../../komponenter/NesteStegKnapp/NesteStegKnapp';
@@ -29,6 +30,7 @@ const Container = styled(VStack).attrs({ gap: '8' })`
 const Inngangsvilkår = () => {
     const { request } = useApp();
     const { behandling, behandlingErRedigerbar } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
 
     const [vilkårperioder, settVilkårperioder] =
         useState<Ressurs<Vilkårperioder>>(byggTomRessurs());
@@ -53,7 +55,6 @@ const Inngangsvilkår = () => {
 
     return (
         <Container>
-            {erLokalt() && <FyllUtVilkårKnapp />}
             <DataViewer
                 response={{
                     vilkårperioder,
@@ -69,6 +70,9 @@ const Inngangsvilkår = () => {
                                 hentedeStønadsperioder={stønadsperioder}
                                 hentStønadsperioder={hentStønadsperioder}
                             >
+                                {erLokalt() && erStegRedigerbart && (
+                                    <FyllUtVilkårKnapp type={'inngangsvilkår'} />
+                                )}
                                 <Målgruppe />
                                 <Aktivitet />
                                 <Stønadsperioder />

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -6,12 +6,15 @@ import { VStack } from '@navikt/ds-react';
 
 import PassBarn from './PassBarn/PassBarn';
 import { useBehandling } from '../../../context/BehandlingContext';
+import { useSteg } from '../../../context/StegContext';
 import { useVilkår } from '../../../context/VilkårContext';
 import { useRegler } from '../../../hooks/useRegler';
 import DataViewer from '../../../komponenter/DataViewer';
 import { NesteStegKnapp } from '../../../komponenter/NesteStegKnapp/NesteStegKnapp';
 import { Steg } from '../../../typer/behandling/steg';
+import { erLokalt } from '../../../utils/miljø';
 import { FanePath } from '../faner';
+import FyllUtVilkårKnapp from '../Inngangsvilkår/FyllUtVilkårKnapp';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
     margin: 2rem;
@@ -21,6 +24,7 @@ const Stønadsvilkår = () => {
     const { regler, hentRegler } = useRegler();
     const { vilkårsvurdering } = useVilkår();
     const { behandlingErRedigerbar } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
 
     useEffect(() => {
         hentRegler();
@@ -28,6 +32,7 @@ const Stønadsvilkår = () => {
 
     return (
         <Container>
+            {erLokalt() && erStegRedigerbart && <FyllUtVilkårKnapp type={'vilår'} />}
             <DataViewer
                 response={{
                     regler,

--- a/src/frontend/context/InngangsvilkårContext.ts
+++ b/src/frontend/context/InngangsvilkårContext.ts
@@ -1,7 +1,8 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 
 import constate from 'constate';
 
+import { useEffectNotInitialRender } from '../hooks/felles/useEffectNotInitialRender';
 import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
 import { Aktivitet } from '../Sider/Behandling/Inngangsvilkår/typer/aktivitet';
 import { Målgruppe } from '../Sider/Behandling/Inngangsvilkår/typer/målgruppe';
@@ -46,9 +47,14 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
 
         // const [vilkårFeilmeldinger, settVilkårfeilmeldinger] = useState<Vurderingsfeilmelding>({});
 
-        useEffect(() => {
+        useEffectNotInitialRender(() => {
             settStønadsperioder(hentedeStønadsperioder);
         }, [hentedeStønadsperioder]);
+
+        useEffectNotInitialRender(() => {
+            settMålgrupper(vilkårperioder.målgrupper);
+            settAktiviteter(vilkårperioder.aktiviteter);
+        }, [vilkårperioder]);
 
         const leggTilMålgruppe = (nyPeriode: Målgruppe) => {
             settMålgrupper((prevState) => [...prevState, nyPeriode]);

--- a/src/frontend/hooks/felles/useEffectNotInitialRender.ts
+++ b/src/frontend/hooks/felles/useEffectNotInitialRender.ts
@@ -1,0 +1,11 @@
+import { DependencyList, useEffect, useRef } from 'react';
+
+export const useEffectNotInitialRender = (func: () => void, deps?: DependencyList): void => {
+    const hasRendered = useRef(false);
+
+    useEffect(() => {
+        if (hasRendered.current) func();
+        else hasRendered.current = true;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps);
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Knappen for å fylle ut vilkår automatisk virker kun om man var i steg Vilkår.
Det er nå lagt till sånn at man kan fylle ut inngangsvilkår på inngangsvilkår-fanen, og vilkår på vilkår-fanen.

Har også fikset sånn at vilkårperioder-statet blir oppdatert hvis vilkårperioder utenfor contexten blir oppdatert - som det blir når man kaller på `hentVilkårperioder.rerun();`

Koblet til:
* https://github.com/navikt/tilleggsstonader-sak/pull/257