### PR TITLE
💄 Stønadsperioder skal ikke lenger vises som tabell

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -88,9 +88,9 @@ const Aktivitet: React.FC = () => {
             {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode((prevState) => !prevState)}
-                    size="small"
+                    size="xsmall"
                     style={{ maxWidth: 'fit-content' }}
-                    variant={skalViseAktiviteter ? 'secondary' : 'primary'}
+                    variant={skalViseAktiviteter ? 'tertiary' : 'primary'}
                     icon={<PlusCircleIcon />}
                 >
                     Legg til ny aktivitet

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -25,7 +25,7 @@ import { FanePath } from '../faner';
 const Container = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 2rem;
+    gap: 3rem;
     margin: 2rem;
 `;
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -88,9 +88,9 @@ const Målgruppe: React.FC = () => {
             {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
                 <Button
                     onClick={() => settLeggerTilNyPeriode(true)}
-                    size="small"
+                    size="xsmall"
                     style={{ maxWidth: 'fit-content' }}
-                    variant={skalViseMålgrupper ? 'secondary' : 'primary'}
+                    variant={skalViseMålgrupper ? 'tertiary' : 'primary'}
                     icon={<PlusCircleIcon />}
                 >
                     Legg til ny målgruppe

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
@@ -20,24 +20,22 @@ const Aksjonsknapper: React.FC<{
 }) => {
     if (redigerer) {
         return (
-            <HStack justify="space-between">
-                <HStack gap="2">
-                    <Button size="small" type="submit" disabled={laster}>
-                        Lagre
-                    </Button>
-                    <Button
-                        type="button"
-                        disabled={laster}
-                        onClick={avbrytRedigering}
-                        size="small"
-                        variant="secondary"
-                    >
-                        Avbryt
-                    </Button>
-                </HStack>
+            <HStack gap="2" align="center">
+                <Button size="small" type="submit" disabled={laster}>
+                    Lagre stønadsperioder
+                </Button>
+                <Button
+                    type="button"
+                    disabled={laster}
+                    onClick={avbrytRedigering}
+                    size="small"
+                    variant="secondary"
+                >
+                    Avbryt
+                </Button>
                 <Button
                     icon={<PlusCircleIcon />}
-                    size="small"
+                    size="xsmall"
                     onClick={(e) => {
                         e.preventDefault();
                         initierFormMedTomRad();

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { Button, Table } from '@navikt/ds-react';
+import { Button } from '@navikt/ds-react';
 
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
@@ -29,65 +29,57 @@ const StønadsperiodeRad: React.FC<Props> = ({
         feilmeldinger && feilmeldinger[property];
 
     return (
-        <Table.Row>
-            <Table.DataCell>
-                <SelectMedOptions
-                    erLesevisning={erLeservisning}
-                    valg={MålgruppeTypeOptions}
-                    label={'Målgruppe'}
-                    hideLabel
-                    value={stønadsperide.målgruppe}
-                    onChange={(e) => oppdaterStønadsperiode('målgruppe', e.target.value)}
-                    size="small"
-                    error={finnFeilmelding('målgruppe')}
+        <>
+            <SelectMedOptions
+                className="kolonne1"
+                erLesevisning={erLeservisning}
+                valg={MålgruppeTypeOptions}
+                label={'Målgruppe'}
+                hideLabel
+                value={stønadsperide.målgruppe}
+                onChange={(e) => oppdaterStønadsperiode('målgruppe', e.target.value)}
+                size="small"
+                error={finnFeilmelding('målgruppe')}
+            />
+
+            <SelectMedOptions
+                erLesevisning={erLeservisning}
+                valg={AktivitetTypeOptions}
+                label={'Aktivitet'}
+                hideLabel
+                value={stønadsperide.aktivitet}
+                onChange={(e) => oppdaterStønadsperiode('aktivitet', e.target.value)}
+                size="small"
+                error={finnFeilmelding('aktivitet')}
+            />
+            <DateInputMedLeservisning
+                erLesevisning={erLeservisning}
+                label={'Fra'}
+                hideLabel
+                value={stønadsperide.fom}
+                onChange={(dato) => oppdaterStønadsperiode('fom', dato || '')}
+                size="small"
+                feil={finnFeilmelding('fom')}
+            />
+            <DateInputMedLeservisning
+                erLesevisning={erLeservisning}
+                label={'Til'}
+                hideLabel
+                value={stønadsperide.tom}
+                onChange={(dato) => oppdaterStønadsperiode('tom', dato || '')}
+                size="small"
+                feil={finnFeilmelding('tom')}
+            />
+            {!erLeservisning && (
+                <Button
+                    type="button"
+                    onClick={slettPeriode}
+                    variant="tertiary"
+                    icon={<TrashIcon />}
+                    size="xsmall"
                 />
-            </Table.DataCell>
-            <Table.DataCell>
-                <SelectMedOptions
-                    erLesevisning={erLeservisning}
-                    valg={AktivitetTypeOptions}
-                    label={'Aktivitet'}
-                    hideLabel
-                    value={stønadsperide.aktivitet}
-                    onChange={(e) => oppdaterStønadsperiode('aktivitet', e.target.value)}
-                    size="small"
-                    error={finnFeilmelding('aktivitet')}
-                />
-            </Table.DataCell>
-            <Table.DataCell>
-                <DateInputMedLeservisning
-                    erLesevisning={erLeservisning}
-                    label={'Fra'}
-                    hideLabel
-                    value={stønadsperide.fom}
-                    onChange={(dato) => oppdaterStønadsperiode('fom', dato || '')}
-                    size="small"
-                    feil={finnFeilmelding('fom')}
-                />
-            </Table.DataCell>
-            <Table.DataCell>
-                <DateInputMedLeservisning
-                    erLesevisning={erLeservisning}
-                    label={'Til'}
-                    hideLabel
-                    value={stønadsperide.tom}
-                    onChange={(dato) => oppdaterStønadsperiode('tom', dato || '')}
-                    size="small"
-                    feil={finnFeilmelding('tom')}
-                />
-            </Table.DataCell>
-            <Table.DataCell>
-                {!erLeservisning && (
-                    <Button
-                        type="button"
-                        onClick={slettPeriode}
-                        variant="tertiary"
-                        icon={<TrashIcon />}
-                        size="xsmall"
-                    />
-                )}
-            </Table.DataCell>
-        </Table.Row>
+            )}
+        </>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -23,7 +23,7 @@ const Container = styled.div`
     gap: 1rem;
 `;
 
-const Grid = styled.div<{ $editMode: boolean }>`
+const Grid = styled.div`
     display: grid;
     grid-template-columns: repeat(5, max-content);
     grid-row-gap: 0.5rem;
@@ -136,7 +136,7 @@ const Stønadsperioder: React.FC = () => {
             <form onSubmit={formState.onSubmit(handleSubmit)}>
                 <VStack gap="4">
                     {stønadsperioderState.value.length !== 0 && (
-                        <Grid $editMode={redigerer}>
+                        <Grid>
                             <Label>Målgruppe</Label>
                             <Label>Aktivitet</Label>
                             <Label>Fra</Label>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -2,8 +2,7 @@ import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Table, VStack } from '@navikt/ds-react';
-import { AWhite } from '@navikt/ds-tokens/dist/tokens';
+import { Heading, Label, VStack } from '@navikt/ds-react';
 
 import Aksjonsknapper from './Aksjonsknapper';
 import StønadsperiodeRad from './StønadsperiodeRad';
@@ -15,12 +14,24 @@ import { useSteg } from '../../../../context/StegContext';
 import useFormState, { FormErrors, FormState } from '../../../../hooks/felles/useFormState';
 import { ListState } from '../../../../hooks/felles/useListState';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
-import Panel from '../../../../komponenter/Panel/Panel';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Stønadsperiode } from '../typer/stønadsperiode';
 
-const HvitTabell = styled(Table)`
-    background-color: ${AWhite};
+const Container = styled.div`
+    display: flex;
+    flex-direction: column;
+    gap: 1rem;
+`;
+
+const Grid = styled.div<{ $editMode: boolean }>`
+    display: grid;
+    grid-template-columns: repeat(5, max-content);
+    grid-row-gap: 0.5rem;
+    grid-column-gap: 1.5rem;
+
+    .kolonne1 {
+        grid-column: 1;
+    }
 `;
 
 export type StønadsperiodeForm = {
@@ -118,39 +129,36 @@ const Stønadsperioder: React.FC = () => {
     };
 
     return (
-        <Panel tittel="Stønadsperioder">
+        <Container>
+            <Heading spacing size="small">
+                Sett stønadsperioder
+            </Heading>
             <form onSubmit={formState.onSubmit(handleSubmit)}>
                 <VStack gap="4">
                     {stønadsperioderState.value.length !== 0 && (
-                        <HvitTabell size="small">
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.HeaderCell>Målgruppe</Table.HeaderCell>
-                                    <Table.HeaderCell>Aktivitet</Table.HeaderCell>
-                                    <Table.HeaderCell>Fra</Table.HeaderCell>
-                                    <Table.HeaderCell>Til</Table.HeaderCell>
-                                    <Table.HeaderCell />
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {stønadsperioderState.value.map((periode, indeks) => (
-                                    <StønadsperiodeRad
-                                        key={periode.id || indeks}
-                                        stønadsperide={periode}
-                                        oppdaterStønadsperiode={(
-                                            property: keyof Stønadsperiode,
-                                            value: string | undefined
-                                        ) => oppdaterStønadsperiode(indeks, property, value)}
-                                        slettPeriode={() => slettPeriode(indeks)}
-                                        feilmeldinger={
-                                            formState.errors.stønadsperioder &&
-                                            formState.errors.stønadsperioder[indeks]
-                                        }
-                                        erLeservisning={!erStegRedigerbart || !redigerer}
-                                    />
-                                ))}
-                            </Table.Body>
-                        </HvitTabell>
+                        <Grid $editMode={redigerer}>
+                            <Label>Målgruppe</Label>
+                            <Label>Aktivitet</Label>
+                            <Label>Fra</Label>
+                            <Label>Til</Label>
+
+                            {stønadsperioderState.value.map((periode, indeks) => (
+                                <StønadsperiodeRad
+                                    key={periode.id || indeks}
+                                    stønadsperide={periode}
+                                    oppdaterStønadsperiode={(
+                                        property: keyof Stønadsperiode,
+                                        value: string | undefined
+                                    ) => oppdaterStønadsperiode(indeks, property, value)}
+                                    slettPeriode={() => slettPeriode(indeks)}
+                                    feilmeldinger={
+                                        formState.errors.stønadsperioder &&
+                                        formState.errors.stønadsperioder[indeks]
+                                    }
+                                    erLeservisning={!erStegRedigerbart || !redigerer}
+                                />
+                            ))}
+                        </Grid>
                     )}
 
                     <Feilmelding>{stønadsperiodeFeil}</Feilmelding>
@@ -167,7 +175,7 @@ const Stønadsperioder: React.FC = () => {
                     )}
                 </VStack>
             </form>
-        </Panel>
+        </Container>
     );
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Siden vi har gått vekk fra tabelldesign på inngangsvilkår skal heller ikke stønadsperiodene ha dette. 

Det er en tanke om at lagring av stønadsperioder og ferdigstille steg skal slås sammen, men fordi det ikke var en quick fix å gjøre som å bare slette tabellen blir det en oppgave for senere. Ser litt rart ut atm fordi det er så mye knapper og den ikke har egen ramme/container, men er like mange klikk og samme flyt som før

Under redigering: 
<img width="1368" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/39b76d3e-414b-4b63-ad69-57c4f92bdd1f">

Ikke redigering: 
<img width="1368" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/a05df19c-e5cc-4bd3-a654-339161672e64">

<img width="1368" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/79973d4c-0732-4750-8ec5-3b56814c47c4">
