### PR TITLE
🐛 Skal ikke vise spørsmål om opphold utenfor norge hvis man ikke svart …

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/ArbeidOgOpphold.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/ArbeidOgOpphold.tsx
@@ -38,6 +38,9 @@ const OppholdUtenforNorge12mnd: React.FC<{
     spørsmål?: JaNei;
     faktaOpphold: FaktaOppholdUtenforNorge[];
 }> = ({ tittel, spørsmål, faktaOpphold }) => {
+    if (!spørsmål) {
+        return null;
+    }
     return (
         <VStack gap={'2'}>
             <Label size="small">{tittel}</Label>


### PR DESCRIPTION
…på spørsmålet

### Hvorfor er denne endringen nødvendig? ✨
Før:
<img width="289" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/17b5fb1f-13b2-4fae-811c-c5206a685e92">
