### PR TITLE
Preutfyll dekket av annet regelverk til nei

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { målgruppeErNedsattArbeidsevne, målgrupperHvorMedlemskapMåVurderes } from './utils';
 import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
 import { DelvilkårMålgruppe, MålgruppeType } from '../typer/målgruppe';
-import { Vurdering } from '../typer/vilkårperiode';
+import { SvarJaNei, Vurdering } from '../typer/vilkårperiode';
 
 const Container = styled.div`
     display: flex;
@@ -21,6 +21,10 @@ const MålgruppeVilkår: React.FC<{
 }> = ({ type, delvilkår, oppdaterDelvilkår }) => {
     const skalVurdereMedlemskap = målgrupperHvorMedlemskapMåVurderes.includes(type);
     const skalVurdereDekketAvAnnetRegelverk = målgruppeErNedsattArbeidsevne(type);
+
+    if (skalVurdereDekketAvAnnetRegelverk && !delvilkår.dekketAvAnnetRegelverk?.svar) {
+        oppdaterDelvilkår('dekketAvAnnetRegelverk', { svar: SvarJaNei.NEI });
+    }
 
     if (skalVurdereMedlemskap || skalVurdereDekketAvAnnetRegelverk) {
         return (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Kan preutfylles fordi vi egentlig ikke vet hvilke andre regelverk som kan gjøre at dette blir ja ([favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20588))