### PR TITLE
Vilkår dekkes av annet regelverk

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -1,9 +1,9 @@
 import React from 'react';
 
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
-import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { målgruppeErNedsattArbeidsevne, målgrupperHvorMedlemskapMåVurderes } from './utils';
 import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
-import { DelvilkårMålgruppe, MålgruppeType } from '../typer/målgruppe';
+import { DelvilkårMålgruppe } from '../typer/målgruppe';
 import { BegrunnelseObligatorisk, Vurdering } from '../typer/vilkårperiode';
 
 const MålgruppeVilkår: React.FC<{
@@ -11,42 +11,34 @@ const MålgruppeVilkår: React.FC<{
     oppdaterDelvilkår: (key: keyof DelvilkårMålgruppe, vurdering: Vurdering) => void;
     feilmelding?: string;
 }> = ({ målgruppeForm, oppdaterDelvilkår }) => {
-    switch (målgruppeForm.type) {
-        case '':
-        case MålgruppeType.AAP:
-        case MålgruppeType.OVERGANGSSTØNAD:
-            return null;
-
-        case MålgruppeType.OMSTILLINGSSTØNAD:
-        case MålgruppeType.UFØRETRYGD:
-            return (
-                <JaNeiVurdering
-                    label="medlemskap"
-                    vurdering={målgruppeForm.delvilkår.medlemskap}
-                    oppdaterVurdering={(vurdering: Vurdering) =>
-                        oppdaterDelvilkår('medlemskap', vurdering)
-                    }
-                    svarJa="Ja (vurdert etter første ledd)"
-                    svarNei="Nei (vurdert etter andre ledd)"
-                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI}
-                />
-            );
-
-        case MålgruppeType.NEDSATT_ARBEIDSEVNE:
-            return (
-                //TODO: Vurdering av nedsatt arbeidsevne
-                <JaNeiVurdering
-                    label="medlemskap"
-                    vurdering={målgruppeForm.delvilkår.medlemskap}
-                    oppdaterVurdering={(vurdering: Vurdering) =>
-                        oppdaterDelvilkår('medlemskap', vurdering)
-                    }
-                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI}
-                />
-            );
-        default:
-            return <Feilmelding>Mangler mapping av {målgruppeForm.type}</Feilmelding>;
+    if (målgruppeForm.type === '') {
+        return null;
     }
+
+    return (
+        <>
+            {målgrupperHvorMedlemskapMåVurderes.includes(målgruppeForm.type) && (
+                <JaNeiVurdering
+                    label="medlemskap"
+                    vurdering={målgruppeForm.delvilkår.medlemskap}
+                    oppdaterVurdering={(vurdering: Vurdering) =>
+                        oppdaterDelvilkår('medlemskap', vurdering)
+                    }
+                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI}
+                />
+            )}
+            {målgruppeErNedsattArbeidsevne(målgruppeForm.type) && (
+                <JaNeiVurdering
+                    label="Dekkes utgiftene av annet regelverk?"
+                    vurdering={målgruppeForm.delvilkår.dekketAvAnnetRegelverk}
+                    oppdaterVurdering={(vurdering: Vurdering) =>
+                        oppdaterDelvilkår('dekketAvAnnetRegelverk', vurdering)
+                    }
+                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_JA}
+                />
+            )}
+        </>
+    );
 };
 
 export default MålgruppeVilkår;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -1,5 +1,9 @@
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
-import { MålgruppeType } from '../typer/målgruppe';
+import {
+    FaktiskMålgruppe,
+    MålgruppeType,
+    MålgruppeTypeTilFaktiskMålgruppe,
+} from '../typer/målgruppe';
 
 export type MålgrupperMedMedlemskapsvurdering =
     | MålgruppeType.NEDSATT_ARBEIDSEVNE
@@ -13,4 +17,14 @@ export const nyMålgruppe = (behandlingId: string): EndreMålgruppeForm => {
         tom: '',
         delvilkår: { '@type': 'MÅLGRUPPE' },
     };
