### PR TITLE
🐛 Skal bruke brevtittel som beskrivelse for frittstående brev

### DIFF
--- a/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
+++ b/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
@@ -35,13 +35,20 @@ const FrittståendeBrev: React.FC<{ valgtStønadstype: Stønadstype; fagsakId: s
     const [feilmelding, settFeilmelding] = useState<string>();
 
     const sendBrev = () => {
-        if (fil.status === RessursStatus.SUKSESS && brevmal) {
+        if (
+            fil.status === RessursStatus.SUKSESS &&
+            brevmaler.status === RessursStatus.SUKSESS &&
+            brevmal
+        ) {
+            const brevTittel = brevmaler.data.find((bm) => bm._id === brevmal)
+                ?.visningsnavn as string;
+
             request<null, { pdf: string; tittel: string }>(
                 `/api/sak/frittstaende-brev/send/${fagsakId}`,
                 'POST',
                 {
                     pdf: fil.data,
-                    tittel: brevmal,
+                    tittel: brevTittel,
                 }
             ).then((res) => {
                 if (res.status === RessursStatus.SUKSESS) {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal vise tittel i dokumentoversikt/gosys.

To første brev er sendt uten fix, det siste med:
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/e54c9312-b2f3-429e-8fee-a66d60169949)

