### PR TITLE
💄 Nytt design på inngangsvilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -3,8 +3,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { Button, Table } from '@navikt/ds-react';
-import { AWhite } from '@navikt/ds-tokens/dist/tokens';
+import { Button } from '@navikt/ds-react';
 
 import EndreAktivitetRad from './EndreAktivitetRad';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -14,9 +13,12 @@ import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel'
 import { paragraflenkerAktivitet, rundskrivAktivitet } from '../../lenker';
 import VilkårperiodeRad from '../Vilkårperioder/VilkårperiodeRad';
 
-const HvitTabell = styled(Table)`
-    background-color: ${AWhite};
-    max-width: 900px;
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    max-width: max-content;
 `;
 
 const Aktivitet: React.FC = () => {
@@ -36,7 +38,7 @@ const Aktivitet: React.FC = () => {
     const kanSetteNyRadIRedigeringsmodus =
         radIRedigeringsmodus === undefined && !leggerTilNyPeriode;
 
-    const skalViseTabell = aktiviteter.length > 0 || leggerTilNyPeriode;
+    const skalViseAktiviteter = aktiviteter.length > 0 || leggerTilNyPeriode;
 
     const settNyRadIRedigeringsmodus = (id: string) => {
         if (kanSetteNyRadIRedigeringsmodus) {
@@ -55,52 +57,37 @@ const Aktivitet: React.FC = () => {
             paragraflenker={paragraflenkerAktivitet}
             rundskrivlenke={rundskrivAktivitet}
         >
-            {skalViseTabell && (
-                <HvitTabell size="small">
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.HeaderCell style={{ width: '20px' }} />
-                            <Table.HeaderCell>Type</Table.HeaderCell>
-                            <Table.HeaderCell>Fra</Table.HeaderCell>
-                            <Table.HeaderCell>Til</Table.HeaderCell>
-                            <Table.HeaderCell>Aktivitetsdager</Table.HeaderCell>
-                            <Table.HeaderCell>Kilde</Table.HeaderCell>
-                            <Table.HeaderCell />
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {aktiviteter.map((aktivitet) => (
-                            <React.Fragment key={aktivitet.id}>
-                                {aktivitet.id === radIRedigeringsmodus ? (
-                                    <EndreAktivitetRad
-                                        aktivitet={aktivitet}
-                                        avbrytRedigering={fjernRadIRedigeringsmodus}
-                                    />
-                                ) : (
-                                    <VilkårperiodeRad
-                                        vilkårperiode={aktivitet}
-                                        type={aktivitet.type}
-                                        startRedigering={() =>
-                                            settNyRadIRedigeringsmodus(aktivitet.id)
-                                        }
-                                        aktivitetsdager={aktivitet.aktivitetsdager}
-                                    />
-                                )}
-                            </React.Fragment>
-                        ))}
-                        {leggerTilNyPeriode && (
-                            <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
-                        )}
-                    </Table.Body>
-                </HvitTabell>
+            {skalViseAktiviteter && (
+                <Container>
+                    {aktiviteter.map((aktivitet) => (
+                        <React.Fragment key={aktivitet.id}>
+                            {aktivitet.id === radIRedigeringsmodus ? (
+                                <EndreAktivitetRad
+                                    aktivitet={aktivitet}
+                                    avbrytRedigering={fjernRadIRedigeringsmodus}
+                                />
+                            ) : (
+                                <VilkårperiodeRad
+                                    vilkårperiode={aktivitet}
+                                    startRedigering={() => settNyRadIRedigeringsmodus(aktivitet.id)}
+                                />
+                            )}
+                        </React.Fragment>
+                    ))}
+                    {leggerTilNyPeriode && (
+                        <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
+                    )}
+                </Container>
             )}
+
             <Feilmelding>{feilmelding}</Feilmelding>
+
             {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode((prevState) => !prevState)}
                     size="small"
                     style={{ maxWidth: 'fit-content' }}
-                    variant={skalViseTabell ? 'secondary' : 'primary'}
+                    variant={skalViseAktiviteter ? 'secondary' : 'primary'}
                     icon={<PlusCircleIcon />}
                 >
                     Legg til ny aktivitet

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetVilkår.tsx
@@ -5,6 +5,7 @@ import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
 import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
 import { Vurdering } from '../typer/vilkårperiode';
 
+// TODO: Rename til AktivitetDelvilkår
 const AktivitetVilkår: React.FC<{
     aktivitetForm: EndreAktivitetForm;
     oppdaterDelvilkår: (key: keyof DelvilkårAktivitet, vurdering: Vurdering) => void;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -1,7 +1,5 @@
 import React, { useState } from 'react';
 
-import { Table } from '@navikt/ds-react';
-
 import AktivitetVilkår from './AktivitetVilkår';
 import { nyAktivitet } from './utils';
 import { useApp } from '../../../../context/AppContext';
@@ -24,7 +22,6 @@ import {
     StønadsperiodeStatus,
     Vurdering,
 } from '../typer/vilkårperiode';
-import EndreVilkårPeriodeInnhold from '../Vilkårperioder/EndreVilkårperiodeInnhold';
 import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiodeRad';
 import { EndreVilkårsperiode, validerVilkårsperiode } from '../Vilkårperioder/validering';
 
@@ -42,6 +39,7 @@ const initaliserForm = (behandlingId: string, eksisterendeAktivitet?: Aktivitet)
         : { ...eksisterendeAktivitet, behandlingId: behandlingId };
 };
 
+// TODO: Rename til EndreAktivitet
 const EndreAktivitetRad: React.FC<{
     aktivitet?: Aktivitet;
     avbrytRedigering: () => void;
@@ -101,69 +99,57 @@ const EndreAktivitetRad: React.FC<{
         }
     };
 
-    const oppdaterPeriode = (key: keyof Periode, nyVerdi: string) => {
+    const oppdaterVilkårperiode = (key: keyof Aktivitet, nyVerdi: string) => {
         settAktivitetForm((prevState) => ({ ...prevState, [key]: nyVerdi }));
     };
 
     return (
-        <>
-            <EndreVilkårperiodeRad
-                vilkårperiode={aktivitet}
-                form={aktivitetForm}
-                lagre={lagre}
-                avbrytRedigering={avbrytRedigering}
-                oppdaterPeriode={oppdaterPeriode}
-                vilkårsperiodeFeil={vilkårsperiodeFeil}
-                typeOptions={AktivitetTypeOptions}
-                oppdaterType={(nyttValg) =>
+        <EndreVilkårperiodeRad
+            vilkårperiode={aktivitet}
+            form={aktivitetForm}
+            lagre={lagre}
+            avbrytRedigering={avbrytRedigering}
+            oppdaterVilkårperiode={oppdaterVilkårperiode}
+            vilkårsperiodeFeil={vilkårsperiodeFeil}
+            typeOptions={AktivitetTypeOptions}
+            oppdaterType={(nyttValg) =>
+                settAktivitetForm((prevState) => ({
+                    ...prevState,
+                    type: nyttValg as AktivitetType,
+                }))
+            }
+            feilmelding={feilmelding}
+            ekstraCeller={
+                <TextField
+                    erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
+                    label="Aktivitetsdager"
+                    value={
+                        harTallverdi(aktivitetForm.aktivitetsdager)
+                            ? aktivitetForm.aktivitetsdager
+                            : ''
+                    }
+                    onChange={(event) =>
+                        settAktivitetForm((prevState) => ({
+                            ...prevState,
+                            aktivitetsdager: tilHeltall(event.target.value),
+                        }))
+                    }
+                    size="small"
+                    error={vilkårsperiodeFeil?.aktivitetsdager}
+                    autoComplete="off"
+                />
+            }
+        >
+            <AktivitetVilkår
+                aktivitetForm={aktivitetForm}
+                oppdaterDelvilkår={(key: keyof DelvilkårAktivitet, vurdering: Vurdering) =>
                     settAktivitetForm((prevState) => ({
                         ...prevState,
-                        type: nyttValg as AktivitetType,
+                        delvilkår: { ...prevState.delvilkår, [key]: vurdering },
                     }))
                 }
-                ekstraCeller={
-                    <Table.DataCell>
-                        <TextField
-                            erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
-                            label="Aktivitetsdager"
-                            hideLabel
-                            value={
-                                harTallverdi(aktivitetForm.aktivitetsdager)
-                                    ? aktivitetForm.aktivitetsdager
-                                    : ''
-                            }
-                            onChange={(event) =>
-                                settAktivitetForm((prevState) => ({
-                                    ...prevState,
-                                    aktivitetsdager: tilHeltall(event.target.value),
-                                }))
-                            }
-                            size="small"
-                            error={vilkårsperiodeFeil?.aktivitetsdager}
-                            autoComplete="off"
-                        />
-                    </Table.DataCell>
-                }
             />
-            <EndreVilkårPeriodeInnhold
-                begrunnelse={aktivitetForm.begrunnelse}
-                oppdaterBegrunnelse={(begrunnelse: string) =>
-                    settAktivitetForm((prevState) => ({ ...prevState, begrunnelse: begrunnelse }))
-                }
-                feilmelding={feilmelding}
-                vilkår={
-                    <AktivitetVilkår
-                        aktivitetForm={aktivitetForm}
-                        oppdaterDelvilkår={(key: keyof DelvilkårAktivitet, vurdering: Vurdering) =>
-                            settAktivitetForm((prevState) => ({
-                                ...prevState,
-                                delvilkår: { ...prevState.delvilkår, [key]: vurdering },
-                            }))
-                        }
-                    />
-                }
-            />
-        </>
+        </EndreVilkårperiodeRad>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -109,7 +109,7 @@ const EndreAktivitetRad: React.FC<{
             form={aktivitetForm}
             lagre={lagre}
             avbrytRedigering={avbrytRedigering}
-            oppdaterVilkårperiode={oppdaterVilkårperiode}
+            oppdaterForm={oppdaterVilkårperiode}
             vilkårsperiodeFeil={vilkårsperiodeFeil}
             typeOptions={AktivitetTypeOptions}
             oppdaterType={(nyttValg) =>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -69,8 +69,8 @@ const Inngangsvilkår = () => {
                                 hentedeStønadsperioder={stønadsperioder}
                                 hentStønadsperioder={hentStønadsperioder}
                             >
-                                <Målgruppe />
                                 <Aktivitet />
+                                <Målgruppe />
                                 <Stønadsperioder />
                             </InngangsvilkårProvider>
                         )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -19,7 +19,6 @@ import {
     StønadsperiodeStatus,
     Vurdering,
 } from '../typer/vilkårperiode';
-import EndreVilkårPeriodeInnhold from '../Vilkårperioder/EndreVilkårperiodeInnhold';
 import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiodeRad';
 import { EndreVilkårsperiode, validerVilkårsperiode } from '../Vilkårperioder/validering';
 
@@ -36,6 +35,7 @@ const initaliserForm = (behandlingId: string, eksisterendeMålgruppe?: Målgrupp
         : { ...eksisterendeMålgruppe, behandlingId: behandlingId };
 };
 
+// TODO: Endre navn til EndreMålgruppe
 const EndreMålgruppeRad: React.FC<{
     målgruppe?: Målgruppe;
     avbrytRedigering: () => void;
@@ -94,46 +94,37 @@ const EndreMålgruppeRad: React.FC<{
         }
     };
 
-    const oppdaterPeriode = (key: keyof Periode, nyVerdi: string) => {
+    const oppdaterVilkårperiode = (key: keyof Målgruppe, nyVerdi: string) => {
         settMålgruppeForm((prevState) => ({ ...prevState, [key]: nyVerdi }));
     };
 
     return (
-        <>
-            <EndreVilkårperiodeRad
-                vilkårperiode={målgruppe}
-                form={målgruppeForm}
-                lagre={lagre}
-                avbrytRedigering={avbrytRedigering}
-                oppdaterPeriode={oppdaterPeriode}
-                vilkårsperiodeFeil={vilkårsperiodeFeil}
-                typeOptions={MålgruppeTypeOptions}
-                oppdaterType={(nyttValg) =>
+        <EndreVilkårperiodeRad
+            vilkårperiode={målgruppe}
+            form={målgruppeForm}
+            lagre={lagre}
+            avbrytRedigering={avbrytRedigering}
+            oppdaterVilkårperiode={oppdaterVilkårperiode}
+            vilkårsperiodeFeil={vilkårsperiodeFeil}
+            typeOptions={MålgruppeTypeOptions}
+            oppdaterType={(nyttValg) =>
+                settMålgruppeForm((prevState) => ({
+                    ...prevState,
+                    type: nyttValg as MålgruppeType,
+                }))
+            }
+            feilmelding={feilmelding}
+        >
+            <MålgruppeVilkår
+                målgruppeForm={målgruppeForm}
+                oppdaterDelvilkår={(key: keyof DelvilkårMålgruppe, vurdering: Vurdering) =>
                     settMålgruppeForm((prevState) => ({
                         ...prevState,
-                        type: nyttValg as MålgruppeType,
+                        delvilkår: { ...prevState.delvilkår, [key]: vurdering },
                     }))
                 }
             />
-            <EndreVilkårPeriodeInnhold
-                begrunnelse={målgruppeForm.begrunnelse}
-                oppdaterBegrunnelse={(begrunnelse: string) =>
-                    settMålgruppeForm((prevState) => ({ ...prevState, begrunnelse: begrunnelse }))
-                }
-                feilmelding={feilmelding}
-                vilkår={
-                    <MålgruppeVilkår
-                        målgruppeForm={målgruppeForm}
-                        oppdaterDelvilkår={(key: keyof DelvilkårMålgruppe, vurdering: Vurdering) =>
-                            settMålgruppeForm((prevState) => ({
-                                ...prevState,
-                                delvilkår: { ...prevState.delvilkår, [key]: vurdering },
-                            }))
-                        }
-                    />
-                }
-            />
-        </>
+        </EndreVilkårperiodeRad>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -94,7 +94,7 @@ const EndreMålgruppeRad: React.FC<{
         }
     };
 
-    const oppdaterVilkårperiode = (key: keyof Målgruppe, nyVerdi: string) => {
+    const oppdaterForm = (key: keyof Målgruppe, nyVerdi: string) => {
         settMålgruppeForm((prevState) => ({ ...prevState, [key]: nyVerdi }));
     };
 
@@ -104,7 +104,7 @@ const EndreMålgruppeRad: React.FC<{
             form={målgruppeForm}
             lagre={lagre}
             avbrytRedigering={avbrytRedigering}
-            oppdaterVilkårperiode={oppdaterVilkårperiode}
+            oppdaterForm={oppdaterForm}
             vilkårsperiodeFeil={vilkårsperiodeFeil}
             typeOptions={MålgruppeTypeOptions}
             oppdaterType={(nyttValg) =>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -3,8 +3,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { Button, Table } from '@navikt/ds-react';
-import { AWhite } from '@navikt/ds-tokens/dist/tokens';
+import { Button } from '@navikt/ds-react';
 
 import EndreMålgruppeRad from './EndreMålgruppeRad';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -14,9 +13,12 @@ import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel'
 import { lovverkslenkerMålgruppe, rundskrivMålgruppe } from '../../lenker';
 import VilkårperiodeRad from '../Vilkårperioder/VilkårperiodeRad';
 
-const HvitTabell = styled(Table)`
-    background-color: ${AWhite};
-    max-width: 750px;
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+
+    max-width: max-content;
 `;
 
 const Målgruppe: React.FC = () => {
@@ -36,7 +38,7 @@ const Målgruppe: React.FC = () => {
     const kanSetteNyRadIRedigeringsmodus =
         radIRedigeringsmodus === undefined && !leggerTilNyPeriode;
 
-    const skalViseTabell = målgrupper.length > 0 || leggerTilNyPeriode;
+    const skalViseMålgrupper = målgrupper.length > 0 || leggerTilNyPeriode;
 
     const settNyRadIRedigeringsmodus = (id: string) => {
         if (kanSetteNyRadIRedigeringsmodus) {
@@ -55,50 +57,37 @@ const Målgruppe: React.FC = () => {
             paragraflenker={lovverkslenkerMålgruppe}
             rundskrivlenke={rundskrivMålgruppe}
         >
-            {skalViseTabell && (
-                <HvitTabell size="small">
-                    <Table.Header>
-                        <Table.Row>
-                            <Table.HeaderCell style={{ width: '20px' }} />
-                            <Table.HeaderCell>Ytelse/situasjon</Table.HeaderCell>
-                            <Table.HeaderCell>Fra</Table.HeaderCell>
-                            <Table.HeaderCell>Til</Table.HeaderCell>
-                            <Table.HeaderCell>Kilde</Table.HeaderCell>
-                            <Table.HeaderCell />
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        {målgrupper.map((målgruppe) => (
-                            <React.Fragment key={målgruppe.id}>
-                                {målgruppe.id === radIRedigeringsmodus ? (
-                                    <EndreMålgruppeRad
-                                        målgruppe={målgruppe}
-                                        avbrytRedigering={fjernRadIRedigeringsmodus}
-                                    />
-                                ) : (
-                                    <VilkårperiodeRad
-                                        vilkårperiode={målgruppe}
-                                        type={målgruppe.type}
-                                        startRedigering={() =>
-                                            settNyRadIRedigeringsmodus(målgruppe.id)
-                                        }
-                                    />
-                                )}
-                            </React.Fragment>
-                        ))}
-                        {leggerTilNyPeriode && (
-                            <EndreMålgruppeRad avbrytRedigering={fjernRadIRedigeringsmodus} />
-                        )}
-                    </Table.Body>
-                </HvitTabell>
+            {skalViseMålgrupper && (
+                <Container>
+                    {målgrupper.map((målgruppe) => (
+                        <React.Fragment key={målgruppe.id}>
+                            {målgruppe.id === radIRedigeringsmodus ? (
+                                <EndreMålgruppeRad
+                                    målgruppe={målgruppe}
+                                    avbrytRedigering={fjernRadIRedigeringsmodus}
+                                />
+                            ) : (
+                                <VilkårperiodeRad
+                                    vilkårperiode={målgruppe}
+                                    startRedigering={() => settNyRadIRedigeringsmodus(målgruppe.id)}
+                                />
+                            )}
+                        </React.Fragment>
+                    ))}
+                    {leggerTilNyPeriode && (
+                        <EndreMålgruppeRad avbrytRedigering={fjernRadIRedigeringsmodus} />
+                    )}
+                </Container>
             )}
+
             <Feilmelding>{feilmelding}</Feilmelding>
+
             {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode(true)}
                     size="small"
                     style={{ maxWidth: 'fit-content' }}
-                    variant={skalViseTabell ? 'secondary' : 'primary'}
+                    variant={skalViseMålgrupper ? 'secondary' : 'primary'}
                     icon={<PlusCircleIcon />}
                 >
                     Legg til ny målgruppe

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -4,8 +4,9 @@ import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import { målgruppeErNedsattArbeidsevne, målgrupperHvorMedlemskapMåVurderes } from './utils';
 import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
 import { DelvilkårMålgruppe } from '../typer/målgruppe';
-import { BegrunnelseObligatorisk, Vurdering } from '../typer/vilkårperiode';
+import { Vurdering } from '../typer/vilkårperiode';
 
+// TODO: Rename til MålgruppeDelvilkår
 const MålgruppeVilkår: React.FC<{
     målgruppeForm: EndreMålgruppeForm;
     oppdaterDelvilkår: (key: keyof DelvilkårMålgruppe, vurdering: Vurdering) => void;
@@ -19,12 +20,11 @@ const MålgruppeVilkår: React.FC<{
         <>
             {målgrupperHvorMedlemskapMåVurderes.includes(målgruppeForm.type) && (
                 <JaNeiVurdering
-                    label="medlemskap"
+                    label="Medlemskap i folketrygden?"
                     vurdering={målgruppeForm.delvilkår.medlemskap}
                     oppdaterVurdering={(vurdering: Vurdering) =>
                         oppdaterDelvilkår('medlemskap', vurdering)
                     }
-                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI}
                 />
             )}
             {målgruppeErNedsattArbeidsevne(målgruppeForm.type) && (
@@ -34,7 +34,6 @@ const MålgruppeVilkår: React.FC<{
                     oppdaterVurdering={(vurdering: Vurdering) =>
                         oppdaterDelvilkår('dekketAvAnnetRegelverk', vurdering)
                     }
-                    begrunnelsePåkrevd={BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_JA}
                 />
             )}
         </>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -63,7 +63,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
             <FeltContainer>
                 <SelectMedOptions
                     label="Ytelse/situasjon"
-                    erLesevisning={vilkårperiode !== undefined}
+                    readOnly={vilkårperiode !== undefined}
                     value={form.type}
                     valg={typeOptions}
                     onChange={(e) => oppdaterType(e.target.value)}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -97,7 +97,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
             {/* TODO: Håndter validering og visning av om begrunnelse er obligatorisk */}
             <Textarea
                 label={'Begrunnelse'}
-                value={vilkårperiode?.begrunnelse || ''}
+                value={form?.begrunnelse || ''}
                 onChange={(e) => oppdaterVilkårperiode('begrunnelse', e.target.value)}
                 size="small"
             />

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -2,119 +2,114 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Button, Table } from '@navikt/ds-react';
+import { Button, HStack, Textarea } from '@navikt/ds-react';
 
-import { KildeIkon } from './KildeIkon';
 import { EndreVilkårsperiode } from './validering';
+import VilkårperiodeKortBase from './VilkårperiodeKort/VilkårperiodeKortBase';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
-import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
+import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
 import SelectMedOptions, { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
-import { Periode } from '../../../../utils/periode';
 import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
 import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
-import {
-    KildeVilkårsperiode,
-    VilkårPeriode,
-    VilkårPeriodeResultat,
-    vilkårperiodeTypeTilTekst,
-} from '../typer/vilkårperiode';
+import { Aktivitet } from '../typer/aktivitet';
+import { Målgruppe } from '../typer/målgruppe';
+import { KildeVilkårsperiode, VilkårPeriode } from '../typer/vilkårperiode';
 
-const TabellRad = styled(Table.Row)<{ $feilmeldingVises: boolean }>`
-    .navds-table__data-cell {
-        border-color: transparent;
-        vertical-align: ${(props) => (props.$feilmeldingVises ? 'top' : 'center')};
-    }
-`;
-
-const KnappeRad = styled.div`
+const FeltContainer = styled.div`
+    flex-grow: 1;
     display: flex;
-    gap: 0.5rem;
+    gap: 1rem;
+    flex-wrap: wrap;
+    heigth: max-content;
+
+    align-self: start;
+    align-items: center;
 `;
 
 interface Props {
-    vilkårperiode?: VilkårPeriode;
+    vilkårperiode?: Målgruppe | Aktivitet;
     form: EndreMålgruppeForm | EndreAktivitetForm;
     avbrytRedigering: () => void;
     lagre: () => void;
-    oppdaterPeriode: (key: keyof Periode, nyVerdi: string) => void;
+    oppdaterVilkårperiode: (key: keyof VilkårPeriode, nyVerdi: string) => void;
     oppdaterType: (nyttvalg: string) => void;
     typeOptions: SelectOption[];
     vilkårsperiodeFeil?: FormErrors<EndreVilkårsperiode>;
     ekstraCeller?: React.ReactNode;
+    feilmelding?: string;
+    children: React.ReactNode;
 }
 
+// TODO: Endre navn til EndreVilkårperiodeKort eller EndreVilkårperiode
 const EndreVilkårperiodeRad: React.FC<Props> = ({
     vilkårperiode,
     form,
     avbrytRedigering,
     lagre,
-    oppdaterPeriode,
+    oppdaterVilkårperiode,
     oppdaterType,
     typeOptions,
     vilkårsperiodeFeil,
     ekstraCeller,
+    feilmelding,
+    children,
 }) => {
     return (
-        <TabellRad $feilmeldingVises={!!vilkårsperiodeFeil} shadeOnHover={false}>
-            <Table.DataCell width="max-content">
-                <VilkårsresultatIkon
-                    vilkårsresultat={vilkårperiode?.resultat || VilkårPeriodeResultat.IKKE_VURDERT}
-                />
-            </Table.DataCell>
-            <Table.DataCell>
+        <VilkårperiodeKortBase vilkårperiode={vilkårperiode} redigeres>
+            <FeltContainer>
                 <SelectMedOptions
-                    label="Type"
-                    hideLabel
+                    label="Ytelse/situasjon"
                     erLesevisning={vilkårperiode !== undefined}
                     value={form.type}
-                    lesevisningVerdi={
-                        form.type !== '' ? vilkårperiodeTypeTilTekst[form.type] : undefined
-                    }
                     valg={typeOptions}
                     onChange={(e) => oppdaterType(e.target.value)}
                     size="small"
                     error={vilkårsperiodeFeil?.type}
                 />
-            </Table.DataCell>
-            <Table.DataCell>
+
                 <DateInputMedLeservisning
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Fra'}
-                    hideLabel
                     value={form?.fom}
-                    onChange={(dato) => oppdaterPeriode('fom', dato || '')}
+                    onChange={(dato) => oppdaterVilkårperiode('fom', dato || '')}
                     size="small"
                     feil={vilkårsperiodeFeil?.fom}
                 />
-            </Table.DataCell>
-            <Table.DataCell>
+
                 <DateInputMedLeservisning
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Til'}
-                    hideLabel
                     value={form?.tom}
-                    onChange={(dato) => oppdaterPeriode('tom', dato || '')}
+                    onChange={(dato) => oppdaterVilkårperiode('tom', dato || '')}
                     size="small"
                     feil={vilkårsperiodeFeil?.tom}
                 />
-            </Table.DataCell>
-            {ekstraCeller}
-            <Table.DataCell align="center">
-                <KildeIkon kilde={vilkårperiode?.kilde || KildeVilkårsperiode.MANUELL} />
-            </Table.DataCell>
-            <Table.DataCell>
-                <KnappeRad>
-                    <Button size="xsmall" onClick={lagre}>
-                        Lagre
-                    </Button>
 
-                    <Button onClick={avbrytRedigering} variant="secondary" size="xsmall">
-                        Avbryt
-                    </Button>
-                </KnappeRad>
-            </Table.DataCell>
-        </TabellRad>
+                {ekstraCeller}
+            </FeltContainer>
+
+            <HStack gap="8">{children}</HStack>
+
+            {/* TODO: Håndter validering og visning av om begrunnelse er obligatorisk */}
+            <Textarea
+                label={'Begrunnelse'}
+                value={vilkårperiode?.begrunnelse || ''}
+                onChange={(e) => oppdaterVilkårperiode('begrunnelse', e.target.value)}
+                size="small"
+            />
+            <HStack gap="4">
+                <Button size="xsmall" onClick={lagre}>
+                    Lagre
+                </Button>
+
+                <Button onClick={avbrytRedigering} variant="secondary" size="xsmall">
+                    Avbryt
+                </Button>
+            </HStack>
+
+            <Feilmelding>{feilmelding}</Feilmelding>
+        </VilkårperiodeKortBase>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -1,9 +1,10 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
 import { Button, HStack, Textarea } from '@navikt/ds-react';
 
+import SlettVilkårperiodeModal from './SlettVilkårperiodeModal';
 import { EndreVilkårsperiode } from './validering';
 import VilkårperiodeKortBase from './VilkårperiodeKort/VilkårperiodeKortBase';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
@@ -55,6 +56,8 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
     feilmelding,
     children,
 }) => {
+    const [visSlettModal, settVisSlettModal] = useState(false);
+
     return (
         <VilkårperiodeKortBase vilkårperiode={vilkårperiode} redigeres>
             <FeltContainer>
@@ -106,6 +109,23 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                 <Button onClick={avbrytRedigering} variant="secondary" size="xsmall">
                     Avbryt
                 </Button>
+                {vilkårperiode !== undefined && (
+                    <>
+                        <Button
+                            size="small"
+                            variant={'tertiary'}
+                            onClick={() => settVisSlettModal(true)}
+                        >
+                            Slett
+                        </Button>
+                        <SlettVilkårperiodeModal
+                            avbrytRedigering={avbrytRedigering}
+                            visModal={visSlettModal}
+                            settVisModal={settVisSlettModal}
+                            vilkårperiode={vilkårperiode}
+                        />
+                    </>
+                )}
             </HStack>
 
             <Feilmelding>{feilmelding}</Feilmelding>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiodeRad.tsx
@@ -33,7 +33,7 @@ interface Props {
     form: EndreMålgruppeForm | EndreAktivitetForm;
     avbrytRedigering: () => void;
     lagre: () => void;
-    oppdaterVilkårperiode: (key: keyof VilkårPeriode, nyVerdi: string) => void;
+    oppdaterForm: (key: keyof VilkårPeriode, nyVerdi: string) => void;
     oppdaterType: (nyttvalg: string) => void;
     typeOptions: SelectOption[];
     vilkårsperiodeFeil?: FormErrors<EndreVilkårsperiode>;
@@ -48,7 +48,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
     form,
     avbrytRedigering,
     lagre,
-    oppdaterVilkårperiode,
+    oppdaterForm,
     oppdaterType,
     typeOptions,
     vilkårsperiodeFeil,
@@ -75,7 +75,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Fra'}
                     value={form?.fom}
-                    onChange={(dato) => oppdaterVilkårperiode('fom', dato || '')}
+                    onChange={(dato) => oppdaterForm('fom', dato || '')}
                     size="small"
                     feil={vilkårsperiodeFeil?.fom}
                 />
@@ -84,7 +84,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Til'}
                     value={form?.tom}
-                    onChange={(dato) => oppdaterVilkårperiode('tom', dato || '')}
+                    onChange={(dato) => oppdaterForm('tom', dato || '')}
                     size="small"
                     feil={vilkårsperiodeFeil?.tom}
                 />
@@ -98,7 +98,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
             <Textarea
                 label={'Begrunnelse'}
                 value={form?.begrunnelse || ''}
-                onChange={(e) => oppdaterVilkårperiode('begrunnelse', e.target.value)}
+                onChange={(e) => oppdaterForm('begrunnelse', e.target.value)}
                 size="small"
             />
             <HStack gap="4">

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
@@ -9,22 +9,21 @@ import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsres
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../typer/ressurs';
 import { formaterIsoDato } from '../../../../utils/dato';
-import { Aktivitet, AktivitetType } from '../typer/aktivitet';
+import { Aktivitet } from '../typer/aktivitet';
 import { Målgruppe, MålgruppeType } from '../typer/målgruppe';
 import {
     LagreVilkårperiodeResponse,
     SlettVilkårperiode,
     StønadsperiodeStatus,
-    VilkårPeriode,
 } from '../typer/vilkårperiode';
 
 type Response = LagreVilkårperiodeResponse<Aktivitet | Målgruppe>;
 const SlettVilkårperiodeModal: React.FC<{
     visModal: boolean;
     settVisModal: React.Dispatch<SetStateAction<boolean>>;
-    vilkårperiode: VilkårPeriode;
-    type: MålgruppeType | AktivitetType;
-}> = ({ vilkårperiode, visModal, settVisModal, type }) => {
+    vilkårperiode: Målgruppe | Aktivitet;
+    avbrytRedigering: () => void;
+}> = ({ vilkårperiode, visModal, settVisModal, avbrytRedigering }) => {
     const { request } = useApp();
     const { behandling } = useBehandling();
     const { oppdaterAktivitet, oppdaterMålgruppe, settStønadsperiodeFeil } = useInngangsvilkår();
@@ -54,12 +53,13 @@ const SlettVilkårperiodeModal: React.FC<{
                     } else {
                         settStønadsperiodeFeil(res.data.stønadsperiodeFeil);
                     }
-                    if (type in MålgruppeType) {
+                    if (vilkårperiode.type in MålgruppeType) {
                         oppdaterMålgruppe(res.data.periode as Målgruppe);
                     } else {
                         oppdaterAktivitet(res.data.periode as Aktivitet);
                     }
                     settVisModal(false);
+                    avbrytRedigering();
                 } else {
                     settFeil(`Feil ved sletting av vilkårperiode: ${res.frontendFeilmelding}`);
                 }
@@ -107,7 +107,7 @@ const SlettVilkårperiodeModal: React.FC<{
                             <Table.DataCell width="max-content">
                                 <VilkårsresultatIkon vilkårsresultat={vilkårperiode.resultat} />
                             </Table.DataCell>
-                            <Table.DataCell>{type}</Table.DataCell>
+                            <Table.DataCell>{vilkårperiode.type}</Table.DataCell>
                             <Table.DataCell>{formaterIsoDato(vilkårperiode.fom)}</Table.DataCell>
                             <Table.DataCell>{formaterIsoDato(vilkårperiode.tom)}</Table.DataCell>
                             <Table.DataCell>{vilkårperiode.kilde}</Table.DataCell>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/DelvilkårDetaljer.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/DelvilkårDetaljer.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import { Detail, VStack } from '@navikt/ds-react';
+
+import {
+    dekketAvAnnetRegelverkSvarTilTekst,
+    lønnetSvarTilTekst,
+    medlemskapSvarTilTekst,
+} from './tekstmapping';
+import { DelvilkårAktivitet } from '../../typer/aktivitet';
+import { DelvilkårMålgruppe } from '../../typer/målgruppe';
+
+const DelvilkårDetaljer: React.FC<{
+    delvilkår: DelvilkårMålgruppe | DelvilkårAktivitet;
+    aktivitetsdager?: number;
+}> = ({ delvilkår, aktivitetsdager }) => {
+    return (
+        <VStack gap="2">
+            {delvilkår['@type'] === 'MÅLGRUPPE' && (
+                <>
+                    {delvilkår.medlemskap?.svar && (
+                        <Detail>{medlemskapSvarTilTekst[delvilkår.medlemskap.svar]}</Detail>
+                    )}
+                    {delvilkår.dekketAvAnnetRegelverk?.svar && (
+                        <Detail>
+                            {
+                                dekketAvAnnetRegelverkSvarTilTekst[
+                                    delvilkår.dekketAvAnnetRegelverk.svar
+                                ]
+                            }
+                        </Detail>
+                    )}
+                </>
+            )}
+            {delvilkår['@type'] === 'AKTIVITET' && (
+                <>
+                    <Detail>{aktivitetsdager} aktivitetsdager</Detail>
+                    {delvilkår.lønnet?.svar && (
+                        <Detail>{lønnetSvarTilTekst[delvilkår.lønnet.svar]}</Detail>
+                    )}
+                </>
+            )}
+        </VStack>
+    );
+};
+
+export default DelvilkårDetaljer;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/OppsummertVilkårsvurdering.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/OppsummertVilkårsvurdering.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+
+import { styled } from 'styled-components';
+
+import { CircleBrokenIcon } from '@navikt/aksel-icons';
+import { HStack, Label } from '@navikt/ds-react';
+import { AGray200 } from '@navikt/ds-tokens/dist/tokens';
+
+import { VilkårperiodeResultatTilTekst } from './tekstmapping';
+import { VilkårsresultatIkon } from '../../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
+import { VilkårPeriodeResultat } from '../../typer/vilkårperiode';
+
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+    width: 200px;
+    border-left: 3px solid ${AGray200};
+    padding-left: 1rem;
+`;
+
+const OppsummertVilkårsvurdering: React.FC<{
+    resultat?: VilkårPeriodeResultat;
+    redigeres: boolean;
+    className?: string;
+}> = ({ resultat, redigeres, className }) => {
+    return (
+        <Container className={className}>
+            {redigeres || !resultat ? (
+                <HStack wrap={false} gap="4">
+                    <span>
+                        <CircleBrokenIcon />
+                    </span>
+                    <Label size="small">Oppsummert vilkårsvurdering vises når du lagrer</Label>
+                </HStack>
+            ) : (
+                <>
+                    <HStack align="center" gap="4">
+                        <VilkårsresultatIkon vilkårsresultat={resultat} />
+                        <Label size="small">{VilkårperiodeResultatTilTekst[resultat]}</Label>
+                    </HStack>
+                    {/* TODO: Oppsummering av vilkårsvurdering */}
+                    {/* Ikke vurdert - list opp vurdering hvor svar mangler, ikke oppfylt - alle som ikke er oppfylt */}
+                </>
+            )}
+        </Container>
+    );
+};
+
+export default OppsummertVilkårsvurdering;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import { styled } from 'styled-components';
+
+import { AWhite } from '@navikt/ds-tokens/dist/tokens';
+
+import OppsummertVilkårsvurdering from './OppsummertVilkårsvurdering';
+import { Aktivitet } from '../../typer/aktivitet';
+import { Målgruppe } from '../../typer/målgruppe';
+
+const Container = styled.div`
+    background-color: ${AWhite};
+    padding: 1rem;
+
+    display: flex;
+    justify-content: space-between;
+    gap: 1rem;
+`;
+
+const VenstreKolonne = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
+`;
+
+const KnappOgOppsummeringContainer = styled.div`
+    display: grid;
+    grid-template-columns: 32px 200px;
+    gap: 1rem;
+    align-items: start;
+
+    .oppsummering {
+        grid-column: 2;
+    }
+`;
+
+const VilkårperiodeKortBase: React.FC<{
+    vilkårperiode?: Målgruppe | Aktivitet;
+    redigeringKnapp?: React.ReactNode;
+    children: React.ReactNode;
+    redigeres?: boolean;
+}> = ({ vilkårperiode, redigeringKnapp, children, redigeres = false }) => {
+    return (
+        <Container>
+            <VenstreKolonne>{children}</VenstreKolonne>
+            <KnappOgOppsummeringContainer>
+                {redigeringKnapp}
+                <OppsummertVilkårsvurdering
+                    redigeres={redigeres}
+                    resultat={vilkårperiode?.resultat}
+                    className="oppsummering"
+                />
+            </KnappOgOppsummeringContainer>
+        </Container>
+    );
+};
+
+export default VilkårperiodeKortBase;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
@@ -1,0 +1,26 @@
+import { SvarJaNei, VilkårPeriodeResultat } from '../../typer/vilkårperiode';
+
+export const medlemskapSvarTilTekst: Record<SvarJaNei, string> = {
+    [SvarJaNei.JA]: 'Medlemskap i folketrygden',
+    [SvarJaNei.JA_IMPLISITT]: 'Medlemskap i folketrygden',
+    [SvarJaNei.NEI]: 'Ikke medlemskap i folketrygden',
+};
+
+export const dekketAvAnnetRegelverkSvarTilTekst: Record<SvarJaNei, string | undefined> = {
+    [SvarJaNei.JA]: 'Utgifter dekkes av annet regelverk',
+    [SvarJaNei.NEI]: 'Utgifter dekkes ikke av annet regelverk',
+    [SvarJaNei.JA_IMPLISITT]: undefined,
+};
+
+export const lønnetSvarTilTekst: Record<SvarJaNei, string | undefined> = {
+    [SvarJaNei.JA]: 'Lønnet',
+    [SvarJaNei.NEI]: 'Ikke lønnet',
+    [SvarJaNei.JA_IMPLISITT]: undefined,
+};
+
+export const VilkårperiodeResultatTilTekst: Record<VilkårPeriodeResultat, string> = {
+    [VilkårPeriodeResultat.OPPFYLT]: 'Vilkår oppfylt',
+    [VilkårPeriodeResultat.IKKE_OPPFYLT]: 'Vilkår ikke oppfylt',
+    [VilkårPeriodeResultat.IKKE_VURDERT]: 'Mangelfull vurdering',
+    [VilkårPeriodeResultat.SLETTET]: 'Slettet',
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -1,153 +1,78 @@
-import React, { useRef, useState } from 'react';
+import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { ChatIcon, PencilIcon, TrashIcon } from '@navikt/aksel-icons';
-import {
-    BodyShort,
-    Button,
-    Detail,
-    HStack,
-    Popover,
-    Spacer,
-    Table,
-    VStack,
-} from '@navikt/ds-react';
-import { ABgSubtle } from '@navikt/ds-tokens/dist/tokens';
+import { PencilIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, Label, VStack } from '@navikt/ds-react';
 
-import { KildeIkon } from './KildeIkon';
-import SlettVilkårperiodeModal from './SlettVilkårperiodeModal';
+import DelvilkårDetaljer from './VilkårperiodeKort/DelvilkårDetaljer';
+import VilkårperiodeKortBase from './VilkårperiodeKort/VilkårperiodeKortBase';
 import { useSteg } from '../../../../context/StegContext';
-import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon';
-import Lesefelt from '../../../../komponenter/Skjema/Lesefelt';
-import { formaterIsoDato, formaterIsoDatoTidMedSekunder } from '../../../../utils/dato';
-import { AktivitetType } from '../typer/aktivitet';
-import { MålgruppeType } from '../typer/målgruppe';
-import {
-    VilkårPeriode,
-    VilkårPeriodeResultat,
-    vilkårperiodeTypeTilTekst,
-} from '../typer/vilkårperiode';
+import { formaterIsoPeriode } from '../../../../utils/dato';
+import { Aktivitet } from '../typer/aktivitet';
+import { Målgruppe } from '../typer/målgruppe';
+import { VilkårPeriodeResultat, vilkårperiodeTypeTilTekst } from '../typer/vilkårperiode';
 
-const TabellRad = styled(Table.Row)<{ disabled?: boolean }>`
-    background: ${(props) => (props.disabled ? ABgSubtle : '')};
+const CelleContainer = styled.div`
+    flex-grow: 1;
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
 `;
 
-const BegrunnelseContainer = styled(VStack)`
-    max-width: 48rem;
+const Celle = styled.div<{ $width?: number }>`
+    width: ${({ $width = 180 }) => $width}px;
 `;
 
+// TODO: Endre navn til VilkårperiodeKort
 const VilkårperiodeRad: React.FC<{
-    vilkårperiode: VilkårPeriode;
-    type: MålgruppeType | AktivitetType;
+    vilkårperiode: Målgruppe | Aktivitet;
     startRedigering: () => void;
-    aktivitetsdager?: number;
-}> = ({ vilkårperiode, type, startRedigering, aktivitetsdager }) => {
+}> = ({ vilkårperiode, startRedigering }) => {
     const { erStegRedigerbart } = useSteg();
 
-    const [visSlettModal, settVisSlettModal] = useState(false);
-    const visRedigerKnapper =
+    const visRedigerKnapp =
         vilkårperiode.resultat != VilkårPeriodeResultat.SLETTET && erStegRedigerbart;
 
-    const buttonRef = useRef<HTMLButtonElement>(null);
-    const [visBeskrivelse, settVisBeskrivelse] = useState(false);
-
     return (
-        <TabellRad
-            key={vilkårperiode.id}
-            disabled={vilkårperiode.resultat === VilkårPeriodeResultat.SLETTET}
-            shadeOnHover={false}
+        <VilkårperiodeKortBase
+            vilkårperiode={vilkårperiode}
+            redigeringKnapp={
+                visRedigerKnapp && (
+                    <Button
+                        variant="tertiary"
+                        size="small"
+                        onClick={startRedigering}
+                        icon={<PencilIcon />}
+                    />
+                )
+            }
         >
-            <Table.DataCell width="max-content">
-                <HStack align="center">
-                    <VilkårsresultatIkon vilkårsresultat={vilkårperiode.resultat} />
-                </HStack>
-            </Table.DataCell>
-            <Table.DataCell>
-                <HStack align="center">
-                    <BodyShort size="small">{vilkårperiodeTypeTilTekst[type]}</BodyShort>
-                    {vilkårperiode.begrunnelse && (
-                        <>
-                            <Spacer />
-                            <Button
-                                ref={buttonRef}
-                                icon={<ChatIcon />}
-                                size={'small'}
-                                variant={'tertiary'}
-                                onClick={() => settVisBeskrivelse(!visBeskrivelse)}
-                            />
-                            <Popover
-                                anchorEl={buttonRef.current}
-                                open={visBeskrivelse}
-                                onClose={() => settVisBeskrivelse(false)}
-                            >
-                                <Popover.Content>
-                                    <BegrunnelseContainer gap="4">
-                                        <Detail>
-                                            Sist endret{' '}
-                                            {formaterIsoDatoTidMedSekunder(
-                                                vilkårperiode.sistEndret
-                                            )}
-                                        </Detail>
-                                        {vilkårperiode.resultat ===
-                                            VilkårPeriodeResultat.SLETTET && (
-                                            <Lesefelt
-                                                verdi={vilkårperiode.slettetKommentar}
-                                                label={'Begrunnelse for sletting'}
-                                            />
-                                        )}
-                                        <Lesefelt
-                                            verdi={vilkårperiode.begrunnelse}
-                                            label={'Begrunnelse periode'}
-                                        />
-                                    </BegrunnelseContainer>
-                                </Popover.Content>
-                            </Popover>
-                        </>
-                    )}
-                </HStack>
-            </Table.DataCell>
-            <Table.DataCell>
-                <BodyShort size="small">{formaterIsoDato(vilkårperiode.fom)}</BodyShort>
-            </Table.DataCell>
-            <Table.DataCell>
-                <BodyShort size="small">{formaterIsoDato(vilkårperiode.tom)}</BodyShort>
-            </Table.DataCell>
-            {aktivitetsdager && (
-                <Table.DataCell align="center">
-                    <BodyShort size="small">{aktivitetsdager}</BodyShort>
-                </Table.DataCell>
-            )}
-            <Table.DataCell align="center">
-                <KildeIkon kilde={vilkårperiode.kilde} />
-            </Table.DataCell>
-            <Table.DataCell>
-                {visRedigerKnapper && (
-                    <HStack gap="2">
-                        <Button
-                            onClick={startRedigering}
-                            variant="secondary"
-                            size="xsmall"
-                            icon={<PencilIcon />}
-                        >
-                            Endre
-                        </Button>
-                        <Button
-                            icon={<TrashIcon />}
-                            size="xsmall"
-                            variant={'tertiary'}
-                            onClick={() => settVisSlettModal(true)}
-                        />
-                        <SlettVilkårperiodeModal
-                            visModal={visSlettModal}
-                            settVisModal={settVisSlettModal}
-                            vilkårperiode={vilkårperiode}
-                            type={type}
-                        />
-                    </HStack>
-                )}
-            </Table.DataCell>
-        </TabellRad>
+            <CelleContainer>
+                <Celle>
+                    <Label size="small" className="ytelse">
+                        {vilkårperiodeTypeTilTekst[vilkårperiode.type]}
+                    </Label>
+                </Celle>
+                <Celle>
+                    <BodyShort size="small">
+                        {formaterIsoPeriode(vilkårperiode.fom, vilkårperiode.tom)}
+                    </BodyShort>
+                </Celle>
+                <Celle>
+                    <DelvilkårDetaljer
+                        delvilkår={vilkårperiode.delvilkår}
+                        aktivitetsdager={(vilkårperiode as Aktivitet).aktivitetsdager}
+                    />
+                </Celle>
+                <Celle $width={300}>
+                    <VStack>
+                        <Label size="small">Begrunnelse:</Label>
+                        <BodyShort size="small">{vilkårperiode.begrunnelse || '-'}</BodyShort>
+                    </VStack>
+                </Celle>
+            </CelleContainer>
+        </VilkårperiodeKortBase>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
@@ -60,7 +60,6 @@ export const svarJaNeiMapping: Record<SvarJaNei, string> = {
 
 export interface Vurdering {
     svar?: SvarJaNei;
-    begrunnelse?: string;
 }
 
 export interface SlettVilkårperiode {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 
-import { Radio, RadioGroup, Textarea } from '@navikt/ds-react';
+import { HStack, Radio, RadioGroup } from '@navikt/ds-react';
 
-import { harVerdi } from '../../../utils/utils';
-import {
-    SvarJaNei,
-    Vurdering,
-    svarJaNeiMapping,
-    BegrunnelseObligatorisk,
-} from '../Inngangsvilkår/typer/vilkårperiode';
+import { SvarJaNei, Vurdering, svarJaNeiMapping } from '../Inngangsvilkår/typer/vilkårperiode';
 
 const JaNeiVurdering: React.FC<{
     label: string;
@@ -16,58 +10,25 @@ const JaNeiVurdering: React.FC<{
     oppdaterVurdering: (vurdering: Vurdering) => void;
     svarJa?: string;
     svarNei?: string;
-    begrunnelsePåkrevd?: BegrunnelseObligatorisk;
 }> = ({
     vurdering,
     oppdaterVurdering,
     label,
     svarJa = svarJaNeiMapping[SvarJaNei.JA],
     svarNei = svarJaNeiMapping[SvarJaNei.NEI],
-    begrunnelsePåkrevd,
 }) => {
-    const begunnelseLabel = (påkrevd?: BegrunnelseObligatorisk, svar?: SvarJaNei): string => {
-        switch (påkrevd) {
-            case BegrunnelseObligatorisk.OBLIGATORISK:
-                return 'Begrunnelse (obligatorisk)';
-            case BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_NEI:
-                return svar === SvarJaNei.NEI
-                    ? 'Begrunnelse (obligatorisk)'
-                    : 'Begrunnelse (valgfri)';
-            case BegrunnelseObligatorisk.OBLIGATORISK_HVIS_SVAR_JA:
-                return svar === SvarJaNei.JA
-                    ? 'Begrunnelse (obligatorisk)'
-                    : 'Begrunnelse (valgfri)';
-            case BegrunnelseObligatorisk.VALGFRI:
-            default:
-                return 'Begrunnelse (valgfri)';
-        }
-    };
-
-    const oppdaterBegrunnelse = (nyBegrunnelse: string) => {
-        oppdaterVurdering({
-            ...vurdering,
-            begrunnelse: harVerdi(nyBegrunnelse) ? nyBegrunnelse : undefined,
-        });
-    };
-
     return (
-        <>
-            <RadioGroup
-                value={vurdering?.svar || ''}
-                legend={label}
-                onChange={(e) => oppdaterVurdering({ ...vurdering, svar: e })}
-                size="small"
-            >
+        <RadioGroup
+            value={vurdering?.svar || ''}
+            legend={label}
+            onChange={(e) => oppdaterVurdering({ ...vurdering, svar: e })}
+            size="small"
+        >
+            <HStack gap="4">
                 <Radio value={SvarJaNei.JA}>{svarJa}</Radio>
                 <Radio value={SvarJaNei.NEI}>{svarNei}</Radio>
-            </RadioGroup>
-            <Textarea
-                value={vurdering?.begrunnelse || ''}
-                onChange={(e) => oppdaterBegrunnelse(e.target.value)}
-                label={begunnelseLabel(begrunnelsePåkrevd, vurdering?.svar)}
-                size="small"
-            />
-        </>
+            </HStack>
+        </RadioGroup>
     );
 };
 

--- a/src/frontend/komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon.tsx
+++ b/src/frontend/komponenter/Ikoner/Vilkårsresultat/VilkårsresultatIkon.tsx
@@ -1,7 +1,6 @@
 import React, { FC } from 'react';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Tag } from '@navikt/ds-react';
 
 import IkkeOppfylt from './IkkeOppfylt';
 import IkkeVurdert from './IkkeVurdert';
@@ -33,11 +32,7 @@ export const VilkårsresultatIkon: FC<{
         case Vilkårsresultat.SKAL_IKKE_VURDERES:
             return <Info className={className} height={height} width={width} />;
         case VilkårPeriodeResultat.SLETTET:
-            return (
-                <Tag size={'small'} variant={'neutral'} icon={<TrashIcon />}>
-                    Slettet
-                </Tag>
-            );
+            return <TrashIcon />;
 
         default:
             return null;

--- a/src/frontend/komponenter/Skjema/Select.tsx
+++ b/src/frontend/komponenter/Skjema/Select.tsx
@@ -5,7 +5,7 @@ import { Select as AkselSelect, SelectProps as AkselSelectProps } from '@navikt/
 import Lesefelt from './Lesefelt';
 
 export interface SelectProps extends AkselSelectProps {
-    erLesevisning: boolean;
+    erLesevisning?: boolean;
     lesevisningVerdi?: string;
 }
 

--- a/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
+++ b/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
@@ -1,20 +1,19 @@
 import React, { FC } from 'react';
 
-import { Select, SelectProps } from '@navikt/ds-react';
+import Select, { SelectProps } from './Select';
 
 export interface SelectOption {
     value: string;
     label: string;
 }
 
-interface Props extends Omit<SelectProps, 'children' | 'readOnly'> {
+interface Props extends Omit<SelectProps, 'children'> {
     valg: SelectOption[];
-    erLesevisning: boolean;
 }
 
-const SelectMedOptions: FC<Props> = ({ valg, erLesevisning, ...props }) => {
+const SelectMedOptions: FC<Props> = ({ valg, ...props }) => {
     return (
-        <Select {...props} readOnly={erLesevisning}>
+        <Select {...props}>
             <option value="">Velg</option>
             {valg.map((v) => (
                 <option key={v.value} value={v.value}>

--- a/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
+++ b/src/frontend/komponenter/Skjema/SelectMedOptions.tsx
@@ -1,19 +1,20 @@
 import React, { FC } from 'react';
 
-import Select, { SelectProps } from './Select';
+import { Select, SelectProps } from '@navikt/ds-react';
 
 export interface SelectOption {
     value: string;
     label: string;
 }
 
-interface Props extends Omit<SelectProps, 'children'> {
+interface Props extends Omit<SelectProps, 'children' | 'readOnly'> {
     valg: SelectOption[];
+    erLesevisning: boolean;
 }
 
-const SelectMedOptions: FC<Props> = ({ valg, ...props }) => {
+const SelectMedOptions: FC<Props> = ({ valg, erLesevisning, ...props }) => {
     return (
-        <Select {...props}>
+        <Select {...props} readOnly={erLesevisning}>
             <option value="">Velg</option>
             {valg.map((v) => (
                 <option key={v.value} value={v.value}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ha kort i stedet for tabellvisning av inngangsvilkår

Funksjonalitet som er endret: 
- Sletting skjer nå inne i redigeringsmodus. 
- Begrunnelse rett på vurdering er slettet (må testes sammen med [denne](https://github.com/navikt/tilleggsstonader-sak/pull/271) om du vil at ting skal funke)
- Samle ting på et kort som skissene

Kommer: 
- Vise tydligere at begrunnelse er påkrevd (må diskuteres om det skal prioriteres nå)
- Fjerne sykepenger vilkår
- En del renaming men vil gjøre det i egen pr så det er lettere å se - se todo kommentarer om hva jeg vil endre til

### Bilder
Ny aktivitet: 
<img width="1342" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/7598b64d-5070-4e28-b6d7-a8b0a3a7ff87">

Redigering av eksisterende aktivitet:
<img width="1343" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/8c4937f1-7d67-469a-8386-d69c95a5a267">

Hvordan ulike statuser ser ut: 
<img width="1343" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/8ec22723-1bf9-4edd-90db-4bf3c5f679b1">

Ny målgruppe: 
<img width="1345" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/802794e4-f51b-4573-9958-8563acc5bea5">

Rediger: 
<img width="1345" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/5e2379e6-27c7-4661-8785-c0430bfb8102">

Ulike statuser: 
<img width="1345" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/2c0f1f88-63c5-4363-9079-52ad2a1b1d79">
