### PR TITLE
Avslag: Ingen målgruppe eller ingen aktivitet ❌

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -119,24 +119,26 @@ const EndreAktivitetRad: React.FC<{
             oppdaterType={(nyttValg) => oppdaterType(nyttValg as AktivitetType)}
             feilmelding={feilmelding}
             ekstraCeller={
-                <TextField
-                    erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
-                    label="Aktivitetsdager"
-                    value={
-                        harTallverdi(aktivitetForm.aktivitetsdager)
-                            ? aktivitetForm.aktivitetsdager
-                            : ''
-                    }
-                    onChange={(event) =>
-                        settAktivitetForm((prevState) => ({
-                            ...prevState,
-                            aktivitetsdager: tilHeltall(event.target.value),
-                        }))
-                    }
-                    size="small"
-                    error={vilkårsperiodeFeil?.aktivitetsdager}
-                    autoComplete="off"
-                />
+                aktivitetForm.type !== AktivitetType.INGEN_AKTIVITET && (
+                    <TextField
+                        erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
+                        label="Aktivitetsdager"
+                        value={
+                            harTallverdi(aktivitetForm.aktivitetsdager)
+                                ? aktivitetForm.aktivitetsdager
+                                : ''
+                        }
+                        onChange={(event) =>
+                            settAktivitetForm((prevState) => ({
+                                ...prevState,
+                                aktivitetsdager: tilHeltall(event.target.value),
+                            }))
+                        }
+                        size="small"
+                        error={vilkårsperiodeFeil?.aktivitetsdager}
+                        autoComplete="off"
+                    />
+                )
             }
         >
             <AktivitetVilkår

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import AktivitetVilkår from './AktivitetVilkår';
-import { nyAktivitet, resetDelvilkår } from './utils';
+import { nyAktivitet, resettAktivitet } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -104,11 +104,7 @@ const EndreAktivitetRad: React.FC<{
     };
 
     const oppdaterType = (type: AktivitetType) => {
-        settAktivitetForm((prevState) => ({
-            ...prevState,
-            type: type,
-            delvilkår: resetDelvilkår(type, prevState.delvilkår),
-        }));
+        settAktivitetForm((prevState) => resettAktivitet(type, prevState));
     };
 
     return (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -6,6 +6,7 @@ import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
+import { useTriggRerendringAvDateInput } from '../../../../hooks/useTriggRerendringAvDateInput';
 import TextField from '../../../../komponenter/Skjema/TextField';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
@@ -47,6 +48,10 @@ const EndreAktivitetRad: React.FC<{
     const { request } = useApp();
     const { behandling } = useBehandling();
     const { oppdaterAktivitet, leggTilAktivitet, settStønadsperiodeFeil } = useInngangsvilkår();
+    const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
+        useTriggRerendringAvDateInput();
+    const { keyDato: tomKeyDato, oppdaterDatoKey: oppdaterTomDatoKey } =
+        useTriggRerendringAvDateInput();
 
     const [aktivitetForm, settAktivitetForm] = useState<EndreAktivitetForm>(
         initaliserForm(behandling.id, aktivitet)
@@ -105,6 +110,8 @@ const EndreAktivitetRad: React.FC<{
 
     const oppdaterType = (type: AktivitetType) => {
         settAktivitetForm((prevState) => resettAktivitet(type, prevState));
+        oppdaterFomDatoKey();
+        oppdaterTomDatoKey();
     };
 
     return (
@@ -118,6 +125,8 @@ const EndreAktivitetRad: React.FC<{
             typeOptions={AktivitetTypeOptions}
             oppdaterType={(nyttValg) => oppdaterType(nyttValg as AktivitetType)}
             feilmelding={feilmelding}
+            fomKeyDato={fomKeyDato}
+            tomKeyDato={tomKeyDato}
             ekstraCeller={
                 aktivitetForm.type !== AktivitetType.INGEN_AKTIVITET && (
                     <TextField

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -61,11 +61,18 @@ const resetDelvilkår = (
     lønnet: skalVurdereLønnet(type) ? delvilkår.lønnet : undefined,
 });
 
-export const finnBegrunnelseGrunnerAktivitet = (delvilkår: DelvilkårAktivitet) => {
+export const finnBegrunnelseGrunnerAktivitet = (
+    type: AktivitetType | '',
+    delvilkår: DelvilkårAktivitet
+) => {
     const delvilkårSomMåBegrunnes = [];
 
     if (delvilkår.lønnet?.svar === SvarJaNei.JA) {
         delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.NEDSATT_ARBEIDSEVNE);
+    }
+
+    if (type === AktivitetType.INGEN_AKTIVITET) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.INGEN_AKTIVITET);
     }
 
     return delvilkårSomMåBegrunnes;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -1,5 +1,6 @@
 import { EndreAktivitetForm } from './EndreAktivitetRad';
 import { dagensDato, treMånederTilbake } from '../../../../utils/dato';
+import { Periode } from '../../../../utils/periode';
 import { harTallverdi } from '../../../../utils/tall';
 import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
 import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
@@ -22,37 +23,30 @@ export const skalVurdereLønnet = (type: AktivitetType | '') => type === Aktivit
 export const resettAktivitet = (
     nyType: AktivitetType,
     eksisterendeAktivitetForm: EndreAktivitetForm
-): EndreAktivitetForm => ({
-    ...eksisterendeAktivitetForm,
-    type: nyType,
-    fom: resetFom(nyType, eksisterendeAktivitetForm),
-    tom: resetTom(nyType, eksisterendeAktivitetForm),
-    aktivitetsdager: resetAktivitetsdager(nyType, eksisterendeAktivitetForm),
-    delvilkår: resetDelvilkår(nyType, eksisterendeAktivitetForm.delvilkår),
-});
+): EndreAktivitetForm => {
+    const { fom, tom } = resetPeriode(nyType, eksisterendeAktivitetForm);
 
-const resetFom = (type: AktivitetType, eksisterendeForm: EndreAktivitetForm) => {
-    if (type === AktivitetType.INGEN_AKTIVITET) {
-        return treMånederTilbake();
-    }
-
-    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.fom);
+    return {
+        ...eksisterendeAktivitetForm,
+        type: nyType,
+        fom: fom,
+        tom: tom,
+        aktivitetsdager: resetAktivitetsdager(nyType, eksisterendeAktivitetForm),
+        delvilkår: resetDelvilkår(nyType, eksisterendeAktivitetForm.delvilkår),
+    };
 };
 
-const resetTom = (type: AktivitetType, eksisterendeForm: EndreAktivitetForm) => {
-    if (type === AktivitetType.INGEN_AKTIVITET) {
-        return dagensDato();
+const resetPeriode = (nyType: string, eksisterendeForm: EndreAktivitetForm): Periode => {
+    if (nyType === AktivitetType.INGEN_AKTIVITET) {
+        return { fom: treMånederTilbake(), tom: dagensDato() };
     }
 
-    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.tom);
-};
-
-const resetEllerBeholdDato = (forrigeType: AktivitetType | '', forrigeDato: string) => {
-    if (forrigeType === AktivitetType.INGEN_AKTIVITET) {
-        return '';
+    if (eksisterendeForm.type === AktivitetType.INGEN_AKTIVITET) {
+        // Resetter datoer om de forrige var satt automatisk
+        return { fom: '', tom: '' };
     }
 
-    return forrigeDato;
+    return { fom: eksisterendeForm.fom, tom: eksisterendeForm.tom };
 };
 
 const resetAktivitetsdager = (nyType: AktivitetType, eksisterendeForm: EndreAktivitetForm) => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -1,4 +1,5 @@
 import { EndreAktivitetForm } from './EndreAktivitetRad';
+import { dagensDato, treMånederTilbake } from '../../../../utils/dato';
 import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
 import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
 import { SvarJaNei } from '../typer/vilkårperiode';
@@ -17,7 +18,42 @@ export const nyAktivitet = (behandlingId: string): EndreAktivitetForm => {
 
 export const skalVurdereLønnet = (type: AktivitetType | '') => type === AktivitetType.TILTAK;
 
-export const resetDelvilkår = (
+export const resettAktivitet = (
+    nyType: AktivitetType,
+    eksisterendeAktivitetForm: EndreAktivitetForm
+): EndreAktivitetForm => ({
+    ...eksisterendeAktivitetForm,
+    type: nyType,
+    fom: resetFom(nyType, eksisterendeAktivitetForm),
+    tom: resetTom(nyType, eksisterendeAktivitetForm),
+    delvilkår: resetDelvilkår(nyType, eksisterendeAktivitetForm.delvilkår),
+});
+
+const resetFom = (type: AktivitetType, eksisterendeForm: EndreAktivitetForm) => {
+    if (type === AktivitetType.INGEN_AKTIVITET) {
+        return treMånederTilbake();
+    }
+
+    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.fom);
+};
+
+const resetTom = (type: AktivitetType, eksisterendeForm: EndreAktivitetForm) => {
+    if (type === AktivitetType.INGEN_AKTIVITET) {
+        return dagensDato();
+    }
+
+    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.tom);
+};
+
+const resetEllerBeholdDato = (forrigeType: AktivitetType | '', forrigeDato: string) => {
+    if (forrigeType === AktivitetType.INGEN_AKTIVITET) {
+        return '';
+    }
+
+    return forrigeDato;
+};
+
+const resetDelvilkår = (
     type: AktivitetType,
     delvilkår: DelvilkårAktivitet
 ): DelvilkårAktivitet => ({

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -1,5 +1,6 @@
 import { EndreAktivitetForm } from './EndreAktivitetRad';
 import { dagensDato, treMånederTilbake } from '../../../../utils/dato';
+import { harTallverdi } from '../../../../utils/tall';
 import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
 import { AktivitetType, DelvilkårAktivitet } from '../typer/aktivitet';
 import { SvarJaNei } from '../typer/vilkårperiode';
@@ -11,7 +12,7 @@ export const nyAktivitet = (behandlingId: string): EndreAktivitetForm => {
         type: '',
         fom: '',
         tom: '',
-        aktivitetsdager: 5,
+        aktivitetsdager: undefined,
         delvilkår: { '@type': 'AKTIVITET' },
     };
 };
@@ -26,6 +27,7 @@ export const resettAktivitet = (
     type: nyType,
     fom: resetFom(nyType, eksisterendeAktivitetForm),
     tom: resetTom(nyType, eksisterendeAktivitetForm),
+    aktivitetsdager: resetAktivitetsdager(nyType, eksisterendeAktivitetForm),
     delvilkår: resetDelvilkår(nyType, eksisterendeAktivitetForm.delvilkår),
 });
 
@@ -51,6 +53,16 @@ const resetEllerBeholdDato = (forrigeType: AktivitetType | '', forrigeDato: stri
     }
 
     return forrigeDato;
+};
+
+const resetAktivitetsdager = (nyType: AktivitetType, eksisterendeForm: EndreAktivitetForm) => {
+    if (nyType === AktivitetType.INGEN_AKTIVITET) {
+        return undefined;
+    } else if (!harTallverdi(eksisterendeForm.aktivitetsdager)) {
+        return 5;
+    }
+
+    return eksisterendeForm.aktivitetsdager;
 };
 
 const resetDelvilkår = (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -6,6 +6,7 @@ import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
+import { useTriggRerendringAvDateInput } from '../../../../hooks/useTriggRerendringAvDateInput';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import {
@@ -43,6 +44,10 @@ const EndreMålgruppeRad: React.FC<{
     const { request } = useApp();
     const { behandling } = useBehandling();
     const { oppdaterMålgruppe, leggTilMålgruppe, settStønadsperiodeFeil } = useInngangsvilkår();
+    const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
+        useTriggRerendringAvDateInput();
+    const { keyDato: tomKeyDato, oppdaterDatoKey: oppdaterTomDatoKey } =
+        useTriggRerendringAvDateInput();
 
     const [målgruppeForm, settMålgruppeForm] = useState<EndreMålgruppeForm>(
         initaliserForm(behandling.id, målgruppe)
@@ -100,6 +105,8 @@ const EndreMålgruppeRad: React.FC<{
 
     const oppdaterType = (type: MålgruppeType) => {
         settMålgruppeForm((prevState) => resettMålgruppe(type, prevState));
+        oppdaterFomDatoKey();
+        oppdaterTomDatoKey();
     };
 
     return (
@@ -113,6 +120,8 @@ const EndreMålgruppeRad: React.FC<{
             typeOptions={MålgruppeTypeOptions}
             oppdaterType={(type) => oppdaterType(type as MålgruppeType)}
             feilmelding={feilmelding}
+            fomKeyDato={fomKeyDato}
+            tomKeyDato={tomKeyDato}
         >
             <MålgruppeVilkår
                 målgruppeForm={målgruppeForm}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 
 import MålgruppeVilkår from './MålgruppeVilkår';
-import { nyMålgruppe, resetDelvilkår } from './utils';
+import { nyMålgruppe, resettMålgruppe } from './utils';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
@@ -99,11 +99,7 @@ const EndreMålgruppeRad: React.FC<{
     };
 
     const oppdaterType = (type: MålgruppeType) => {
-        settMålgruppeForm((prevState) => ({
-            ...prevState,
-            type: type,
-            delvilkår: resetDelvilkår(type, prevState.delvilkår),
-        }));
+        settMålgruppeForm((prevState) => resettMålgruppe(type, prevState));
     };
 
     return (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -1,5 +1,6 @@
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import { dagensDato, treMånederTilbake } from '../../../../utils/dato';
+import { Periode } from '../../../../utils/periode';
 import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
 import { Aktivitet } from '../typer/aktivitet';
 import {
@@ -42,36 +43,28 @@ export const skalVurdereDekkesAvAnnetRegelverk = (type: MålgruppeType) =>
 export const resettMålgruppe = (
     nyType: MålgruppeType,
     eksisterendeForm: EndreMålgruppeForm
-): EndreMålgruppeForm => ({
-    ...eksisterendeForm,
-    type: nyType,
-    fom: resetFom(nyType, eksisterendeForm),
-    tom: resetTom(nyType, eksisterendeForm),
-    delvilkår: resetDelvilkår(nyType, eksisterendeForm.delvilkår),
-});
-
-const resetFom = (type: MålgruppeType, eksisterendeForm: EndreMålgruppeForm) => {
-    if (type === MålgruppeType.INGEN_MÅLGRUPPE) {
-        return treMånederTilbake();
-    }
-
-    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.fom);
+): EndreMålgruppeForm => {
+    const { fom, tom } = resetPeriode(nyType, eksisterendeForm);
+    return {
+        ...eksisterendeForm,
+        type: nyType,
+        fom: fom,
+        tom: tom,
+        delvilkår: resetDelvilkår(nyType, eksisterendeForm.delvilkår),
+    };
 };
 
-const resetTom = (type: MålgruppeType, eksisterendeForm: EndreMålgruppeForm) => {
-    if (type === MålgruppeType.INGEN_MÅLGRUPPE) {
-        return dagensDato();
+const resetPeriode = (nyType: string, eksisterendeForm: EndreMålgruppeForm): Periode => {
+    if (nyType === MålgruppeType.INGEN_MÅLGRUPPE) {
+        return { fom: treMånederTilbake(), tom: dagensDato() };
     }
 
-    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.tom);
-};
-
-const resetEllerBeholdDato = (forrigeType: MålgruppeType | '', forrigeDato: string) => {
-    if (forrigeType === MålgruppeType.INGEN_MÅLGRUPPE) {
-        return '';
+    if (eksisterendeForm.type === MålgruppeType.INGEN_MÅLGRUPPE) {
+        // Resetter datoer om de forrige var satt automatisk
+        return { fom: '', tom: '' };
     }
 
-    return forrigeDato;
+    return { fom: eksisterendeForm.fom, tom: eksisterendeForm.tom };
 };
 
 const resetDelvilkår = (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -104,6 +104,10 @@ export const finnBegrunnelseGrunnerMålgruppe = (
         delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.MEDLEMSKAP);
     }
 
+    if (type === MålgruppeType.INGEN_MÅLGRUPPE) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.INGEN_MÅLGRUPPE);
+    }
+
     if (delvilkår.dekketAvAnnetRegelverk?.svar === SvarJaNei.JA) {
         delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.DEKKET_AV_ANNET_REGELVERK);
     }

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -1,4 +1,5 @@
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
+import { dagensDato, treMånederTilbake } from '../../../../utils/dato';
 import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
 import { Aktivitet } from '../typer/aktivitet';
 import {
@@ -38,10 +39,42 @@ export const målgruppeErNedsattArbeidsevne = (målgruppeType: MålgruppeType) =
 export const skalVurdereDekkesAvAnnetRegelverk = (type: MålgruppeType) =>
     målgruppeErNedsattArbeidsevne(type);
 
-const dekkesAvAnnetRegelverkAutomatiskNeiHvisMangler = (delvilkår: DelvilkårMålgruppe) =>
-    delvilkår.dekketAvAnnetRegelverk || { svar: SvarJaNei.NEI };
+export const resettMålgruppe = (
+    nyType: MålgruppeType,
+    eksisterendeForm: EndreMålgruppeForm
+): EndreMålgruppeForm => ({
+    ...eksisterendeForm,
+    type: nyType,
+    fom: resetFom(nyType, eksisterendeForm),
+    tom: resetTom(nyType, eksisterendeForm),
+    delvilkår: resetDelvilkår(nyType, eksisterendeForm.delvilkår),
+});
 
-export const resetDelvilkår = (
+const resetFom = (type: MålgruppeType, eksisterendeForm: EndreMålgruppeForm) => {
+    if (type === MålgruppeType.INGEN_MÅLGRUPPE) {
+        return treMånederTilbake();
+    }
+
+    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.fom);
+};
+
+const resetTom = (type: MålgruppeType, eksisterendeForm: EndreMålgruppeForm) => {
+    if (type === MålgruppeType.INGEN_MÅLGRUPPE) {
+        return dagensDato();
+    }
+
+    return resetEllerBeholdDato(eksisterendeForm.type, eksisterendeForm.tom);
+};
+
+const resetEllerBeholdDato = (forrigeType: MålgruppeType | '', forrigeDato: string) => {
+    if (forrigeType === MålgruppeType.INGEN_MÅLGRUPPE) {
+        return '';
+    }
+
+    return forrigeDato;
+};
+
+const resetDelvilkår = (
     type: MålgruppeType,
     delvilkår: DelvilkårMålgruppe
 ): DelvilkårMålgruppe => ({
@@ -53,6 +86,9 @@ export const resetDelvilkår = (
         ? dekkesAvAnnetRegelverkAutomatiskNeiHvisMangler(delvilkår)
         : undefined,
 });
+
+const dekkesAvAnnetRegelverkAutomatiskNeiHvisMangler = (delvilkår: DelvilkårMålgruppe) =>
+    delvilkår.dekketAvAnnetRegelverk || { svar: SvarJaNei.NEI };
 
 export const finnBegrunnelseGrunnerMålgruppe = (
     type: MålgruppeType | '',

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -42,6 +42,8 @@ interface Props {
     ekstraCeller?: React.ReactNode;
     feilmelding?: string;
     children: React.ReactNode;
+    fomKeyDato: string | undefined;
+    tomKeyDato: string | undefined;
 }
 
 // TODO: Endre navn til EndreVilkårperiodeKort eller EndreVilkårperiode
@@ -57,6 +59,8 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
     ekstraCeller,
     feilmelding,
     children,
+    fomKeyDato,
+    tomKeyDato,
 }) => {
     const [visSlettModal, settVisSlettModal] = useState(false);
 
@@ -76,6 +80,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                 />
 
                 <DateInputMedLeservisning
+                    key={fomKeyDato}
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Fra'}
                     value={form?.fom}
@@ -85,6 +90,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                 />
 
                 <DateInputMedLeservisning
+                    key={tomKeyDato}
                     erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
                     label={'Til'}
                     value={form?.tom}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/utils.ts
@@ -1,5 +1,5 @@
 import { EndreAktivitetForm } from '../../Aktivitet/EndreAktivitetRad';
-import { finnBegrunnelseGrunnerAktivitet } from '../../Aktivitet/utils';
+import { erFormForAktivitet, finnBegrunnelseGrunnerAktivitet } from '../../Aktivitet/utils';
 import { EndreMålgruppeForm } from '../../Målgruppe/EndreMålgruppeRad';
 import { erFormForMålgruppe, finnBegrunnelseGrunnerMålgruppe } from '../../Målgruppe/utils';
 
@@ -8,6 +8,8 @@ export enum BegrunnelseGrunner {
     DEKKET_AV_ANNET_REGELVERK = 'DEKKET_AV_ANNET_REGELVERK',
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
     LØNNET = 'LØNNET',
+    INGEN_AKTIVITET = 'INGEN_AKTIVITET',
+    INGEN_MÅLGRUPPE = 'INGEN_MÅLGRUPPE',
 }
 
 export const begrunnelseTilTekst: Record<BegrunnelseGrunner, string> = {
@@ -15,13 +17,15 @@ export const begrunnelseTilTekst: Record<BegrunnelseGrunner, string> = {
     DEKKET_AV_ANNET_REGELVERK: 'Utgifter dekket av annet regelverk',
     NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
     LØNNET: 'Ordinær lønn i tiltaket',
+    INGEN_AKTIVITET: 'Ingen aktivitet',
+    INGEN_MÅLGRUPPE: 'Ingen målgruppe',
 };
 
 export const finnBegrunnelseGrunner = (
     vilkårperiodeForm: EndreMålgruppeForm | EndreAktivitetForm
 ): BegrunnelseGrunner[] => {
-    if (vilkårperiodeForm.delvilkår['@type'] === 'AKTIVITET') {
-        return finnBegrunnelseGrunnerAktivitet(vilkårperiodeForm.delvilkår);
+    if (erFormForAktivitet(vilkårperiodeForm)) {
+        return finnBegrunnelseGrunnerAktivitet(vilkårperiodeForm.type, vilkårperiodeForm.delvilkår);
     } else if (erFormForMålgruppe(vilkårperiodeForm)) {
         return finnBegrunnelseGrunnerMålgruppe(vilkårperiodeForm.type, vilkårperiodeForm.delvilkår);
     } else return [];

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/validering.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/validering.tsx
@@ -41,6 +41,7 @@ export const validerVilkårsperiode = (
 
     if (
         erFormForAktivitet(endretVilkårsperiode) &&
+        endretVilkårsperiode.type !== AktivitetType.INGEN_AKTIVITET &&
         !aktivitetsdagerErGyldigTall(endretVilkårsperiode.aktivitetsdager)
     ) {
         return { ...feil, aktivitetsdager: 'Aktivitetsdager må være et tall mellom 1 og 5' };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
@@ -17,12 +17,14 @@ export enum AktivitetType {
     TILTAK = 'TILTAK',
     UTDANNING = 'UTDANNING',
     REELL_ARBEIDSSØKER = 'REELL_ARBEIDSSØKER',
+    INGEN_AKTIVITET = 'INGEN_AKTIVITET',
 }
 
 export const AktivitetTypeTilTekst: Record<AktivitetType, string> = {
     TILTAK: 'Tiltak',
     UTDANNING: 'Utdanning',
     REELL_ARBEIDSSØKER: 'Reell arbeidssøker',
+    INGEN_AKTIVITET: 'Ingen aktivitet',
 };
 
 export const AktivitetTypeOptions: SelectOption[] = Object.entries(AktivitetTypeTilTekst).map(

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
@@ -19,6 +19,7 @@ export enum MålgruppeType {
     OMSTILLINGSSTØNAD = 'OMSTILLINGSSTØNAD',
     OVERGANGSSTØNAD = 'OVERGANGSSTØNAD',
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
+    INGEN_MÅLGRUPPE = 'INGEN_MÅLGRUPPE',
 }
 
 export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
@@ -27,6 +28,7 @@ export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
     OMSTILLINGSSTØNAD: 'Omstillingsstønad',
     OVERGANGSSTØNAD: 'Overgangsstønad',
     NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
+    INGEN_MÅLGRUPPE: 'Ingen målgruppe',
 };
 
 export const MålgruppeTypeOptions: SelectOption[] = Object.entries(MålgruppeTypeTilTekst).map(
@@ -43,6 +45,7 @@ export enum FaktiskMålgruppe {
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
     ENSLIG_FORSØRGER = 'ENSLIG_FORSØRGER',
     GJENLEVENDE = 'GJENLEVENDE',
+    INGEN_MÅLGRUPPE = 'INGEN_MÅLGRUPPE',
 }
 
 export const MålgruppeTypeTilFaktiskMålgruppe: Record<MålgruppeType, FaktiskMålgruppe> = {
@@ -51,4 +54,5 @@ export const MålgruppeTypeTilFaktiskMålgruppe: Record<MålgruppeType, FaktiskM
     OMSTILLINGSSTØNAD: FaktiskMålgruppe.GJENLEVENDE,
     OVERGANGSSTØNAD: FaktiskMålgruppe.ENSLIG_FORSØRGER,
     NEDSATT_ARBEIDSEVNE: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
+    INGEN_MÅLGRUPPE: FaktiskMålgruppe.INGEN_MÅLGRUPPE,
 };

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -1,8 +1,12 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useEffect } from 'react';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
-import { nullableTilDato, tilLocaleDateString } from '../../utils/dato';
+import {
+    nullableTilDato,
+    nullableTilLocaleDateString,
+    tilLocaleDateString,
+} from '../../utils/dato';
 
 export interface DateInputProps {
     feil?: ReactNode;
@@ -14,10 +18,17 @@ export interface DateInputProps {
 }
 
 const DateInput: React.FC<DateInputProps> = ({ feil, hideLabel, label, onChange, size, value }) => {
-    const { datepickerProps, inputProps } = useDatepicker({
+    const { datepickerProps, inputProps, selectedDay, setSelected } = useDatepicker({
         defaultSelected: nullableTilDato(value),
         onDateChange: (val) => onChange(val ? tilLocaleDateString(val) : val),
     });
+
+    useEffect(() => {
+        if (nullableTilLocaleDateString(selectedDay) !== value) {
+            setSelected(nullableTilDato(value));
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [value]);
 
     return (
         <DatePicker {...datepickerProps}>

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -23,6 +23,7 @@ const DateInput: React.FC<DateInputProps> = ({ feil, hideLabel, label, onChange,
         onDateChange: (val) => onChange(val ? tilLocaleDateString(val) : val),
     });
 
+    // Oppdater valgt dato i datepicker om value endres utenfra
     useEffect(() => {
         if (nullableTilLocaleDateString(selectedDay) !== value) {
             setSelected(nullableTilDato(value));

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -1,12 +1,8 @@
-import React, { ReactNode, useEffect } from 'react';
+import React, { ReactNode } from 'react';
 
 import { DatePicker, useDatepicker } from '@navikt/ds-react';
 
-import {
-    nullableTilDato,
-    nullableTilLocaleDateString,
-    tilLocaleDateString,
-} from '../../utils/dato';
+import { nullableTilDato, tilLocaleDateString } from '../../utils/dato';
 
 export interface DateInputProps {
     feil?: ReactNode;
@@ -18,18 +14,10 @@ export interface DateInputProps {
 }
 
 const DateInput: React.FC<DateInputProps> = ({ feil, hideLabel, label, onChange, size, value }) => {
-    const { datepickerProps, inputProps, selectedDay, setSelected } = useDatepicker({
+    const { datepickerProps, inputProps } = useDatepicker({
         defaultSelected: nullableTilDato(value),
         onDateChange: (val) => onChange(val ? tilLocaleDateString(val) : val),
     });
-
-    // Oppdater valgt dato i datepicker om value endres utenfra
-    useEffect(() => {
-        if (nullableTilLocaleDateString(selectedDay) !== value) {
-            setSelected(nullableTilDato(value));
-        }
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, [value]);
 
     return (
         <DatePicker {...datepickerProps}>

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -1,5 +1,6 @@
 import {
     addDays,
+    addMonths,
     format,
     formatISO,
     isAfter,
@@ -51,6 +52,7 @@ export const dagensDatoFormatert = (): string => {
         year: 'numeric',
     });
 };
+
 export const tilDato = (dato: string | Date): Date =>
     typeof dato === 'string' ? parseISO(dato) : dato;
 
@@ -69,6 +71,9 @@ export const erDatoFørEllerLik = (fra: string, til: string): boolean => {
 };
 
 export const tilLocaleDateString = (dato: Date) => formatISO(dato, { representation: 'date' });
+
+export const nullableTilLocaleDateString = (dato: Date | undefined) =>
+    dato ? formatISO(dato, { representation: 'date' }) : dato;
 
 export const tilÅrMåned = (date: Date): string => {
     return formatISO(date).substring(0, 7);
@@ -96,3 +101,7 @@ export const plusDager = (dato: string | Date, antallDager: number): string =>
 
 export const formaterÅrMåned = (dato: string): string =>
     format(parseISO(dato), 'MMM yyyy', { locale: nb });
+
+export const dagensDato = (): string => tilLocaleDateString(new Date());
+
+export const treMånederTilbake = (): string => tilLocaleDateString(addMonths(new Date(), -3));

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -72,9 +72,6 @@ export const erDatoFørEllerLik = (fra: string, til: string): boolean => {
 
 export const tilLocaleDateString = (dato: Date) => formatISO(dato, { representation: 'date' });
 
-export const nullableTilLocaleDateString = (dato: Date | undefined) =>
-    dato ? formatISO(dato, { representation: 'date' }) : dato;
-
 export const tilÅrMåned = (date: Date): string => {
     return formatISO(date).substring(0, 7);
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det skal være mulig å velge "ingen aktivitet" eller "ingen målgruppe" slik at vi kan registrere at vilkår ikke er oppfylt. 

Ved valg av ingen aktivitet/målgruppe: 
- Fom = tre måneder tilbake i tid
- Tom = dagens dato
- Aktivitetsdager skal ikke settes

Må merges etter [PR 305 i sak](https://github.com/navikt/tilleggsstonader-sak/pull/305)

### Bilder 🎨 
Under redigering: 
<img width="832" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/03234a32-c4b5-4148-8094-afa9f73bcd36">
<img width="832" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/54042c73-a307-494f-8a64-1e8f609bb054">

Obligatorisk begrunnelse: 
<img width="832" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/8c4c36c9-e3c8-42d4-a3e2-e0b6c334094d">

Lagret: 
<img width="1352" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/97bddf79-567e-476c-8b32-ddbaf1e22d29">
