### PR TITLE
🐛 Flytter initiering av dekketAvAnnetRegelverk til endring av type som …

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -6,7 +6,7 @@ import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import { målgruppeErNedsattArbeidsevne, målgrupperHvorMedlemskapMåVurderes } from './utils';
 import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
 import { DelvilkårMålgruppe } from '../typer/målgruppe';
-import { SvarJaNei, Vurdering } from '../typer/vilkårperiode';
+import { Vurdering } from '../typer/vilkårperiode';
 
 const Container = styled.div`
     display: flex;
@@ -23,13 +23,6 @@ const MålgruppeVilkår: React.FC<{
 
     const skalVurdereMedlemskap = målgrupperHvorMedlemskapMåVurderes.includes(målgruppeForm.type);
     const skalVurdereDekketAvAnnetRegelverk = målgruppeErNedsattArbeidsevne(målgruppeForm.type);
-
-    if (
-        skalVurdereDekketAvAnnetRegelverk &&
-        !målgruppeForm.delvilkår.dekketAvAnnetRegelverk?.svar
-    ) {
-        oppdaterDelvilkår('dekketAvAnnetRegelverk', { svar: SvarJaNei.NEI });
-    }
 
     if (!skalVurdereMedlemskap && !skalVurdereDekketAvAnnetRegelverk) {
         return null;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -5,6 +5,7 @@ import {
     MålgruppeType,
     MålgruppeTypeTilFaktiskMålgruppe,
 } from '../typer/målgruppe';
+import { SvarJaNei } from '../typer/vilkårperiode';
 
 export type MålgrupperMedMedlemskapsvurdering =
     | MålgruppeType.NEDSATT_ARBEIDSEVNE
@@ -30,6 +31,9 @@ export const målgruppeErNedsattArbeidsevne = (målgruppeType: MålgruppeType) =
     return MålgruppeTypeTilFaktiskMålgruppe[målgruppeType] === FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE;
 };
 
+const dekkesAvAnnetRegelverkAutomatiskNeiHvisMangler = (delvilkår: DelvilkårMålgruppe) =>
+    delvilkår.dekketAvAnnetRegelverk || { svar: SvarJaNei.NEI };
+
 export const resetDelvilkår = (
     type: MålgruppeType,
     delvilkår: DelvilkårMålgruppe
@@ -39,6 +43,6 @@ export const resetDelvilkår = (
         ? delvilkår.medlemskap
         : undefined,
     dekketAvAnnetRegelverk: målgruppeErNedsattArbeidsevne(type)
-        ? delvilkår.dekketAvAnnetRegelverk
+        ? dekkesAvAnnetRegelverkAutomatiskNeiHvisMangler(delvilkår)
         : undefined,
 });


### PR DESCRIPTION
…resetter delvilkår.

Beholder eksisterende eller initierer med nytt default-verdi

### Hvorfor er denne endringen nødvendig? ✨
TIdligere så ble oppdateringen av dekketAvAnnetRegelverk utført i en komponent som endrer seg og renderingen kaster warning.
> Warning: Cannot update a component (`EndreMålgruppeRad`) while rendering a different component (`MålgruppeVilkår`). To locate the bad setState() call inside `MålgruppeVilkår`, follow the stack trace as described i

Så flytter initieringen til resetDelvilkår for å unngå side-effects 
