### PR TITLE
🐛  Skal også derefe referanser/variabler i valgtfelt

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
@@ -28,7 +28,7 @@ export const malQuery = (id: string, målform: 'bokmål' = 'bokmål') => groq`*[
                                 ...,
                                 "markDefs": markDefs[]{
                                     ...,
-                                    _type == "reference" => @->{...}
+                                    _type=="variabel" => variabelreferanse -> {...}
                                  }
                             },
                             "variabler": nb[].markDefs[]{


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Variabler i valgtfelt funker ikke uten dette.