### PR TITLE
Når man endrer type så må man rydde opp statet for delvilkår, hvis ik…

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetVilkår.tsx
@@ -4,8 +4,9 @@ import styled from 'styled-components';
 
 import { EndreAktivitetForm } from './EndreAktivitetRad';
 import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
-import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
+import { DelvilkårAktivitet } from '../typer/aktivitet';
 import { Vurdering } from '../typer/vilkårperiode';
+import {skalVurdereLønnet} from "./utils";
 
 const Container = styled.div`
     display: flex;
@@ -19,11 +20,9 @@ const AktivitetVilkår: React.FC<{
 }> = ({ aktivitetForm, oppdaterDelvilkår }) => {
     if (aktivitetForm.type === '') return null;
 
-    const skalVurdereLønnet = aktivitetForm.type === AktivitetType.TILTAK;
-
     return (
         <Container>
-            {skalVurdereLønnet && (
+            {skalVurdereLønnet(aktivitetForm.type) && (
                 <JaNeiVurdering
                     label="Lønnet"
                     vurdering={aktivitetForm.delvilkår.lønnet}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import AktivitetVilkår from './AktivitetVilkår';
-import { nyAktivitet } from './utils';
+import { nyAktivitet, resetDelvilkår } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -103,6 +103,14 @@ const EndreAktivitetRad: React.FC<{
         settAktivitetForm((prevState) => ({ ...prevState, [key]: nyVerdi }));
     };
 
+    const oppdaterType = (type: AktivitetType) => {
+        settAktivitetForm((prevState) => ({
+            ...prevState,
+            type: type,
+            delvilkår: resetDelvilkår(type, prevState.delvilkår),
+        }));
+    };
+
     return (
         <EndreVilkårperiodeRad
             vilkårperiode={aktivitet}
@@ -112,12 +120,7 @@ const EndreAktivitetRad: React.FC<{
             oppdaterForm={oppdaterVilkårperiode}
             vilkårsperiodeFeil={vilkårsperiodeFeil}
             typeOptions={AktivitetTypeOptions}
-            oppdaterType={(nyttValg) =>
-                settAktivitetForm((prevState) => ({
-                    ...prevState,
-                    type: nyttValg as AktivitetType,
-                }))
-            }
+            oppdaterType={(nyttValg) => oppdaterType(nyttValg as AktivitetType)}
             feilmelding={feilmelding}
             ekstraCeller={
                 <TextField

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -1,4 +1,5 @@
 import { EndreAktivitetForm } from './EndreAktivitetRad';
+import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
 
 export const nyAktivitet = (behandlingId: string): EndreAktivitetForm => {
     return {
@@ -10,3 +11,14 @@ export const nyAktivitet = (behandlingId: string): EndreAktivitetForm => {
         delvilkår: { '@type': 'AKTIVITET' },
     };
 };
+
+export const skalVurdereLønnet = (type: AktivitetType | '') => type === AktivitetType.TILTAK;
+
+export const resetDelvilkår = (
+    type: AktivitetType,
+    delvilkår: DelvilkårAktivitet
+): DelvilkårAktivitet => ({
+    ...delvilkår,
+    lønnet: skalVurdereLønnet(type) ? delvilkår.lønnet : undefined,
+    // fjerner ikke mottarSykepenger då den alltid skal vurderes
+});

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import MålgruppeVilkår from './MålgruppeVilkår';
-import { nyMålgruppe } from './utils';
+import { nyMålgruppe, resetDelvilkår } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -98,6 +98,14 @@ const EndreMålgruppeRad: React.FC<{
         settMålgruppeForm((prevState) => ({ ...prevState, [key]: nyVerdi }));
     };
 
+    const oppdaterType = (type: MålgruppeType) => {
+        settMålgruppeForm((prevState) => ({
+            ...prevState,
+            type: type,
+            delvilkår: resetDelvilkår(type, prevState.delvilkår),
+        }));
+    };
+
     return (
         <EndreVilkårperiodeRad
             vilkårperiode={målgruppe}
@@ -107,12 +115,7 @@ const EndreMålgruppeRad: React.FC<{
             oppdaterForm={oppdaterForm}
             vilkårsperiodeFeil={vilkårsperiodeFeil}
             typeOptions={MålgruppeTypeOptions}
-            oppdaterType={(nyttValg) =>
-                settMålgruppeForm((prevState) => ({
-                    ...prevState,
-                    type: nyttValg as MålgruppeType,
-                }))
-            }
+            oppdaterType={(type) => oppdaterType(type as MålgruppeType)}
             feilmelding={feilmelding}
         >
             <MålgruppeVilkår

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -1,5 +1,6 @@
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import {
+    DelvilkårMålgruppe,
     FaktiskMålgruppe,
     MålgruppeType,
     MålgruppeTypeTilFaktiskMålgruppe,
@@ -28,3 +29,16 @@ export const målgrupperHvorMedlemskapMåVurderes = [
 export const målgruppeErNedsattArbeidsevne = (målgruppeType: MålgruppeType) => {
     return MålgruppeTypeTilFaktiskMålgruppe[målgruppeType] === FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE;
 };
+
+export const resetDelvilkår = (
+    type: MålgruppeType,
+    delvilkår: DelvilkårMålgruppe
+): DelvilkårMålgruppe => ({
+    ...delvilkår,
+    medlemskap: målgrupperHvorMedlemskapMåVurderes.includes(type)
+        ? delvilkår.medlemskap
+        : undefined,
+    dekketAvAnnetRegelverk: målgruppeErNedsattArbeidsevne(type)
+        ? delvilkår.dekketAvAnnetRegelverk
+        : undefined,
+});


### PR DESCRIPTION
…ke så risikerer man at man sender vurdering av eks lønnet når den ikke skal være med

### Hvorfor er denne endringen nødvendig? ✨
Hvis man velger noe på et vilkår og sen endrer type så resetter man ikke statet for vurdering som ikke skal bli.
Då feiler det når man prøver å sende inn det til backend. 

Denne må ev. fikses/ryddes opp i etter at 296 er fikset og merget
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/296

<img width="400" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/750b74a5-04c6-4a44-bb3e-fe66588db9ff">

