### PR TITLE
🐛 Lesevisning av utgiftsrader

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -148,26 +148,28 @@ const UtgifterValg: React.FC<Props> = ({
                                 feil={errorState && errorState[indeks]?.tom}
                                 size="small"
                             />
-                            {erStegRedigerbart && (
-                                <div>
-                                    <Button
-                                        type="button"
-                                        onClick={() => leggTilTomRadUnder(indeks)}
-                                        variant="tertiary"
-                                        icon={<PlusCircleIcon />}
-                                        size="small"
-                                    />
-                                    {indeks !== 0 && (
+                            <div>
+                                {erStegRedigerbart && (
+                                    <>
                                         <Button
                                             type="button"
-                                            onClick={() => slettPeriode(barn.barnId, indeks)}
+                                            onClick={() => leggTilTomRadUnder(indeks)}
                                             variant="tertiary"
-                                            icon={<TrashIcon />}
+                                            icon={<PlusCircleIcon />}
                                             size="small"
                                         />
-                                    )}
-                                </div>
-                            )}
+                                        {indeks !== 0 && (
+                                            <Button
+                                                type="button"
+                                                onClick={() => slettPeriode(barn.barnId, indeks)}
+                                                variant="tertiary"
+                                                icon={<TrashIcon />}
+                                                size="small"
+                                            />
+                                        )}
+                                    </>
+                                )}
+                            </div>
                         </React.Fragment>
                     ))}
                 </Grid>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Utgifter/UtgifterValg.tsx
@@ -18,7 +18,7 @@ import { GrunnlagBarn } from '../../../../vilkår';
 import { leggTilTomRadUnderIListe, tomUtgiftRad } from '../../utils';
 import { InnvilgeVedtakForm } from '../InnvilgeBarnetilsyn';
 
-const Grid = styled.div<{ $lesevisning?: boolean }>`
+const Grid = styled.div`
     display: grid;
     grid-template-columns: repeat(4, max-content);
     grid-gap: 0.5rem 1rem;
@@ -93,7 +93,7 @@ const UtgifterValg: React.FC<Props> = ({
                 )}
             </Heading>
             {utgifter && utgifter.length > 0 && (
-                <Grid $lesevisning={!erStegRedigerbart}>
+                <Grid>
                     <Label size="small">Månedlig utgift</Label>
                     <Label size="small">Fra</Label>
                     <Label size="small">Til</Label>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fjernet param `$lesevisning` då den likevel ikke brukes. Den kan ev. brukes for å ikke bruke en wrapping div som denne løsning gjør, men føler det blir mer styr, då man må bruke props 2 steder.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20570

<img width="342" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/4ab0d251-804c-4986-83d1-e62904322e10">

<img width="574" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/73cba4f8-0051-4d5c-84ce-5463f401b9c0">
