### PR TITLE
Validering og visning av obligatorisk begrunnelse

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -22,7 +22,7 @@ import {
     StønadsperiodeStatus,
     Vurdering,
 } from '../typer/vilkårperiode';
-import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiodeRad';
+import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad';
 import { EndreVilkårsperiode, validerVilkårsperiode } from '../Vilkårperioder/validering';
 
 export interface EndreAktivitetForm extends Periode {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import AktivitetVilkår from './AktivitetVilkår';
-import { nyAktivitet, resetDelvilkår } from './utils';
+import { harObligatoriskBegrunnelse, nyAktivitet, resetDelvilkår } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -57,7 +57,9 @@ const EndreAktivitetRad: React.FC<{
         useState<FormErrors<EndreVilkårsperiode>>();
 
     const validerForm = (): boolean => {
-        const vilkårsperiodeFeil = validerVilkårsperiode(aktivitetForm);
+        const erBegrunnelseObligatorisk = harObligatoriskBegrunnelse(aktivitetForm);
+
+        const vilkårsperiodeFeil = validerVilkårsperiode(aktivitetForm, erBegrunnelseObligatorisk);
         settVilkårsperiodeFeil(vilkårsperiodeFeil);
 
         return isValid(vilkårsperiodeFeil);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import AktivitetVilkår from './AktivitetVilkår';
-import { harObligatoriskBegrunnelse, nyAktivitet, resetDelvilkår } from './utils';
+import { nyAktivitet, resetDelvilkår } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -57,9 +57,7 @@ const EndreAktivitetRad: React.FC<{
         useState<FormErrors<EndreVilkårsperiode>>();
 
     const validerForm = (): boolean => {
-        const erBegrunnelseObligatorisk = harObligatoriskBegrunnelse(aktivitetForm);
-
-        const vilkårsperiodeFeil = validerVilkårsperiode(aktivitetForm, erBegrunnelseObligatorisk);
+        const vilkårsperiodeFeil = validerVilkårsperiode(aktivitetForm);
         settVilkårsperiodeFeil(vilkårsperiodeFeil);
 
         return isValid(vilkårsperiodeFeil);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -34,3 +34,8 @@ export const finnBegrunnelseGrunnerAktivitet = (delvilkår: DelvilkårAktivitet)
 
     return delvilkårSomMåBegrunnes;
 };
+
+export const harObligatoriskBegrunnelse = (målgruppeForm: EndreAktivitetForm) => {
+    const begrunnelseGrunner = finnBegrunnelseGrunnerAktivitet(målgruppeForm.delvilkår);
+    return begrunnelseGrunner.length > 0;
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -1,4 +1,5 @@
 import { EndreAktivitetForm } from './EndreAktivitetRad';
+import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
 import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
 import { SvarJaNei } from '../typer/vilkårperiode';
 import { BegrunnelseGrunner } from '../Vilkårperioder/EndreVilkårperiode/utils';
@@ -35,7 +36,11 @@ export const finnBegrunnelseGrunnerAktivitet = (delvilkår: DelvilkårAktivitet)
     return delvilkårSomMåBegrunnes;
 };
 
-export const harObligatoriskBegrunnelse = (målgruppeForm: EndreAktivitetForm) => {
-    const begrunnelseGrunner = finnBegrunnelseGrunnerAktivitet(målgruppeForm.delvilkår);
-    return begrunnelseGrunner.length > 0;
+export const erFormForAktivitet = (
+    vilkårperiode: EndreMålgruppeForm | EndreAktivitetForm
+): vilkårperiode is EndreAktivitetForm => {
+    return (
+        (Object.keys(AktivitetType).includes(vilkårperiode.type) || vilkårperiode.type === '') &&
+        vilkårperiode.delvilkår['@type'] === 'AKTIVITET'
+    );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -1,5 +1,7 @@
 import { EndreAktivitetForm } from './EndreAktivitetRad';
 import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
+import { SvarJaNei } from '../typer/vilkårperiode';
+import { BegrunnelseGrunner } from '../Vilkårperioder/EndreVilkårperiode/utils';
 
 export const nyAktivitet = (behandlingId: string): EndreAktivitetForm => {
     return {
@@ -22,3 +24,13 @@ export const resetDelvilkår = (
     lønnet: skalVurdereLønnet(type) ? delvilkår.lønnet : undefined,
     // fjerner ikke mottarSykepenger då den alltid skal vurderes
 });
+
+export const finnBegrunnelseGrunnerAktivitet = (delvilkår: DelvilkårAktivitet) => {
+    const delvilkårSomMåBegrunnes = [];
+
+    if (delvilkår.lønnet?.svar === SvarJaNei.JA) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.NEDSATT_ARBEIDSEVNE);
+    }
+
+    return delvilkårSomMåBegrunnes;
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import MålgruppeVilkår from './MålgruppeVilkår';
-import { nyMålgruppe, resetDelvilkår } from './utils';
+import { harObligatoriskBegrunnelse, nyMålgruppe, resetDelvilkår } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -53,7 +53,9 @@ const EndreMålgruppeRad: React.FC<{
         useState<FormErrors<EndreVilkårsperiode>>();
 
     const validerForm = (): boolean => {
-        const vilkårsperiodeFeil = validerVilkårsperiode(målgruppeForm);
+        const erBegrunnelseObligatorisk = harObligatoriskBegrunnelse(målgruppeForm);
+
+        const vilkårsperiodeFeil = validerVilkårsperiode(målgruppeForm, erBegrunnelseObligatorisk);
         settVilkårsperiodeFeil(vilkårsperiodeFeil);
 
         return isValid(vilkårsperiodeFeil);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -19,7 +19,7 @@ import {
     StønadsperiodeStatus,
     Vurdering,
 } from '../typer/vilkårperiode';
-import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiodeRad';
+import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad';
 import { EndreVilkårsperiode, validerVilkårsperiode } from '../Vilkårperioder/validering';
 
 export interface EndreMålgruppeForm extends Periode {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import MålgruppeVilkår from './MålgruppeVilkår';
-import { harObligatoriskBegrunnelse, nyMålgruppe, resetDelvilkår } from './utils';
+import { nyMålgruppe, resetDelvilkår } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -53,9 +53,7 @@ const EndreMålgruppeRad: React.FC<{
         useState<FormErrors<EndreVilkårsperiode>>();
 
     const validerForm = (): boolean => {
-        const erBegrunnelseObligatorisk = harObligatoriskBegrunnelse(målgruppeForm);
-
-        const vilkårsperiodeFeil = validerVilkårsperiode(målgruppeForm, erBegrunnelseObligatorisk);
+        const vilkårsperiodeFeil = validerVilkårsperiode(målgruppeForm);
         settVilkårsperiodeFeil(vilkårsperiodeFeil);
 
         return isValid(vilkårsperiodeFeil);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -73,6 +73,14 @@ export const finnBegrunnelseGrunnerMålgruppe = (
     return delvilkårSomMåBegrunnes;
 };
 
+export const harObligatoriskBegrunnelse = (målgruppeForm: EndreMålgruppeForm) => {
+    const begrunnelseGrunner = finnBegrunnelseGrunnerMålgruppe(
+        målgruppeForm.type,
+        målgruppeForm.delvilkår
+    );
+    return begrunnelseGrunner.length > 0;
+};
+
 export const erFormForMålgruppe = (
     vilkårperiode: EndreMålgruppeForm | EndreAktivitetForm
 ): vilkårperiode is EndreMålgruppeForm => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -73,14 +73,6 @@ export const finnBegrunnelseGrunnerMålgruppe = (
     return delvilkårSomMåBegrunnes;
 };
 
-export const harObligatoriskBegrunnelse = (målgruppeForm: EndreMålgruppeForm) => {
-    const begrunnelseGrunner = finnBegrunnelseGrunnerMålgruppe(
-        målgruppeForm.type,
-        målgruppeForm.delvilkår
-    );
-    return begrunnelseGrunner.length > 0;
-};
-
 export const erFormForMålgruppe = (
     vilkårperiode: EndreMålgruppeForm | EndreAktivitetForm
 ): vilkårperiode is EndreMålgruppeForm => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -1,4 +1,5 @@
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
+import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
 import {
     DelvilkårMålgruppe,
     FaktiskMålgruppe,
@@ -6,6 +7,7 @@ import {
     MålgruppeTypeTilFaktiskMålgruppe,
 } from '../typer/målgruppe';
 import { SvarJaNei } from '../typer/vilkårperiode';
+import { BegrunnelseGrunner } from '../Vilkårperioder/EndreVilkårperiode/utils';
 
 export type MålgrupperMedMedlemskapsvurdering =
     | MålgruppeType.NEDSATT_ARBEIDSEVNE
@@ -49,3 +51,33 @@ export const resetDelvilkår = (
         ? dekkesAvAnnetRegelverkAutomatiskNeiHvisMangler(delvilkår)
         : undefined,
 });
+
+export const finnBegrunnelseGrunnerMålgruppe = (
+    type: MålgruppeType | '',
+    delvilkår: DelvilkårMålgruppe
+) => {
+    const delvilkårSomMåBegrunnes = [];
+
+    if (type === MålgruppeType.NEDSATT_ARBEIDSEVNE) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.NEDSATT_ARBEIDSEVNE);
+    }
+
+    if (type !== '' && målgrupperHvorMedlemskapMåVurderes.includes(type)) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.MEDLEMSKAP);
+    }
+
+    if (delvilkår.dekketAvAnnetRegelverk?.svar === SvarJaNei.JA) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.DEKKET_AV_ANNET_REGELVERK);
+    }
+
+    return delvilkårSomMåBegrunnes;
+};
+
+export const erFormForMålgruppe = (
+    vilkårperiode: EndreMålgruppeForm | EndreAktivitetForm
+): vilkårperiode is EndreMålgruppeForm => {
+    return (
+        (Object.keys(MålgruppeType).includes(vilkårperiode.type) || vilkårperiode.type === '') &&
+        vilkårperiode.delvilkår['@type'] === 'MÅLGRUPPE'
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Textarea } from '@navikt/ds-react';
+
+import { BegrunnelseGrunner, begrunnelseTilTekst } from './utils';
+
+interface Props {
+    begrunnelse?: string;
+    oppdaterBegrunnelse: (nyBegrunnelse: string) => void;
+    delvilkårSomKreverBegrunnelse: BegrunnelseGrunner[];
+}
+
+const Liste = styled.ul`
+    margin: 0.25rem;
+`;
+
+const Begrunnelse: React.FC<Props> = ({
+    begrunnelse,
+    oppdaterBegrunnelse,
+    delvilkårSomKreverBegrunnelse,
+}) => {
+    const begrunnelseSuffix =
+        delvilkårSomKreverBegrunnelse.length > 0 ? '(obligatorisk)' : '(valgfri)';
+
+    return (
+        <Textarea
+            label={`Begrunnelse ${begrunnelseSuffix}`}
+            description={
+                delvilkårSomKreverBegrunnelse.length > 0 && (
+                    <>
+                        Du må begrunne vurderingen av:
+                        <Liste>
+                            {delvilkårSomKreverBegrunnelse.map((delvilkår, indeks) => (
+                                <li key={indeks}>{begrunnelseTilTekst[delvilkår]}</li>
+                            ))}
+                        </Liste>
+                    </>
+                )
+            }
+            value={begrunnelse || ''}
+            onChange={(e) => oppdaterBegrunnelse(e.target.value)}
+            size="small"
+        />
+    );
+};
+
+export default Begrunnelse;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
@@ -10,6 +10,7 @@ interface Props {
     begrunnelse?: string;
     oppdaterBegrunnelse: (nyBegrunnelse: string) => void;
     delvilkårSomKreverBegrunnelse: BegrunnelseGrunner[];
+    feil?: string;
 }
 
 const Liste = styled.ul`
@@ -20,6 +21,7 @@ const Begrunnelse: React.FC<Props> = ({
     begrunnelse,
     oppdaterBegrunnelse,
     delvilkårSomKreverBegrunnelse,
+    feil,
 }) => {
     const begrunnelseSuffix =
         delvilkårSomKreverBegrunnelse.length > 0 ? '(obligatorisk)' : '(valgfri)';
@@ -42,6 +44,7 @@ const Begrunnelse: React.FC<Props> = ({
             value={begrunnelse || ''}
             onChange={(e) => oppdaterBegrunnelse(e.target.value)}
             size="small"
+            error={feil}
         />
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
@@ -32,7 +32,7 @@ const Begrunnelse: React.FC<Props> = ({
             description={
                 delvilkårSomKreverBegrunnelse.length > 0 && (
                     <>
-                        Du må begrunne vurderingen av:
+                        Du må begrunne:
                         <Liste>
                             {delvilkårSomKreverBegrunnelse.map((delvilkår, indeks) => (
                                 <li key={indeks}>{begrunnelseTilTekst[delvilkår]}</li>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/Begrunnelse.tsx
@@ -14,7 +14,7 @@ interface Props {
 }
 
 const Liste = styled.ul`
-    margin: 0.25rem;
+    margin: 0.25rem 0;
 `;
 
 const Begrunnelse: React.FC<Props> = ({

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeInnhold.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { Table, Textarea } from '@navikt/ds-react';
 
-import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { Feilmelding } from '../../../../../komponenter/Feil/Feilmelding';
 
 const Innhold = styled.div`
     display: flex;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -103,6 +103,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                 begrunnelse={form?.begrunnelse || ''}
                 oppdaterBegrunnelse={(nyBegrunnelse) => oppdaterForm('begrunnelse', nyBegrunnelse)}
                 delvilkårSomKreverBegrunnelse={delvilkårSomKreverBegrunnelse}
+                feil={vilkårsperiodeFeil?.begrunnelse}
             />
             <HStack gap="4">
                 <Button size="xsmall" onClick={lagre}>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -2,8 +2,10 @@ import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Button, HStack, Textarea } from '@navikt/ds-react';
+import { Button, HStack } from '@navikt/ds-react';
 
+import Begrunnelse from './Begrunnelse';
+import { finnBegrunnelseGrunner } from './utils';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { Feilmelding } from '../../../../../komponenter/Feil/Feilmelding';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
@@ -58,6 +60,8 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
 }) => {
     const [visSlettModal, settVisSlettModal] = useState(false);
 
+    const delvilkårSomKreverBegrunnelse = finnBegrunnelseGrunner(form);
+
     return (
         <VilkårperiodeKortBase vilkårperiode={vilkårperiode} redigeres>
             <FeltContainer>
@@ -95,11 +99,10 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
             {children}
 
             {/* TODO: Håndter validering og visning av om begrunnelse er obligatorisk */}
-            <Textarea
-                label={'Begrunnelse'}
-                value={form?.begrunnelse || ''}
-                onChange={(e) => oppdaterForm('begrunnelse', e.target.value)}
-                size="small"
+            <Begrunnelse
+                begrunnelse={form?.begrunnelse || ''}
+                oppdaterBegrunnelse={(nyBegrunnelse) => oppdaterForm('begrunnelse', nyBegrunnelse)}
+                delvilkårSomKreverBegrunnelse={delvilkårSomKreverBegrunnelse}
             />
             <HStack gap="4">
                 <Button size="xsmall" onClick={lagre}>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -98,7 +98,6 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
 
             {children}
 
-            {/* TODO: Håndter validering og visning av om begrunnelse er obligatorisk */}
             <Begrunnelse
                 begrunnelse={form?.begrunnelse || ''}
                 oppdaterBegrunnelse={(nyBegrunnelse) => oppdaterForm('begrunnelse', nyBegrunnelse)}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -4,18 +4,18 @@ import styled from 'styled-components';
 
 import { Button, HStack, Textarea } from '@navikt/ds-react';
 
-import SlettVilkårperiodeModal from './SlettVilkårperiodeModal';
-import { EndreVilkårsperiode } from './validering';
-import VilkårperiodeKortBase from './VilkårperiodeKort/VilkårperiodeKortBase';
-import { FormErrors } from '../../../../hooks/felles/useFormState';
-import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
-import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
-import SelectMedOptions, { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
-import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
-import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
-import { Aktivitet } from '../typer/aktivitet';
-import { Målgruppe } from '../typer/målgruppe';
-import { KildeVilkårsperiode, VilkårPeriode } from '../typer/vilkårperiode';
+import { FormErrors } from '../../../../../hooks/felles/useFormState';
+import { Feilmelding } from '../../../../../komponenter/Feil/Feilmelding';
+import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
+import SelectMedOptions, { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
+import { EndreAktivitetForm } from '../../Aktivitet/EndreAktivitetRad';
+import { EndreMålgruppeForm } from '../../Målgruppe/EndreMålgruppeRad';
+import { Aktivitet } from '../../typer/aktivitet';
+import { Målgruppe } from '../../typer/målgruppe';
+import { KildeVilkårsperiode, VilkårPeriode } from '../../typer/vilkårperiode';
+import SlettVilkårperiodeModal from '../SlettVilkårperiodeModal';
+import { EndreVilkårsperiode } from '../validering';
+import VilkårperiodeKortBase from '../VilkårperiodeKort/VilkårperiodeKortBase';
 
 const FeltContainer = styled.div`
     flex-grow: 1;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -27,7 +27,7 @@ const FeltContainer = styled.div`
     heigth: max-content;
 
     align-self: start;
-    align-items: center;
+    align-items: start;
 `;
 
 interface Props {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/utils.ts
@@ -1,0 +1,28 @@
+import { EndreAktivitetForm } from '../../Aktivitet/EndreAktivitetRad';
+import { finnBegrunnelseGrunnerAktivitet } from '../../Aktivitet/utils';
+import { EndreMålgruppeForm } from '../../Målgruppe/EndreMålgruppeRad';
+import { erFormForMålgruppe, finnBegrunnelseGrunnerMålgruppe } from '../../Målgruppe/utils';
+
+export enum BegrunnelseGrunner {
+    MEDLEMSKAP = 'MEDLEMSKAP',
+    DEKKET_AV_ANNET_REGELVERK = 'DEKKET_AV_ANNET_REGELVERK',
+    NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
+    LØNNET = 'LØNNET',
+}
+
+export const begrunnelseTilTekst: Record<BegrunnelseGrunner, string> = {
+    MEDLEMSKAP: 'Medlemskap',
+    DEKKET_AV_ANNET_REGELVERK: 'Dekket av annet regelverk',
+    NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
+    LØNNET: 'Lønnet',
+};
+
+export const finnBegrunnelseGrunner = (
+    vilkårperiodeForm: EndreMålgruppeForm | EndreAktivitetForm
+): BegrunnelseGrunner[] => {
+    if (vilkårperiodeForm.delvilkår['@type'] === 'AKTIVITET') {
+        return finnBegrunnelseGrunnerAktivitet(vilkårperiodeForm.delvilkår);
+    } else if (erFormForMålgruppe(vilkårperiodeForm)) {
+        return finnBegrunnelseGrunnerMålgruppe(vilkårperiodeForm.type, vilkårperiodeForm.delvilkår);
+    } else return [];
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/utils.ts
@@ -12,9 +12,9 @@ export enum BegrunnelseGrunner {
 
 export const begrunnelseTilTekst: Record<BegrunnelseGrunner, string> = {
     MEDLEMSKAP: 'Medlemskap',
-    DEKKET_AV_ANNET_REGELVERK: 'Dekket av annet regelverk',
+    DEKKET_AV_ANNET_REGELVERK: 'Utgifter dekket av annet regelverk',
     NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
-    LØNNET: 'Lønnet',
+    LØNNET: 'Ordinær lønn i tiltaket',
 };
 
 export const finnBegrunnelseGrunner = (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/validering.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/validering.tsx
@@ -1,7 +1,11 @@
+import { finnBegrunnelseGrunner } from './EndreVilkårperiode/utils';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { Periode, validerPeriode } from '../../../../utils/periode';
 import { harTallverdi } from '../../../../utils/tall';
 import { harIkkeVerdi } from '../../../../utils/utils';
+import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
+import { erFormForAktivitet } from '../Aktivitet/utils';
+import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
 import { AktivitetType } from '../typer/aktivitet';
 import { MålgruppeType } from '../typer/målgruppe';
 
@@ -12,8 +16,7 @@ export interface EndreVilkårsperiode extends Periode {
 }
 
 export const validerVilkårsperiode = (
-    endretVilkårsperiode: EndreVilkårsperiode,
-    erBegrunnelseObligatorisk: boolean
+    endretVilkårsperiode: EndreMålgruppeForm | EndreAktivitetForm
 ): FormErrors<EndreVilkårsperiode> => {
     const feil: FormErrors<EndreVilkårsperiode> = {
         fom: undefined,
@@ -37,13 +40,15 @@ export const validerVilkårsperiode = (
     }
 
     if (
-        endretVilkårsperiode.type in AktivitetType &&
+        erFormForAktivitet(endretVilkårsperiode) &&
         !aktivitetsdagerErGyldigTall(endretVilkårsperiode.aktivitetsdager)
     ) {
         return { ...feil, aktivitetsdager: 'Aktivitetsdager må være et tall mellom 1 og 5' };
     }
 
-    if (erBegrunnelseObligatorisk && harIkkeVerdi(endretVilkårsperiode.begrunnelse))
+    const obligatoriskeBegrunnelser = finnBegrunnelseGrunner(endretVilkårsperiode);
+
+    if (obligatoriskeBegrunnelser.length > 0 && harIkkeVerdi(endretVilkårsperiode.begrunnelse))
         return { ...feil, begrunnelse: 'Begrunnelse er obligatorisk' };
 
     return feil;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/validering.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/validering.tsx
@@ -1,22 +1,26 @@
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { Periode, validerPeriode } from '../../../../utils/periode';
 import { harTallverdi } from '../../../../utils/tall';
+import { harIkkeVerdi } from '../../../../utils/utils';
 import { AktivitetType } from '../typer/aktivitet';
 import { MålgruppeType } from '../typer/målgruppe';
 
 export interface EndreVilkårsperiode extends Periode {
     type: AktivitetType | MålgruppeType | '';
     aktivitetsdager?: number;
+    begrunnelse?: string;
 }
 
 export const validerVilkårsperiode = (
-    endretVilkårsperiode: EndreVilkårsperiode
+    endretVilkårsperiode: EndreVilkårsperiode,
+    erBegrunnelseObligatorisk: boolean
 ): FormErrors<EndreVilkårsperiode> => {
     const feil: FormErrors<EndreVilkårsperiode> = {
         fom: undefined,
         tom: undefined,
         type: undefined,
         aktivitetsdager: undefined,
+        begrunnelse: undefined,
     };
 
     if (endretVilkårsperiode.type === '') {
@@ -38,6 +42,9 @@ export const validerVilkårsperiode = (
     ) {
         return { ...feil, aktivitetsdager: 'Aktivitetsdager må være et tall mellom 1 og 5' };
     }
+
+    if (erBegrunnelseObligatorisk && harIkkeVerdi(endretVilkårsperiode.begrunnelse))
+        return { ...feil, begrunnelse: 'Begrunnelse er obligatorisk' };
 
     return feil;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Om en begrunnelse er obligatorisk skal det listes opp grunnene til dette og gi en feilmelding dersom man prøver å lagre uten å fylle ut: 
<img width="1205" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/ee34288a-83d0-4da6-9876-3adea6164bc5">