+};
+
+export const målgrupperHvorMedlemskapMåVurderes = [
+    MålgruppeType.NEDSATT_ARBEIDSEVNE,
+    MålgruppeType.UFØRETRYGD,
+    MålgruppeType.OMSTILLINGSSTØNAD,
+];
+
+export const målgruppeErNedsattArbeidsevne = (målgruppeType: MålgruppeType) => {
+    return MålgruppeTypeTilFaktiskMålgruppe[målgruppeType] === FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE;
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
@@ -10,6 +10,7 @@ export interface Målgruppe extends VilkårPeriode {
 export interface DelvilkårMålgruppe {
     '@type': 'MÅLGRUPPE';
     medlemskap?: Vurdering;
+    dekketAvAnnetRegelverk?: Vurdering;
 }
 
 export enum MålgruppeType {
@@ -34,3 +35,17 @@ export const MålgruppeTypeOptions: SelectOption[] = Object.entries(MålgruppeTy
         label: label,
     })
 );
+
+export enum FaktiskMålgruppe {
+    NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
+    ENSLIG_FORSØRGER = 'ENSLIG_FORSØRGER',
+    GJENLEVENDE = 'GJENLEVENDE',
+}
+
+export const MålgruppeTypeTilFaktiskMålgruppe: Record<MålgruppeType, FaktiskMålgruppe> = {
+    AAP: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+    UFØRETRYGD: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+    OMSTILLINGSSTØNAD: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+    OVERGANGSSTØNAD: FaktiskMålgruppe.ENSLIG_FORSØRGER,
+    NEDSATT_ARBEIDSEVNE: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
@@ -36,6 +36,9 @@ export const MålgruppeTypeOptions: SelectOption[] = Object.entries(MålgruppeTy
     })
 );
 
+// TODO: Endre navn på enum
+// FaktiskMålgruppe brukes som navn foreløpig
+// Disse verdiene er faktiske målgrupper, mens målgruppetype burde hete noe ala hovedytelse eller liknende
 export enum FaktiskMålgruppe {
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
     ENSLIG_FORSØRGER = 'ENSLIG_FORSØRGER',

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
@@ -49,6 +49,7 @@ export enum BegrunnelseObligatorisk {
     OBLIGATORISK = 'OBLIGATORISK',
     VALGFRI = 'VALGFRI',
     OBLIGATORISK_HVIS_SVAR_NEI = 'OBLIGATORISK_HVIS_SVAR_NEI',
+    OBLIGATORISK_HVIS_SVAR_JA = 'OBLIGATORISK_HVIS_SVAR_JA',
 }
 
 export const svarJaNeiMapping: Record<SvarJaNei, string> = {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
@@ -32,6 +32,10 @@ const JaNeiVurdering: React.FC<{
                 return svar === SvarJaNei.NEI
                     ? 'Begrunnelse (obligatorisk)'
                     : 'Begrunnelse (valgfri)';
+            case BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_JA:
+                return svar === SvarJaNei.JA
+                    ? 'Begrunnelse (obligatorisk)'
+                    : 'Begrunnelse (valgfri)';
             case BegrunnelseObligatorisk.VALGFRI:
             default:
                 return 'Begrunnelse (valgfri)';

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Radio, RadioGroup, Textarea } from '@navikt/ds-react';
 
+import { harVerdi } from '../../../utils/utils';
 import {
     SvarJaNei,
     Vurdering,
@@ -42,6 +43,13 @@ const JaNeiVurdering: React.FC<{
         }
     };
 
+    const oppdaterBegrunnelse = (nyBegrunnelse: string) => {
+        oppdaterVurdering({
+            ...vurdering,
+            begrunnelse: harVerdi(nyBegrunnelse) ? nyBegrunnelse : undefined,
+        });
+    };
+
     return (
         <>
             <RadioGroup
@@ -55,7 +63,7 @@ const JaNeiVurdering: React.FC<{
             </RadioGroup>
             <Textarea
                 value={vurdering?.begrunnelse || ''}
-                onChange={(e) => oppdaterVurdering({ ...vurdering, begrunnelse: e.target.value })}
+                onChange={(e) => oppdaterBegrunnelse(e.target.value)}
                 label={begunnelseLabel(begrunnelsePåkrevd, vurdering?.svar)}
                 size="small"
             />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Alle "målgrupper" som går under `NEDSATT_ARBEIDSEVNE` må ha en vurdering av om utgiftene dekkes av annet regelverk, som gir oppfylt hvis svaret er NEI. Begrunnelse kreves hvis svaret er JA. 

Switch ble kaotisk når det kom flere vilkår, så gikk for if i stedet. 

Henger sammen med [PR 267 i sak](https://github.com/navikt/tilleggsstonader-sak/pull/267)

**OBS**
Det vi nå kaller målgruppe burde bytte navn til noe annet (f.eks. hovedytelse eller liknende). Målgruppe er egentlig nedsatt arbeidsevne, enslig eller gjenlevende, men dette er mye jobb så må vente. `FaktiskMålgruppe` brukes i frontend for det som er `Målgruppe`

<img width="1009" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/3544b560-0005-41fd-8ccc-13697b6fdd3a">