### PR TITLE
💄 Fjern høyremeny og plasser totrinnskontroll over venstremeny

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
-
 import BehandlingTabsInnhold from './BehandlingTabsInnhold';
-import Høyremeny from './Høyremeny/Høyremeny';
 import VenstreMeny from './Venstremeny/Venstremeny';
 import { BehandlingProvider } from '../../context/BehandlingContext';
 import { PersonopplysningerProvider } from '../../context/PersonopplysningerContext';
@@ -25,17 +22,6 @@ const InnholdWrapper = styled.div`
     max-width: calc(100% - 20rem);
 `;
 
-const HøyreMenyWrapper = styled.div`
-    border-left: 2px solid ${ABorderDefault};
-    background-color: white;
-
-    width: 20rem;
-    min-width: 20rem;
-
-    // Når skjermen blir for liten  så blir høyremenyn liggendes ovenfor venstredelen
-    z-index: 10;
-`;
-
 const BehandlingInnhold: React.FC<{
     behandling: Behandling;
     hentBehandling: RerrunnableEffect;
@@ -52,9 +38,6 @@ const BehandlingInnhold: React.FC<{
                             <BehandlingTabsInnhold />
                         </InnholdWrapper>
                     </VilkårProvider>
-                    <HøyreMenyWrapper>
-                        <Høyremeny />
-                    </HøyreMenyWrapper>
                 </BehandlingContainer>
             </PersonopplysningerProvider>
         </BehandlingProvider>

--- a/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
+++ b/src/frontend/Sider/Behandling/Høyremeny/Høyremeny.tsx
@@ -1,9 +1,0 @@
-import * as React from 'react';
-
-import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
-
-const Høyremeny = () => {
-    return <Totrinnskontroll />;
-};
-
-export default Høyremeny;

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -7,6 +7,7 @@ import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 
 import Oppsummering from './Oppsummering/Oppsummering';
 import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
+import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
 
 const Container = styled.div`
     border-right: 1px solid ${ABorderDefault};
@@ -30,6 +31,7 @@ const tabs = [
 const VenstreMeny: React.FC = () => {
     return (
         <Container>
+            <Totrinnskontroll />
             <Tabs defaultValue="oppsummering" style={{ width: 'inherit', height: '100%' }}>
                 <StickyTablistContainer>
                     <Tabs.List>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi har kun hatt høyremenyen i løsningen fordi det var plasseringen til totrinnskontrollen. Denne er nå flyttet over tabs i venstermenyen så alt innholdet kan få litt mer plass. 

For beslutter: 
<img width="1708" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/e2e03957-85fd-4a95-ae5e-6c669f10732a">

For saksbehandler: 
<img width="1708" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/ecb5d8c8-096a-442a-9bf7-2767d05802da">

Underkjent: 
<img width="1708" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/06e12418-e385-4dc0-8c58-acd798fed50c">

Før sendt til beslutter (ser bare oppsummering som før): 
<img width="1708" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/eae9c586-8b2e-4d96-9140-80c645fc5f7c">

