### PR TITLE
Vise aktivitet som fakta i venstremeny

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Aktivitet.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import { Informasjonskilde, Informasjonsrad, InfoSeksjon } from './Visningskomponenter';
+import { FaktaAktivtet } from '../../../../typer/behandling/behandlingFakta/faktaAktivitet';
+
+const Aktivitet: React.FC<{ aktivitet: FaktaAktivtet }> = ({ aktivitet }) => {
+    const aktiviteter = aktivitet.søknadsgrunnlag?.aktiviteter;
+    const annenAktivitet = aktivitet.søknadsgrunnlag?.annenAktivitet;
+    const erLønnetAktivitet = aktivitet.søknadsgrunnlag?.lønnetAktivitet;
+
+    return (
+        <>
+            <InfoSeksjon label="Valgte Aktiviteter">
+                {aktiviteter?.map((akt) => (
+                    <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={akt} />
+                ))}
+            </InfoSeksjon>
+            <InfoSeksjon label="Annen Aktivitet">
+                <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={annenAktivitet} />
+            </InfoSeksjon>
+            <InfoSeksjon label="Lønnet aktivitet?">
+                <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={erLønnetAktivitet} />
+            </InfoSeksjon>
+        </>
+    );
+};
+
+export default Aktivitet;

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Aktivitet.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { Informasjonskilde, Informasjonsrad, InfoSeksjon } from './Visningskomponenter';
+import { Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
 import { FaktaAktivtet } from '../../../../typer/behandling/behandlingFakta/faktaAktivitet';
 
 const Aktivitet: React.FC<{ aktivitet: FaktaAktivtet }> = ({ aktivitet }) => {
@@ -10,17 +10,21 @@ const Aktivitet: React.FC<{ aktivitet: FaktaAktivtet }> = ({ aktivitet }) => {
 
     return (
         <>
-            <InfoSeksjon label="Valgte Aktiviteter">
-                {aktiviteter?.map((akt) => (
-                    <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={akt} />
-                ))}
-            </InfoSeksjon>
-            <InfoSeksjon label="Annen Aktivitet">
-                <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={annenAktivitet} />
-            </InfoSeksjon>
-            <InfoSeksjon label="Lønnet aktivitet?">
-                <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={erLønnetAktivitet} />
-            </InfoSeksjon>
+            {aktiviteter?.map((akt) => (
+                <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={akt} />
+            ))}
+            {annenAktivitet && (
+                <Informasjonsrad
+                    kilde={Informasjonskilde.SØKNAD}
+                    verdi={`Annen aktivitet: ${annenAktivitet}`}
+                />
+            )}
+            {erLønnetAktivitet && (
+                <Informasjonsrad
+                    kilde={Informasjonskilde.SØKNAD}
+                    verdi={`Lønnet aktivitet: ${erLønnetAktivitet}`}
+                />
+            )}
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -2,6 +2,7 @@ import React, { useCallback, useEffect, useState } from 'react';
 
 import { VStack } from '@navikt/ds-react';
 
+import Aktivitet from './Aktivitet';
 import ArbeidOgOpphold from './ArbeidOgOpphold';
 import BarnDetaljer from './BarnDetaljer';
 import Vedlegg from './Vedlegg';
@@ -53,6 +54,7 @@ const Oppsummering: React.FC = () => {
 
                     <InfoSeksjon label="Aktivitet">
                         {/* TODO: Legg inn info om aktiviteter*/}
+                        <Aktivitet aktivitet={behandlingFakta.aktivitet}></Aktivitet>
                     </InfoSeksjon>
 
                     {behandlingFakta.barn.map((barn) => (

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Visningskomponenter.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Visningskomponenter.tsx
@@ -22,7 +22,7 @@ export const Informasjonsrad: React.FC<{
     verdi?: string | ReactNode;
 }> = ({ kilde, verdi = 'Ingen data registrert' }) => {
     return (
-        <HStack gap="2">
+        <HStack gap="2" wrap={false}>
             {mapIkon(kilde)}
             <BodyShort size="small">{verdi}</BodyShort>
         </HStack>

--- a/src/frontend/typer/behandling/behandlingFakta/faktaAktivitet.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaAktivitet.ts
@@ -1,5 +1,18 @@
+import { JaNei } from '../../common';
+
 export interface FaktaAktivtet {
     søknadsgrunnlag?: SøknadsgrunnlagAktivitet;
 }
 
-interface SøknadsgrunnlagAktivitet {}
+interface SøknadsgrunnlagAktivitet {
+    aktiviteter: string[];
+    annenAktivitet?: TypeAnnenAktivitet;
+    lønnetAktivitet?: JaNei;
+}
+
+export enum TypeAnnenAktivitet {
+    TILTAK = 'TILTAK',
+    UTDANNING = 'UTDANNING',
+    ARBEIDSSØKER = 'ARBEIDSSØKER',
+    INGEN_AKTIVITET = 'INGEN_AKTIVITET',
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vise aktivitet som fakta i venstremeny.

Denne PR testes sammen med: https://github.com/navikt/tilleggsstonader-sak/pull/295
****
### FØR:
<img width="643" alt="Skjermbilde 2024-04-29 kl  16 08 50" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/28704275/016671b2-a9ec-4a5c-afd4-c195cad70345">

****
### ETTER: 

<img width="642" alt="Skjermbilde 2024-04-29 kl  16 06 43" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/28704275/b4bc2c83-3590-4a6d-9c02-737591bccdd8">


****

