### PR TITLE
💄 Samle aktivitet og målgruppe i en container

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -3,13 +3,13 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { Button } from '@navikt/ds-react';
+import { Button, HStack, Heading } from '@navikt/ds-react';
 
 import EndreAktivitetRad from './EndreAktivitetRad';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../../context/StegContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
-import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
+import { ParagrafOgRundskrivLenker } from '../../../../komponenter/VilkårPanel/VilkårPanel';
 import { paragraflenkerAktivitet, rundskrivAktivitet } from '../../lenker';
 import VilkårperiodeRad from '../Vilkårperioder/VilkårperiodeRad';
 
@@ -52,13 +52,16 @@ const Aktivitet: React.FC = () => {
     };
 
     return (
-        <VilkårPanel
-            tittel="Aktivitet"
-            paragraflenker={paragraflenkerAktivitet}
-            rundskrivlenke={rundskrivAktivitet}
-        >
+        <Container>
+            <HStack gap="8" align="center">
+                <Heading size="small">Aktivitet</Heading>
+                <ParagrafOgRundskrivLenker
+                    paragrafLenker={paragraflenkerAktivitet}
+                    rundskrivLenke={rundskrivAktivitet}
+                />
+            </HStack>
             {skalViseAktiviteter && (
-                <Container>
+                <>
                     {aktiviteter.map((aktivitet) => (
                         <React.Fragment key={aktivitet.id}>
                             {aktivitet.id === radIRedigeringsmodus ? (
@@ -77,7 +80,7 @@ const Aktivitet: React.FC = () => {
                     {leggerTilNyPeriode && (
                         <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
                     )}
-                </Container>
+                </>
             )}
 
             <Feilmelding>{feilmelding}</Feilmelding>
@@ -93,7 +96,7 @@ const Aktivitet: React.FC = () => {
                     Legg til ny aktivitet
                 </Button>
             )}
-        </VilkårPanel>
+        </Container>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useState } from 'react';
 
 import { styled } from 'styled-components';
 
-import { VStack } from '@navikt/ds-react';
+import { ABlue50 } from '@navikt/ds-tokens/dist/tokens';
 
 import Aktivitet from './Aktivitet/Aktivitet';
 import FyllUtVilkårKnapp from './FyllUtVilkårKnapp';
@@ -22,8 +22,19 @@ import { features } from '../../../utils/features';
 import { erLokalt } from '../../../utils/miljø';
 import { FanePath } from '../faner';
 
-const Container = styled(VStack).attrs({ gap: '8' })`
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 2rem;
     margin: 2rem;
+`;
+
+const VilkårContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 3rem;
+    padding: 2rem;
+    background-color: ${ABlue50};
 `;
 
 const Inngangsvilkår = () => {
@@ -69,8 +80,10 @@ const Inngangsvilkår = () => {
                                 hentedeStønadsperioder={stønadsperioder}
                                 hentStønadsperioder={hentStønadsperioder}
                             >
-                                <Aktivitet />
-                                <Målgruppe />
+                                <VilkårContainer>
+                                    <Aktivitet />
+                                    <Målgruppe />
+                                </VilkårContainer>
                                 <Stønadsperioder />
                             </InngangsvilkårProvider>
                         )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -3,14 +3,14 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { Button } from '@navikt/ds-react';
+import { Button, HStack, Heading } from '@navikt/ds-react';
 
 import EndreMålgruppeRad from './EndreMålgruppeRad';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../../context/StegContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
-import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
-import { lovverkslenkerMålgruppe, rundskrivMålgruppe } from '../../lenker';
+import { ParagrafOgRundskrivLenker } from '../../../../komponenter/VilkårPanel/VilkårPanel';
+import { paragraflenkerMålgruppe, rundskrivMålgruppe } from '../../lenker';
 import VilkårperiodeRad from '../Vilkårperioder/VilkårperiodeRad';
 
 const Container = styled.div`
@@ -52,13 +52,16 @@ const Målgruppe: React.FC = () => {
     };
 
     return (
-        <VilkårPanel
-            tittel="Målgruppe"
-            paragraflenker={lovverkslenkerMålgruppe}
-            rundskrivlenke={rundskrivMålgruppe}
-        >
+        <Container>
+            <HStack gap="8" align="center">
+                <Heading size="small">Målgruppe</Heading>
+                <ParagrafOgRundskrivLenker
+                    paragrafLenker={paragraflenkerMålgruppe}
+                    rundskrivLenke={rundskrivMålgruppe}
+                />
+            </HStack>
             {skalViseMålgrupper && (
-                <Container>
+                <>
                     {målgrupper.map((målgruppe) => (
                         <React.Fragment key={målgruppe.id}>
                             {målgruppe.id === radIRedigeringsmodus ? (
@@ -77,7 +80,7 @@ const Målgruppe: React.FC = () => {
                     {leggerTilNyPeriode && (
                         <EndreMålgruppeRad avbrytRedigering={fjernRadIRedigeringsmodus} />
                     )}
-                </Container>
+                </>
             )}
 
             <Feilmelding>{feilmelding}</Feilmelding>
@@ -93,7 +96,7 @@ const Målgruppe: React.FC = () => {
                     Legg til ny målgruppe
                 </Button>
             )}
-        </VilkårPanel>
+        </Container>
     );
 };
 

--- a/src/frontend/Sider/Behandling/lenker.ts
+++ b/src/frontend/Sider/Behandling/lenker.ts
@@ -3,7 +3,7 @@ export type Lenke = {
     url: string;
 };
 
-export const lovverkslenkerMålgruppe: Lenke[] = [
+export const paragraflenkerMålgruppe: Lenke[] = [
     {
         tekst: '§ 11-A3',
         url: 'https://lovdata.no/pro/#document/NL/lov/1997-02-28-19/%C2%A711a-3',

--- a/src/frontend/komponenter/VilkårPanel/VilkårPanel.tsx
+++ b/src/frontend/komponenter/VilkårPanel/VilkårPanel.tsx
@@ -40,7 +40,8 @@ export const VilkårPanel: React.FC<VilkårpanelProps> = ({
         </Panel>
     );
 };
-const ParagrafOgRundskrivLenker: React.FC<{
+
+export const ParagrafOgRundskrivLenker: React.FC<{
     paragrafLenker: Lenke[];
     rundskrivLenke: string;
 }> = ({ paragrafLenker, rundskrivLenke }) => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Før:
<img width="1370" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/9777a738-233d-4039-813c-1d9b049035bc">

Etter: 
<img width="1364" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/9d5312b1-899a-49a9-b826-f82daaaffb0e">
