### PR TITLE
Utled fom-dato på ingen aktivitet/målgruppe basert på søknadstidspunkt

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingContainer.tsx
@@ -7,6 +7,7 @@ import { useApp } from '../../context/AppContext';
 import { useRerunnableEffect } from '../../hooks/useRerunnableEffect';
 import DataViewer from '../../komponenter/DataViewer';
 import { Behandling } from '../../typer/behandling/behandling';
+import { BehandlingFakta } from '../../typer/behandling/behandlingFakta/behandlingFakta';
 import { Personopplysninger } from '../../typer/personopplysninger';
 import { byggTomRessurs, Ressurs } from '../../typer/ressurs';
 
@@ -15,6 +16,8 @@ const BehandlingContainer = () => {
     const [behandling, settBehandling] = useState<Ressurs<Behandling>>(byggTomRessurs());
     const [personopplysninger, settPersonopplysninger] =
         useState<Ressurs<Personopplysninger>>(byggTomRessurs());
+    const [behandlingFakta, settBehandlingFakta] =
+        useState<Ressurs<BehandlingFakta>>(byggTomRessurs());
 
     const behandlingId = useParams<{
         behandlingId: string;
@@ -36,13 +39,22 @@ const BehandlingContainer = () => {
         document.title = 'Behandling';
     }, []);
 
+    const hentBehandlingFaktaCallback = useCallback(() => {
+        request<BehandlingFakta, null>(`/api/sak/behandling/${behandlingId}/fakta`).then(
+            settBehandlingFakta
+        );
+    }, [request, behandlingId]);
+
+    useEffect(hentBehandlingFaktaCallback, [hentBehandlingFaktaCallback]);
+
     return (
-        <DataViewer response={{ behandling, personopplysninger }}>
-            {({ behandling, personopplysninger }) => (
+        <DataViewer response={{ behandling, personopplysninger, behandlingFakta }}>
+            {({ behandling, personopplysninger, behandlingFakta }) => (
                 <BehandlingInnhold
                     behandling={behandling}
                     hentBehandling={hentBehandling}
                     personopplysninger={personopplysninger}
+                    behandlingFakta={behandlingFakta}
                 />
             )}
         </DataViewer>

--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -10,6 +10,7 @@ import { VilkårProvider } from '../../context/VilkårContext';
 import { RerrunnableEffect } from '../../hooks/useRerunnableEffect';
 import PersonHeader from '../../komponenter/PersonHeader/PersonHeader';
 import { Behandling } from '../../typer/behandling/behandling';
+import { BehandlingFakta } from '../../typer/behandling/behandlingFakta/behandlingFakta';
 import { Personopplysninger } from '../../typer/personopplysninger';
 
 const BehandlingContainer = styled.div`
@@ -26,9 +27,14 @@ const BehandlingInnhold: React.FC<{
     behandling: Behandling;
     hentBehandling: RerrunnableEffect;
     personopplysninger: Personopplysninger;
-}> = ({ behandling, hentBehandling, personopplysninger }) => {
+    behandlingFakta: BehandlingFakta;
+}> = ({ behandling, hentBehandling, personopplysninger, behandlingFakta }) => {
     return (
-        <BehandlingProvider behandling={behandling} hentBehandling={hentBehandling}>
+        <BehandlingProvider
+            behandling={behandling}
+            hentBehandling={hentBehandling}
+            behandlingFakta={behandlingFakta}
+        >
             <PersonopplysningerProvider personopplysninger={personopplysninger}>
                 <PersonHeader fagsakPersonId={behandling.fagsakPersonId} />
                 <BehandlingContainer>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -46,7 +46,7 @@ const EndreAktivitetRad: React.FC<{
     avbrytRedigering: () => void;
 }> = ({ aktivitet, avbrytRedigering }) => {
     const { request } = useApp();
-    const { behandling } = useBehandling();
+    const { behandling, behandlingFakta } = useBehandling();
     const { oppdaterAktivitet, leggTilAktivitet, settStønadsperiodeFeil } = useInngangsvilkår();
     const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
         useTriggRerendringAvDateInput();
@@ -109,7 +109,9 @@ const EndreAktivitetRad: React.FC<{
     };
 
     const oppdaterType = (type: AktivitetType) => {
-        settAktivitetForm((prevState) => resettAktivitet(type, prevState));
+        settAktivitetForm((prevState) =>
+            resettAktivitet(type, prevState, behandlingFakta.søknadMottattTidspunkt)
+        );
         oppdaterFomDatoKey();
         oppdaterTomDatoKey();
     };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -1,5 +1,5 @@
 import { EndreAktivitetForm } from './EndreAktivitetRad';
-import { dagensDato, treMånederTilbake } from '../../../../utils/dato';
+import { dagensDato, førsteDagIMånedTreMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi } from '../../../../utils/tall';
 import { EndreMålgruppeForm } from '../Målgruppe/EndreMålgruppeRad';
@@ -22,9 +22,10 @@ export const skalVurdereLønnet = (type: AktivitetType | '') => type === Aktivit
 
 export const resettAktivitet = (
     nyType: AktivitetType,
-    eksisterendeAktivitetForm: EndreAktivitetForm
+    eksisterendeAktivitetForm: EndreAktivitetForm,
+    søknadMottattTidspunkt?: string
 ): EndreAktivitetForm => {
-    const { fom, tom } = resetPeriode(nyType, eksisterendeAktivitetForm);
+    const { fom, tom } = resetPeriode(nyType, eksisterendeAktivitetForm, søknadMottattTidspunkt);
 
     return {
         ...eksisterendeAktivitetForm,
@@ -36,9 +37,13 @@ export const resettAktivitet = (
     };
 };
 
-const resetPeriode = (nyType: string, eksisterendeForm: EndreAktivitetForm): Periode => {
+const resetPeriode = (
+    nyType: string,
+    eksisterendeForm: EndreAktivitetForm,
+    søknadMottattTidspunkt?: string
+): Periode => {
     if (nyType === AktivitetType.INGEN_AKTIVITET) {
-        return { fom: treMånederTilbake(), tom: dagensDato() };
+        return { fom: førsteDagIMånedTreMånederForut(søknadMottattTidspunkt), tom: dagensDato() };
     }
 
     if (eksisterendeForm.type === AktivitetType.INGEN_AKTIVITET) {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -42,7 +42,7 @@ const EndreMålgruppeRad: React.FC<{
     avbrytRedigering: () => void;
 }> = ({ målgruppe, avbrytRedigering }) => {
     const { request } = useApp();
-    const { behandling } = useBehandling();
+    const { behandling, behandlingFakta } = useBehandling();
     const { oppdaterMålgruppe, leggTilMålgruppe, settStønadsperiodeFeil } = useInngangsvilkår();
     const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
         useTriggRerendringAvDateInput();
@@ -104,7 +104,9 @@ const EndreMålgruppeRad: React.FC<{
     };
 
     const oppdaterType = (type: MålgruppeType) => {
-        settMålgruppeForm((prevState) => resettMålgruppe(type, prevState));
+        settMålgruppeForm((prevState) =>
+            resettMålgruppe(type, prevState, behandlingFakta.søknadMottattTidspunkt)
+        );
         oppdaterFomDatoKey();
         oppdaterTomDatoKey();
     };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -1,5 +1,5 @@
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
-import { dagensDato, treMånederTilbake } from '../../../../utils/dato';
+import { dagensDato, førsteDagIMånedTreMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
 import { EndreAktivitetForm } from '../Aktivitet/EndreAktivitetRad';
 import { Aktivitet } from '../typer/aktivitet';
@@ -42,9 +42,10 @@ export const skalVurdereDekkesAvAnnetRegelverk = (type: MålgruppeType) =>
 
 export const resettMålgruppe = (
     nyType: MålgruppeType,
-    eksisterendeForm: EndreMålgruppeForm
+    eksisterendeForm: EndreMålgruppeForm,
+    søknadMottattTidspunkt?: string
 ): EndreMålgruppeForm => {
-    const { fom, tom } = resetPeriode(nyType, eksisterendeForm);
+    const { fom, tom } = resetPeriode(nyType, eksisterendeForm, søknadMottattTidspunkt);
     return {
         ...eksisterendeForm,
         type: nyType,
@@ -54,9 +55,13 @@ export const resettMålgruppe = (
     };
 };
 
-const resetPeriode = (nyType: string, eksisterendeForm: EndreMålgruppeForm): Periode => {
+const resetPeriode = (
+    nyType: string,
+    eksisterendeForm: EndreMålgruppeForm,
+    søknadMottattTidspunkt?: string
+): Periode => {
     if (nyType === MålgruppeType.INGEN_MÅLGRUPPE) {
-        return { fom: treMånederTilbake(), tom: dagensDato() };
+        return { fom: førsteDagIMånedTreMånederForut(søknadMottattTidspunkt), tom: dagensDato() };
     }
 
     if (eksisterendeForm.type === MålgruppeType.INGEN_MÅLGRUPPE) {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/SelectVedtaksresultat.tsx
@@ -43,8 +43,8 @@ const SelectVedtaksresultat: FC<Props> = ({
                 size="small"
             >
                 <option value="">Velg</option>
-                <option value={TypeVedtak.INNVILGELSE}>Innvilge</option>
-                <option value={TypeVedtak.AVSLAG}>Avslå</option>
+                <option value={TypeVedtak.INNVILGELSE}>Innvilgelse</option>
+                <option value={TypeVedtak.AVSLAG}>Avslag</option>
             </Select>
         </Container>
     );

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -9,6 +9,7 @@ import Vedlegg from './Vedlegg';
 import { Informasjonskilde, Informasjonsrad, InfoSeksjon } from './Visningskomponenter';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { hovedytelseTilTekst } from '../../../../typer/behandling/behandlingFakta/faktaHovedytelse';
+import { formaterDato } from '../../../../utils/dato';
 import { tekstEllerKode } from '../../../../utils/tekstformatering';
 
 const Oppsummering: React.FC = () => {
@@ -16,6 +17,14 @@ const Oppsummering: React.FC = () => {
 
     return (
         <VStack gap="8">
+            {behandlingFakta.søknadMottattTidspunkt && (
+                <InfoSeksjon label="Søknadsdato">
+                    <Informasjonsrad
+                        kilde={Informasjonskilde.SØKNAD}
+                        verdi={formaterDato(behandlingFakta.søknadMottattTidspunkt)}
+                    />
+                </InfoSeksjon>
+            )}
             <InfoSeksjon label="Ytelse/situasjon">
                 <Informasjonsrad
                     kilde={Informasjonskilde.SØKNAD}

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 
 import { VStack } from '@navikt/ds-react';
 
@@ -7,64 +7,42 @@ import ArbeidOgOpphold from './ArbeidOgOpphold';
 import BarnDetaljer from './BarnDetaljer';
 import Vedlegg from './Vedlegg';
 import { Informasjonskilde, Informasjonsrad, InfoSeksjon } from './Visningskomponenter';
-import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
-import DataViewer from '../../../../komponenter/DataViewer';
-import { BehandlingFakta } from '../../../../typer/behandling/behandlingFakta/behandlingFakta';
 import { hovedytelseTilTekst } from '../../../../typer/behandling/behandlingFakta/faktaHovedytelse';
-import { byggTomRessurs, Ressurs } from '../../../../typer/ressurs';
 import { tekstEllerKode } from '../../../../utils/tekstformatering';
 
 const Oppsummering: React.FC = () => {
-    const { request } = useApp();
-    const { behandling } = useBehandling();
-
-    const [behandlingFakta, settBehandlingFakta] =
-        useState<Ressurs<BehandlingFakta>>(byggTomRessurs());
-
-    const hentBehandlingFaktaCallback = useCallback(() => {
-        request<BehandlingFakta, null>(`/api/sak/behandling/${behandling.id}/fakta`).then(
-            settBehandlingFakta
-        );
-    }, [request, behandling.id]);
-
-    useEffect(hentBehandlingFaktaCallback, [hentBehandlingFaktaCallback]);
+    const { behandlingFakta } = useBehandling();
 
     return (
-        <DataViewer response={{ behandlingFakta }}>
-            {({ behandlingFakta }) => (
-                <VStack gap="8">
-                    <InfoSeksjon label="Ytelse/situasjon">
-                        <Informasjonsrad
-                            kilde={Informasjonskilde.SØKNAD}
-                            verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse
-                                ?.map((hovedytelse) =>
-                                    tekstEllerKode(hovedytelseTilTekst, hovedytelse)
-                                )
-                                ?.join(', ')}
-                        />
-                    </InfoSeksjon>
-                    {behandlingFakta.hovedytelse.søknadsgrunnlag?.arbeidOgOpphold && (
-                        <InfoSeksjon label={'Arbeid og opphold'}>
-                            <ArbeidOgOpphold
-                                fakta={behandlingFakta.hovedytelse.søknadsgrunnlag.arbeidOgOpphold}
-                            />
-                        </InfoSeksjon>
-                    )}
-
-                    <InfoSeksjon label="Aktivitet">
-                        {/* TODO: Legg inn info om aktiviteter*/}
-                        <Aktivitet aktivitet={behandlingFakta.aktivitet}></Aktivitet>
-                    </InfoSeksjon>
-
-                    {behandlingFakta.barn.map((barn) => (
-                        <BarnDetaljer barn={barn} key={barn.barnId} />
-                    ))}
-
-                    <Vedlegg fakta={behandlingFakta.dokumentasjon} />
-                </VStack>
+        <VStack gap="8">
+            <InfoSeksjon label="Ytelse/situasjon">
+                <Informasjonsrad
+                    kilde={Informasjonskilde.SØKNAD}
+                    verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse
+                        ?.map((hovedytelse) => tekstEllerKode(hovedytelseTilTekst, hovedytelse))
+                        ?.join(', ')}
+                />
+            </InfoSeksjon>
+            {behandlingFakta.hovedytelse.søknadsgrunnlag?.arbeidOgOpphold && (
+                <InfoSeksjon label={'Arbeid og opphold'}>
+                    <ArbeidOgOpphold
+                        fakta={behandlingFakta.hovedytelse.søknadsgrunnlag.arbeidOgOpphold}
+                    />
+                </InfoSeksjon>
             )}
-        </DataViewer>
+
+            <InfoSeksjon label="Aktivitet">
+                {/* TODO: Legg inn info om aktiviteter*/}
+                <Aktivitet aktivitet={behandlingFakta.aktivitet}></Aktivitet>
+            </InfoSeksjon>
+
+            {behandlingFakta.barn.map((barn) => (
+                <BarnDetaljer barn={barn} key={barn.barnId} />
+            ))}
+
+            <Vedlegg fakta={behandlingFakta.dokumentasjon} />
+        </VStack>
     );
 };
 

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -2,21 +2,24 @@ import constate from 'constate';
 
 import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
 import { Behandling } from '../typer/behandling/behandling';
+import { BehandlingFakta } from '../typer/behandling/behandlingFakta/behandlingFakta';
 import { erBehandlingRedigerbar } from '../typer/behandling/behandlingStatus';
 
 interface Props {
     behandling: Behandling;
     hentBehandling: RerrunnableEffect;
+    behandlingFakta: BehandlingFakta;
 }
 
 export const [BehandlingProvider, useBehandling] = constate(
-    ({ behandling, hentBehandling }: Props) => {
+    ({ behandling, hentBehandling, behandlingFakta }: Props) => {
         const behandlingErRedigerbar = erBehandlingRedigerbar(behandling);
 
         return {
             behandling,
             behandlingErRedigerbar,
             hentBehandling,
+            behandlingFakta,
         };
     }
 );

--- a/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
@@ -4,6 +4,7 @@ import { FaktaDokumentasjon } from './faktaDokumentasjon';
 import { FaktaHovedytelse } from './faktaHovedytelse';
 
 export interface BehandlingFakta {
+    søknadMottattTidspunkt?: string;
     hovedytelse: FaktaHovedytelse;
     aktivitet: FaktaAktivtet;
     barn: FaktaBarn[];

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -8,6 +8,7 @@ import {
     isEqual,
     isValid,
     parseISO,
+    startOfMonth,
 } from 'date-fns';
 import { nb } from 'date-fns/locale';
 
@@ -101,4 +102,8 @@ export const formaterÅrMåned = (dato: string): string =>
 
 export const dagensDato = (): string => tilLocaleDateString(new Date());
 
-export const treMånederTilbake = (): string => tilLocaleDateString(addMonths(new Date(), -3));
+// Funksjon finner første dag i måneden tre måneder før gitt dato eller dagens dato
+export const førsteDagIMånedTreMånederForut = (dato?: string): string => {
+    const utgangspunktDato = dato ? tilDato(dato) : new Date();
+    return tilLocaleDateString(startOfMonth(addMonths(tilDato(utgangspunktDato), -3)));
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tilbakemeldinger etter funksjonell testing
Fom og tom på vilkårperioder skal preutfylles ved valg av "ingen aktivitet" eller "ingen målgruppe". De preutfylles nå med tre mnd tilbake -> d.d. En saksbehandling gjort i dag ville altså fått 15.02.24 - 15.05.24. 

Det riktige her er å sette fom = første dagen i måneden som er tre måneder før søknadstidspunkt:
- Søknad sendt inn 01.05, 10.05 og 25.05 skal alle få _fom=01.02_
- Søknad sendt inn i løpet av juni skal få 01.03

### Hva er gjort? 🤓 
For å få til dette måtte man ha `søknadstidspunktet` og dette ble lagt i `behandlingFakta` (se [pr 313 i sak](https://github.com/navikt/tilleggsstonader-sak/pull/313))
- Flyttet `behandlingFakta` inn i `BehandlingContext` slik at dato er tilgjengelig både for oppsummering og inngangsvilkår
- La til søknadsdato i oppsummering fordi den nå var tilgjengelig (kommer egen pr med litt mer)

**Har også** endret ordformen på vedtaksresultat fra verb -> substantiv etter ønske

<img width="1541" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/5b7bafd6-3c3b-4c18-bb1a-136d2e57927d">
