### PR TITLE
✨ Vedtak med resultat avslag 

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -11,6 +11,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import { useVedtak } from '../../../hooks/useVedtak';
 import DataViewer from '../../../komponenter/DataViewer';
 import { RessursStatus } from '../../../typer/ressurs';
+import { erVedtakInnvilgelse } from '../../../typer/vedtak';
 import SendTilBeslutterFooter from '../Totrinnskontroll/SendTilBeslutterFooter';
 
 const Container = styled.div`
@@ -58,7 +59,11 @@ const Brev: React.FC = () => {
                                             mellomlagretBrev={mellomlagretBrev}
                                             fil={fil}
                                             settFil={settFil}
-                                            beregningsresultat={vedtak.beregningsresultat}
+                                            beregningsresultat={
+                                                erVedtakInnvilgelse(vedtak)
+                                                    ? vedtak.beregningsresultat
+                                                    : undefined
+                                            }
                                         />
                                         <SendTilBeslutterFooter />
                                     </>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/AvslåVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/AvslåVedtak.tsx
@@ -45,6 +45,7 @@ const AvslåVedtak: React.FC<{ vedtak?: AvslagBarnetilsyn }> = ({ vedtak }) => {
                 onChange={(e) => settBegrunnelse(e.target.value)}
                 error={feilmelding}
                 readOnly={!erStegRedigerbart}
+                style={{ width: '40rem' }}
             />
 
             <StegKnapp

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/AvslåVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/AvslåVedtak.tsx
@@ -1,0 +1,61 @@
+import React, { useState } from 'react';
+
+import { Textarea } from '@navikt/ds-react';
+
+import { useApp } from '../../../../context/AppContext';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import { useSteg } from '../../../../context/StegContext';
+import { StegKnapp } from '../../../../komponenter/Stegflyt/StegKnapp';
+import { Steg } from '../../../../typer/behandling/steg';
+import { AvslagBarnetilsyn, AvslåBarnetilsynRequest } from '../../../../typer/vedtak';
+import { harVerdi } from '../../../../utils/utils';
+import { FanePath } from '../../faner';
+
+const AvslåVedtak: React.FC<{ vedtak?: AvslagBarnetilsyn }> = ({ vedtak }) => {
+    const { behandling } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
+    const { request } = useApp();
+
+    const [begrunnelse, settBegrunnelse] = useState<string>(vedtak?.begrunnelse || '');
+    const [feilmelding, settFeilmelding] = useState<string | undefined>();
+
+    const lagreVedtak = () => {
+        return request<null, AvslåBarnetilsynRequest>(
+            `/api/sak/vedtak/tilsyn-barn/${behandling.id}/avslag`,
+            'POST',
+            { begrunnelse: begrunnelse }
+        );
+    };
+
+    const validerOgLagreVedtak = () => {
+        if (!harVerdi(begrunnelse)) {
+            settFeilmelding('Begrunnelse for avslag må fylles ut');
+            return Promise.reject();
+        } else {
+            settFeilmelding(undefined);
+            return lagreVedtak();
+        }
+    };
+
+    return (
+        <>
+            <Textarea
+                label="Begrunnelse for avslag"
+                value={begrunnelse}
+                onChange={(e) => settBegrunnelse(e.target.value)}
+                error={feilmelding}
+                readOnly={!erStegRedigerbart}
+            />
+
+            <StegKnapp
+                steg={Steg.BEREGNE_YTELSE}
+                nesteFane={FanePath.BREV}
+                onNesteSteg={validerOgLagreVedtak}
+            >
+                Lagre vedtak og gå videre
+            </StegKnapp>
+        </>
+    );
+};
+
+export default AvslåVedtak;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -21,7 +21,8 @@ import { Steg } from '../../../../../typer/behandling/steg';
 import { byggTomRessurs, RessursFeilet, RessursSuksess } from '../../../../../typer/ressurs';
 import {
     BeregningsresultatTilsynBarn,
-    InnvilgeVedtakForBarnetilsyn,
+    InnvilgeBarnetilsynRequest,
+    InnvilgelseBarnetilsyn,
     Utgift,
 } from '../../../../../typer/vedtak';
 import { FanePath } from '../../../faner';
@@ -38,7 +39,7 @@ const Knapp = styled(Button)`
 
 const initUtgifter = (
     barnMedOppfylteVilkår: GrunnlagBarn[],
-    vedtak?: InnvilgeVedtakForBarnetilsyn
+    vedtak?: InnvilgelseBarnetilsyn
 ): Record<string, Utgift[]> =>
     barnMedOppfylteVilkår.reduce((acc, barn) => {
         const utgiftForBarn = vedtak?.utgifter?.[barn.barnId];
@@ -49,14 +50,14 @@ const initUtgifter = (
     }, {});
 
 const initFormState = (
-    vedtak: InnvilgeVedtakForBarnetilsyn | undefined,
+    vedtak: InnvilgelseBarnetilsyn | undefined,
     barnMedOppfylteVilkår: GrunnlagBarn[]
 ) => ({
     utgifter: initUtgifter(barnMedOppfylteVilkår, vedtak),
 });
 
 interface Props {
-    lagretVedtak?: InnvilgeVedtakForBarnetilsyn;
+    lagretVedtak?: InnvilgelseBarnetilsyn;
     settResultatType: (val: BehandlingResultat | undefined) => void;
     låsFraDatoFørsteRad: boolean;
     barnMedOppfylteVilkår: GrunnlagBarn[];
@@ -67,7 +68,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
     const { behandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
     // TODO: Prøve å slippe denne castingen
-    const lagretInnvilgetVedtak = lagretVedtak as InnvilgeVedtakForBarnetilsyn;
+    const lagretInnvilgetVedtak = lagretVedtak as InnvilgelseBarnetilsyn;
 
     const formState = useFormState<InnvilgeVedtakForm>(
         initFormState(lagretInnvilgetVedtak, barnMedOppfylteVilkår),
@@ -94,9 +95,9 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
         // eslint-disable-next-line
     }, [lagretInnvilgetVedtak]);
 
-    const lagreVedtak = (vedtaksRequest: InnvilgeVedtakForBarnetilsyn) => {
+    const lagreVedtak = (vedtaksRequest: InnvilgeBarnetilsynRequest) => {
         settLaster(true);
-        return request<null, InnvilgeVedtakForBarnetilsyn>(
+        return request<null, InnvilgeBarnetilsynRequest>(
             `/api/sak/vedtak/tilsyn-barn/${behandling.id}`,
             'POST',
             vedtaksRequest
@@ -119,7 +120,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
             const vedtaksRequest = lagVedtakRequest({
                 utgifter: utgifterState.value,
             });
-            request<BeregningsresultatTilsynBarn, InnvilgeVedtakForBarnetilsyn>(
+            request<BeregningsresultatTilsynBarn, InnvilgeBarnetilsynRequest>(
                 `/api/sak/vedtak/tilsyn-barn/${behandling.id}/beregn`,
                 'POST',
                 vedtaksRequest

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -72,31 +72,15 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
 
     const utgifterState = formState.getProps('utgifter') as RecordState<Utgift[]>;
 
-    const [laster, settLaster] = useState<boolean>(false);
     const [beregningsresultat, settBeregningsresultat] =
         useState(byggTomRessurs<BeregningsresultatTilsynBarn>());
 
-    // TODO: Finn ut hva denne gjør
-    useEffect(() => {
-        if (!lagretVedtak && laster) {
-            return;
-        }
-        // utgiftsperiodeState.setValue(initUtgiftsperioder(lagretInnvilgetVedtak));
-        formState.setErrors((prevState) => ({
-            ...prevState,
-            utgiftsperioder: [],
-        }));
-
-        // eslint-disable-next-line
-    }, [lagretVedtak]);
-
     const lagreVedtak = (vedtaksRequest: InnvilgeBarnetilsynRequest) => {
-        settLaster(true);
         return request<null, InnvilgeBarnetilsynRequest>(
             `/api/sak/vedtak/tilsyn-barn/${behandling.id}`,
             'POST',
             vedtaksRequest
-        ).finally(() => settLaster(false));
+        );
     };
 
     const validerOgLagreVedtak = (): Promise<RessursSuksess<unknown> | RessursFeilet> => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -64,11 +64,9 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
     const { request } = useApp();
     const { behandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
-    // TODO: Prøve å slippe denne castingen
-    const lagretInnvilgetVedtak = lagretVedtak as InnvilgelseBarnetilsyn;
 
     const formState = useFormState<InnvilgeVedtakForm>(
-        initFormState(lagretInnvilgetVedtak, barnMedOppfylteVilkår),
+        initFormState(lagretVedtak, barnMedOppfylteVilkår),
         validerInnvilgetVedtakForm
     );
 
@@ -80,7 +78,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
 
     // TODO: Finn ut hva denne gjør
     useEffect(() => {
-        if (!lagretInnvilgetVedtak && laster) {
+        if (!lagretVedtak && laster) {
             return;
         }
         // utgiftsperiodeState.setValue(initUtgiftsperioder(lagretInnvilgetVedtak));
@@ -90,7 +88,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
         }));
 
         // eslint-disable-next-line
-    }, [lagretInnvilgetVedtak]);
+    }, [lagretVedtak]);
 
     const lagreVedtak = (vedtaksRequest: InnvilgeBarnetilsynRequest) => {
         settLaster(true);
@@ -153,10 +151,8 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, barnMedOppf
                             </DataViewer>
                         </>
                     )}
-                    {!erStegRedigerbart && lagretInnvilgetVedtak?.beregningsresultat && (
-                        <Beregningsresultat
-                            beregningsresultat={lagretInnvilgetVedtak?.beregningsresultat}
-                        />
+                    {!erStegRedigerbart && lagretVedtak?.beregningsresultat && (
+                        <Beregningsresultat beregningsresultat={lagretVedtak?.beregningsresultat} />
                     )}
                 </VStack>
             </Panel>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -16,7 +16,6 @@ import DataViewer from '../../../../../komponenter/DataViewer';
 import Panel from '../../../../../komponenter/Panel/Panel';
 import { Skillelinje } from '../../../../../komponenter/Skillelinje';
 import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
-import { BehandlingResultat } from '../../../../../typer/behandling/behandlingResultat';
 import { Steg } from '../../../../../typer/behandling/steg';
 import { byggTomRessurs, RessursFeilet, RessursSuksess } from '../../../../../typer/ressurs';
 import {
@@ -58,8 +57,6 @@ const initFormState = (
 
 interface Props {
     lagretVedtak?: InnvilgelseBarnetilsyn;
-    settResultatType: (val: BehandlingResultat | undefined) => void;
-    låsFraDatoFørsteRad: boolean;
     barnMedOppfylteVilkår: GrunnlagBarn[];
 }
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -4,12 +4,12 @@ import { InnvilgeBarnetilsyn } from './InnvilgeBarnetilsyn';
 import { useVilkår } from '../../../../../context/VilkårContext';
 import DataViewer from '../../../../../komponenter/DataViewer';
 import { BehandlingResultat } from '../../../../../typer/behandling/behandlingResultat';
-import { InnvilgeVedtakForBarnetilsyn } from '../../../../../typer/vedtak';
+import { InnvilgelseBarnetilsyn } from '../../../../../typer/vedtak';
 import { barnSomOppfyllerAlleVilkår } from '../utils';
 
 interface Props {
     settResultatType: (val: BehandlingResultat | undefined) => void;
-    lagretVedtak?: InnvilgeVedtakForBarnetilsyn;
+    lagretVedtak?: InnvilgelseBarnetilsyn;
 }
 
 export const InnvilgeVedtak: FC<Props> = ({ settResultatType, lagretVedtak }) => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -3,16 +3,14 @@ import React, { FC } from 'react';
 import { InnvilgeBarnetilsyn } from './InnvilgeBarnetilsyn';
 import { useVilkår } from '../../../../../context/VilkårContext';
 import DataViewer from '../../../../../komponenter/DataViewer';
-import { BehandlingResultat } from '../../../../../typer/behandling/behandlingResultat';
 import { InnvilgelseBarnetilsyn } from '../../../../../typer/vedtak';
 import { barnSomOppfyllerAlleVilkår } from '../utils';
 
 interface Props {
-    settResultatType: (val: BehandlingResultat | undefined) => void;
     lagretVedtak?: InnvilgelseBarnetilsyn;
 }
 
-export const InnvilgeVedtak: FC<Props> = ({ settResultatType, lagretVedtak }) => {
+export const InnvilgeVedtak: FC<Props> = ({ lagretVedtak }) => {
     const { vilkårsvurdering } = useVilkår();
 
     return (
@@ -20,8 +18,6 @@ export const InnvilgeVedtak: FC<Props> = ({ settResultatType, lagretVedtak }) =>
         <DataViewer response={{ vilkårsvurdering }}>
             {({ vilkårsvurdering }) => (
                 <InnvilgeBarnetilsyn
-                    settResultatType={settResultatType}
-                    låsFraDatoFørsteRad={false}
                     barnMedOppfylteVilkår={barnSomOppfyllerAlleVilkår(vilkårsvurdering)}
                     lagretVedtak={lagretVedtak}
                 />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeVedtak.tsx
@@ -14,7 +14,6 @@ export const InnvilgeVedtak: FC<Props> = ({ lagretVedtak }) => {
     const { vilkårsvurdering } = useVilkår();
 
     return (
-        // TODO: Revurderes fra og med
         <DataViewer response={{ vilkårsvurdering }}>
             {({ vilkårsvurdering }) => (
                 <InnvilgeBarnetilsyn

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -2,12 +2,13 @@ import React, { FC, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
+import AvslåVedtak from './AvslåVedtak';
 import { InnvilgeVedtak } from './InnvilgeVedtak/InnvilgeVedtak';
 import { useVedtak } from '../../../../hooks/useVedtak';
 import DataViewer from '../../../../komponenter/DataViewer';
 import Panel from '../../../../komponenter/Panel/Panel';
-import { BehandlingResultat } from '../../../../typer/behandling/behandlingResultat';
 import { RessursStatus } from '../../../../typer/ressurs';
+import { AvslagBarnetilsyn, InnvilgelseBarnetilsyn, TypeVedtak } from '../../../../typer/vedtak';
 import SelectVedtaksresultat from '../Felles/SelectVedtaksresultat';
 
 const Container = styled.div`
@@ -20,28 +21,25 @@ const Container = styled.div`
 const VedtakOgBeregningBarnetilsyn: FC = () => {
     const { vedtak } = useVedtak();
 
-    const [resultatType, settResultatType] = useState<BehandlingResultat | undefined>();
+    const [typeVedtak, settTypeVedtak] = useState<TypeVedtak | undefined>();
 
     useEffect(() => {
-        // TODO: Oppdater sjekk av resultat når flere implementeres
-        // Sjekker at utgifter eksisterer så resultat kun settes til innvilget om det finnes data
-        if (vedtak.status === RessursStatus.SUKSESS && vedtak.data.utgifter) {
-            settResultatType(BehandlingResultat.INNVILGET);
+        if (vedtak.status === RessursStatus.SUKSESS) {
+            settTypeVedtak(vedtak.data.type);
         }
     }, [vedtak]);
 
     return (
         <Container>
-            {/* TODO: Send inn korrekt resultat */}
             <Panel tittel="Vedtak">
                 <SelectVedtaksresultat
-                    resultatVedtak={resultatType}
-                    settResultatVedtak={settResultatType}
+                    resultatVedtak={typeVedtak}
+                    settResultatVedtak={settTypeVedtak}
                 />
             </Panel>
             <DataViewer response={{ vedtak }}>
                 {({ vedtak }) => {
-                    switch (resultatVedtak) {
+                    switch (typeVedtak) {
                         case TypeVedtak.INNVILGET:
                             return (
                                 <InnvilgeVedtak lagretVedtak={vedtak as InnvilgelseBarnetilsyn} />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -35,20 +35,20 @@ const VedtakOgBeregningBarnetilsyn: FC = () => {
             {/* TODO: Send inn korrekt resultat */}
             <Panel tittel="Vedtak">
                 <SelectVedtaksresultat
-                    resultatType={resultatType}
-                    settResultatType={settResultatType}
+                    resultatVedtak={resultatType}
+                    settResultatVedtak={settResultatType}
                 />
             </Panel>
             <DataViewer response={{ vedtak }}>
                 {({ vedtak }) => {
-                    switch (resultatType) {
-                        case BehandlingResultat.INNVILGET:
+                    switch (resultatVedtak) {
+                        case TypeVedtak.INNVILGET:
                             return (
-                                <InnvilgeVedtak
-                                    settResultatType={settResultatType}
-                                    lagretVedtak={vedtak}
-                                />
+                                <InnvilgeVedtak lagretVedtak={vedtak as InnvilgelseBarnetilsyn} />
                             );
+
+                        case TypeVedtak.AVSLÅTT:
+                            return <AvslåVedtak vedtak={vedtak as AvslagBarnetilsyn} />;
 
                         case undefined:
                             return null;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -40,12 +40,12 @@ const VedtakOgBeregningBarnetilsyn: FC = () => {
             <DataViewer response={{ vedtak }}>
                 {({ vedtak }) => {
                     switch (typeVedtak) {
-                        case TypeVedtak.INNVILGET:
+                        case TypeVedtak.INNVILGELSE:
                             return (
                                 <InnvilgeVedtak lagretVedtak={vedtak as InnvilgelseBarnetilsyn} />
                             );
 
-                        case TypeVedtak.AVSLÅTT:
+                        case TypeVedtak.AVSLAG:
                             return <AvslåVedtak vedtak={vedtak as AvslagBarnetilsyn} />;
 
                         case undefined:

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -2,7 +2,7 @@ import { v4 as uuidv4 } from 'uuid';
 
 import { InnvilgeVedtakForm } from './InnvilgeVedtak/InnvilgeBarnetilsyn';
 import { FormState } from '../../../../hooks/felles/useFormState';
-import { InnvilgeVedtakForBarnetilsyn, Utgift } from '../../../../typer/vedtak';
+import { InnvilgeBarnetilsynRequest, Utgift } from '../../../../typer/vedtak';
 import { GrunnlagBarn, Vilkårsresultat, Vilkårsvurdering } from '../../vilkår';
 
 export const tomUtgiftPerBarn = (barnIBehandling: GrunnlagBarn[]): Record<string, Utgift[]> =>
@@ -29,7 +29,7 @@ export const leggTilTomRadUnderIListe = <T>(liste: T[], nyRad: T, indeks: number
 
 export const lagVedtakRequest = (
     form: FormState<InnvilgeVedtakForm>
-): InnvilgeVedtakForBarnetilsyn => {
+): InnvilgeBarnetilsynRequest => {
     return {
         utgifter: form.utgifter,
     };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -6,8 +6,7 @@ import { Heading } from '@navikt/ds-react';
 
 import { useSteg } from '../../../../context/StegContext';
 import Select from '../../../../komponenter/Skjema/Select';
-import { behandlingResultatTilTekst } from '../../../../typer/behandling/behandlingResultat';
-import { TypeVedtak } from '../../../../typer/vedtak';
+import { TypeVedtak, typeVedtakTilTekst } from '../../../../typer/vedtak';
 
 const Container = styled.div`
     width: max-content;
@@ -40,12 +39,12 @@ const SelectVedtaksresultat: FC<Props> = ({
                     settResultatType(vedtaksresultat);
                     // settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                 }}
-                lesevisningVerdi={resultatType && behandlingResultatTilTekst[resultatType]}
+                lesevisningVerdi={resultatType && typeVedtakTilTekst[resultatType]}
                 size="small"
             >
                 <option value="">Velg</option>
-                <option value={TypeVedtak.INNVILGET}>Innvilge</option>
-                <option value={TypeVedtak.AVSLÅTT}>Avslå</option>
+                <option value={TypeVedtak.INNVILGELSE}>Innvilge</option>
+                <option value={TypeVedtak.AVSLAG}>Avslå</option>
             </Select>
         </Container>
     );

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -6,20 +6,21 @@ import { Heading } from '@navikt/ds-react';
 
 import { useSteg } from '../../../../context/StegContext';
 import Select from '../../../../komponenter/Skjema/Select';
-import {
-    BehandlingResultat,
-    behandlingResultatTilTekst,
-} from '../../../../typer/behandling/behandlingResultat';
+import { behandlingResultatTilTekst } from '../../../../typer/behandling/behandlingResultat';
+import { TypeVedtak } from '../../../../typer/vedtak';
 
 const Container = styled.div`
     width: max-content;
 `;
 interface Props {
-    resultatType?: BehandlingResultat;
-    settResultatType: (val: BehandlingResultat | undefined) => void;
+    resultatVedtak?: TypeVedtak;
+    settResultatVedtak: (val: TypeVedtak | undefined) => void;
 }
 
-const SelectVedtaksresultat: FC<Props> = ({ resultatType, settResultatType }) => {
+const SelectVedtaksresultat: FC<Props> = ({
+    resultatVedtak: resultatType,
+    settResultatVedtak: settResultatType,
+}) => {
     const { erStegRedigerbart } = useSteg();
     // const { settIkkePersistertKomponent } = useApp();
 
@@ -35,7 +36,7 @@ const SelectVedtaksresultat: FC<Props> = ({ resultatType, settResultatType }) =>
                 value={resultatType || ''}
                 onChange={(e) => {
                     const vedtaksresultat =
-                        e.target.value === '' ? undefined : (e.target.value as BehandlingResultat);
+                        e.target.value === '' ? undefined : (e.target.value as TypeVedtak);
                     settResultatType(vedtaksresultat);
                     // settIkkePersistertKomponent(VEDTAK_OG_BEREGNING);
                 }}
@@ -43,7 +44,8 @@ const SelectVedtaksresultat: FC<Props> = ({ resultatType, settResultatType }) =>
                 size="small"
             >
                 <option value="">Velg</option>
-                <option value={BehandlingResultat.INNVILGET}>Innvilge</option>
+                <option value={TypeVedtak.INNVILGET}>Innvilge</option>
+                <option value={TypeVedtak.AVSLÅTT}>Avslå</option>
             </Select>
         </Container>
     );

--- a/src/frontend/hooks/useVedtak.ts
+++ b/src/frontend/hooks/useVedtak.ts
@@ -3,23 +3,23 @@ import { useCallback, useEffect, useState } from 'react';
 import { useApp } from '../context/AppContext';
 import { useBehandling } from '../context/BehandlingContext';
 import { Ressurs, byggTomRessurs } from '../typer/ressurs';
-import { InnvilgeVedtakForBarnetilsyn } from '../typer/vedtak';
+import { VedtakBarnetilsyn } from '../typer/vedtak';
 
 interface Response {
     hentVedtak: (behandlingId: string) => void;
-    vedtak: Ressurs<InnvilgeVedtakForBarnetilsyn>;
+    vedtak: Ressurs<VedtakBarnetilsyn>;
 }
 
 export const useVedtak = (): Response => {
     const { request } = useApp();
     const { behandling } = useBehandling();
 
-    const [vedtak, settVedtak] = useState<Ressurs<InnvilgeVedtakForBarnetilsyn>>(byggTomRessurs());
+    const [vedtak, settVedtak] = useState<Ressurs<VedtakBarnetilsyn>>(byggTomRessurs());
 
     const hentVedtak = useCallback(() => {
-        request<InnvilgeVedtakForBarnetilsyn, null>(
-            `/api/sak/vedtak/tilsyn-barn/${behandling.id}`
-        ).then(settVedtak);
+        request<VedtakBarnetilsyn, null>(`/api/sak/vedtak/tilsyn-barn/${behandling.id}`).then(
+            settVedtak
+        );
     }, [behandling, request]);
 
     useEffect(() => {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -1,12 +1,17 @@
 export enum TypeVedtak {
-    INNVILGET = 'INNVILGET',
-    AVSLÅTT = 'AVSLÅTT',
+    INNVILGELSE = 'INNVILGELSE',
+    AVSLAG = 'AVSLAG',
 }
+
+export const typeVedtakTilTekst: Record<TypeVedtak, string> = {
+    INNVILGELSE: 'Innvilgelse',
+    AVSLAG: 'Avslag',
+};
 
 export type VedtakBarnetilsyn = InnvilgelseBarnetilsyn | AvslagBarnetilsyn;
 
 export const erVedtakInnvilgelse = (vedtak: VedtakBarnetilsyn): vedtak is InnvilgelseBarnetilsyn =>
-    vedtak.type === TypeVedtak.INNVILGET;
+    vedtak.type === TypeVedtak.INNVILGELSE;
 
 export type InnvilgeBarnetilsynRequest = {
     utgifter: Record<string, Utgift[]>;
@@ -14,7 +19,7 @@ export type InnvilgeBarnetilsynRequest = {
 };
 
 export interface InnvilgelseBarnetilsyn extends InnvilgeBarnetilsynRequest {
-    type: TypeVedtak.INNVILGET;
+    type: TypeVedtak.INNVILGELSE;
 }
 
 export type AvslåBarnetilsynRequest = {
@@ -22,7 +27,7 @@ export type AvslåBarnetilsynRequest = {
 };
 
 export interface AvslagBarnetilsyn extends AvslåBarnetilsynRequest {
-    type: TypeVedtak.AVSLÅTT;
+    type: TypeVedtak.AVSLAG;
 }
 
 export type Stønadsperiode = {

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -1,11 +1,29 @@
-export enum VedtakType {
-    InnvilgelseBarnetilsyn = 'InnvilgelseBarnetilsyn',
+export enum TypeVedtak {
+    INNVILGET = 'INNVILGET',
+    AVSLÅTT = 'AVSLÅTT',
 }
 
-export type InnvilgeVedtakForBarnetilsyn = {
+export type VedtakBarnetilsyn = InnvilgelseBarnetilsyn | AvslagBarnetilsyn;
+
+export const erVedtakInnvilgelse = (vedtak: VedtakBarnetilsyn): vedtak is InnvilgelseBarnetilsyn =>
+    vedtak.type === TypeVedtak.INNVILGET;
+
+export type InnvilgeBarnetilsynRequest = {
     utgifter: Record<string, Utgift[]>;
     beregningsresultat?: BeregningsresultatTilsynBarn;
 };
+
+export interface InnvilgelseBarnetilsyn extends InnvilgeBarnetilsynRequest {
+    type: TypeVedtak.INNVILGET;
+}
+
+export type AvslåBarnetilsynRequest = {
+    begrunnelse: string;
+};
+
+export interface AvslagBarnetilsyn extends AvslåBarnetilsynRequest {
+    type: TypeVedtak.AVSLÅTT;
+}
 
 export type Stønadsperiode = {
     fom: string;

--- a/src/frontend/utils/utils.ts
+++ b/src/frontend/utils/utils.ts
@@ -1,6 +1,7 @@
 export const harIkkeVerdi = (str: string | undefined | null): boolean => !harVerdi(str);
 
-export const harVerdi = (str: string | undefined | null): boolean => !!str && str.trim() !== '';
+export const harVerdi = (str: string | undefined | null): str is string =>
+    !!str && str.trim() !== '';
 
 export const fjernSpaces = (str: string) => str.replace(/ /g, '');
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal være mulig å sette et vedtak til avslag. Hører sammen med [PR 296 i sak](https://github.com/navikt/tilleggsstonader-sak/pull/296).

Var ingen skisser på dette enda, så har kun laget et tekstfelt med begrunnelse som tekstfelt som en start, med read only for leservisning. 

### Bilder: 
<img width="1400" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/1171d72f-848c-497b-a539-fad3619f5d3b">

Om steget ikke er redigerbart/leservisning: 
<img width="1400" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/0a6f7bd4-fb7b-41d8-ad55-6b2a20688bc6">
