### PR TITLE
Fjern ikoner og fiks spacing i venstremeny

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Aktivitet.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
+import { BriefcaseIcon } from '@navikt/aksel-icons';
+import { BodyShort } from '@navikt/ds-react';
+
+import { InfoSeksjon } from './Visningskomponenter';
 import { FaktaAktivtet } from '../../../../typer/behandling/behandlingFakta/faktaAktivitet';
 
 const Aktivitet: React.FC<{ aktivitet: FaktaAktivtet }> = ({ aktivitet }) => {
@@ -9,27 +12,22 @@ const Aktivitet: React.FC<{ aktivitet: FaktaAktivtet }> = ({ aktivitet }) => {
     const erLønnetAktivitet = aktivitet.søknadsgrunnlag?.lønnetAktivitet;
 
     return (
-        <>
+        <InfoSeksjon label="Aktivitet" ikon={<BriefcaseIcon />}>
             {aktiviteter?.map(
                 (aktivitet) =>
                     aktivitet !== 'Annet' && (
-                        <Informasjonsrad
-                            key={aktivitet}
-                            kilde={Informasjonskilde.SØKNAD}
-                            verdi={aktivitet}
-                        />
+                        <BodyShort size="small" key={aktivitet}>
+                            {aktivitet}
+                        </BodyShort>
                     )
             )}
             {annenAktivitet && (
-                <Informasjonsrad
-                    kilde={Informasjonskilde.SØKNAD}
-                    verdi={`Annen aktivitet: ${annenAktivitet}`}
-                />
+                <BodyShort size="small">Annen aktivitet: {annenAktivitet}</BodyShort>
             )}
             {erLønnetAktivitet && erLønnetAktivitet === 'JA' && (
-                <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={`Lønnet aktivitet`} />
+                <BodyShort size="small">Lønnet aktivitet</BodyShort>
             )}
-        </>
+        </InfoSeksjon>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/ArbeidOgOpphold.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/ArbeidOgOpphold.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { BodyShort, Label, VStack } from '@navikt/ds-react';
+import { BriefcaseIcon } from '@navikt/aksel-icons';
+import { BodyShort, Label } from '@navikt/ds-react';
 
-import { Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
+import { InfoSeksjon } from './Visningskomponenter';
 import {
     FaktaArbeidOgOpphold,
     FaktaOppholdUtenforNorge,
@@ -15,22 +16,17 @@ import { tekstEllerKode } from '../../../../utils/tekstformatering';
 
 const OppholdUtenforNorge: React.FC<{ opphold: FaktaOppholdUtenforNorge }> = ({ opphold }) => {
     return (
-        <Informasjonsrad
-            kilde={Informasjonskilde.SØKNAD}
-            verdi={
-                <VStack>
-                    <BodyShort size="small">{opphold.land}</BodyShort>
-                    <BodyShort size="small">
-                        {opphold.årsak
-                            .map((årsak) => tekstEllerKode(årsakOppholdUtenforNorgeTilTekst, årsak))
-                            .join(', ')}
-                    </BodyShort>
-                    <BodyShort size="small">
-                        {formaterIsoDato(opphold.fom)} - {formaterIsoDato(opphold.tom)}
-                    </BodyShort>
-                </VStack>
-            }
-        />
+        <>
+            <BodyShort size="small">{opphold.land}</BodyShort>
+            <BodyShort size="small">
+                {opphold.årsak
+                    .map((årsak) => tekstEllerKode(årsakOppholdUtenforNorgeTilTekst, årsak))
+                    .join(', ')}
+            </BodyShort>
+            <BodyShort size="small">
+                {formaterIsoDato(opphold.fom)} - {formaterIsoDato(opphold.tom)}
+            </BodyShort>
+        </>
     );
 };
 
@@ -43,54 +39,44 @@ const OppholdUtenforNorge12mnd: React.FC<{
         return null;
     }
     return (
-        <VStack gap={'2'}>
+        <div>
             <Label size="small">{tittel}</Label>
             {spørsmål === JaNei.NEI && (
-                <Informasjonsrad kilde={Informasjonskilde.SØKNAD} verdi={jaNeiTilTekst[spørsmål]} />
+                <BodyShort size="small">{jaNeiTilTekst[spørsmål]}</BodyShort>
             )}
             {faktaOpphold.map((opphold, indeks) => (
                 <OppholdUtenforNorge key={indeks} opphold={opphold} />
             ))}
-        </VStack>
+        </div>
     );
 };
 
 const ArbeidOgOpphold: React.FC<{ fakta: FaktaArbeidOgOpphold }> = ({ fakta }) => {
     return (
-        <>
+        <InfoSeksjon label={'Arbeid og opphold'} ikon={<BriefcaseIcon />}>
             {fakta.jobberIAnnetLand === JaNei.NEI && (
-                <Informasjonsrad
-                    kilde={Informasjonskilde.SØKNAD}
-                    verdi={`Jobber i annet land: ${jaNeiTilTekst[fakta.jobberIAnnetLand]}`}
-                />
+                <BodyShort size="small">
+                    Jobber i annet land: {jaNeiTilTekst[fakta.jobberIAnnetLand]}
+                </BodyShort>
             )}
             {fakta.jobbAnnetLand && (
-                <Informasjonsrad
-                    kilde={Informasjonskilde.SØKNAD}
-                    verdi={`Jobber i: ${fakta.jobbAnnetLand}`}
-                />
+                <BodyShort size="small">Jobber i: {fakta.jobbAnnetLand}</BodyShort>
             )}
 
             {fakta.harPengestøtteAnnetLand && (
                 <div>
                     <Label size={'small'}>Pengestøtte fra annet land</Label>
-                    <Informasjonsrad
-                        kilde={Informasjonskilde.SØKNAD}
-                        verdi={
-                            <VStack gap={'2'}>
-                                {fakta.pengestøtteAnnetLand && (
-                                    <BodyShort size="small">{fakta.pengestøtteAnnetLand}</BodyShort>
-                                )}
-                                <BodyShort size="small">
-                                    {fakta.harPengestøtteAnnetLand
-                                        .map((pengestøtte) =>
-                                            tekstEllerKode(typePengestøtteTilTekst, pengestøtte)
-                                        )
-                                        .join(', ')}
-                                </BodyShort>
-                            </VStack>
-                        }
-                    />
+
+                    {fakta.pengestøtteAnnetLand && (
+                        <BodyShort size="small">{fakta.pengestøtteAnnetLand}</BodyShort>
+                    )}
+                    <BodyShort size="small">
+                        {fakta.harPengestøtteAnnetLand
+                            .map((pengestøtte) =>
+                                tekstEllerKode(typePengestøtteTilTekst, pengestøtte)
+                            )
+                            .join(', ')}
+                    </BodyShort>
                 </div>
             )}
 
@@ -105,7 +91,7 @@ const ArbeidOgOpphold: React.FC<{ fakta: FaktaArbeidOgOpphold }> = ({ fakta }) =
                 spørsmål={fakta.harOppholdUtenforNorgeNeste12mnd}
                 faktaOpphold={fakta.oppholdUtenforNorgeNeste12mnd}
             />
-        </>
+        </InfoSeksjon>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/BarnDetaljer.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/BarnDetaljer.tsx
@@ -1,6 +1,9 @@
 import React from 'react';
 
-import { InfoSeksjon, Informasjonskilde, Informasjonsrad } from './Visningskomponenter';
+import { ChildEyesIcon } from '@navikt/aksel-icons';
+import { BodyShort } from '@navikt/ds-react';
+
+import { InfoSeksjon } from './Visningskomponenter';
 import {
     FaktaBarn,
     typeBarnepassTilTekst,
@@ -15,26 +18,20 @@ const BarnDetaljer: React.FC<{ barn: FaktaBarn }> = ({ barn }) => {
     const årsak = barn.søknadgrunnlag?.årsak;
 
     return (
-        <InfoSeksjon label={`${barn.registergrunnlag.navn} ${barn.ident}`}>
-            <Informasjonsrad
-                kilde={Informasjonskilde.SØKNAD}
-                verdi={tekstEllerKode(typeBarnepassTilTekst, typePass)}
-            />
+        <InfoSeksjon label={`${barn.registergrunnlag.navn} ${barn.ident}`} ikon={<ChildEyesIcon />}>
+            <BodyShort size="small">{tekstEllerKode(typeBarnepassTilTekst, typePass)}</BodyShort>
             {startetIFemte !== undefined && (
                 <>
-                    <Informasjonsrad
-                        kilde={Informasjonskilde.SØKNAD}
-                        verdi={
-                            startetIFemte === JaNei.JA
-                                ? 'Startet i 5. klasse'
-                                : 'Ikke startet i 5. klasse'
-                        }
-                    />
+                    <BodyShort size="small">
+                        {startetIFemte === JaNei.JA
+                            ? 'Startet i 5. klasse'
+                            : 'Ikke startet i 5. klasse'}
+                    </BodyShort>
+
                     {startetIFemte === JaNei.JA && (
-                        <Informasjonsrad
-                            kilde={Informasjonskilde.SØKNAD}
-                            verdi={tekstEllerKode(årsakBarnepassTilTekst, årsak)}
-                        />
+                        <BodyShort size="small">
+                            {tekstEllerKode(årsakBarnepassTilTekst, årsak)}{' '}
+                        </BodyShort>
                     )}
                 </>
             )}

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Hovedytelse.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Hovedytelse.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { CardIcon } from '@navikt/aksel-icons';
+import { BodyShort } from '@navikt/ds-react';
+
+import { InfoSeksjon } from './Visningskomponenter';
+import {
+    FaktaHovedytelse,
+    hovedytelseTilTekst,
+} from '../../../../typer/behandling/behandlingFakta/faktaHovedytelse';
+import { tekstEllerKode } from '../../../../utils/tekstformatering';
+
+const Hovedytelse: React.FC<{ faktaHovedytelse: FaktaHovedytelse }> = ({ faktaHovedytelse }) => {
+    return (
+        <InfoSeksjon label="Ytelse/situasjon" ikon={<CardIcon />}>
+            <BodyShort size="small">
+                {faktaHovedytelse.søknadsgrunnlag?.hovedytelse
+                    ?.map((hovedytelse) => tekstEllerKode(hovedytelseTilTekst, hovedytelse))
+                    ?.join(', ')}
+            </BodyShort>
+        </InfoSeksjon>
+    );
+};
+
+export default Hovedytelse;

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Oppsummering.tsx
@@ -1,16 +1,16 @@
 import React from 'react';
 
-import { VStack } from '@navikt/ds-react';
+import { CalendarIcon } from '@navikt/aksel-icons';
+import { BodyShort, VStack } from '@navikt/ds-react';
 
 import Aktivitet from './Aktivitet';
 import ArbeidOgOpphold from './ArbeidOgOpphold';
 import BarnDetaljer from './BarnDetaljer';
+import Hovedytelse from './Hovedytelse';
 import Vedlegg from './Vedlegg';
-import { Informasjonskilde, Informasjonsrad, InfoSeksjon } from './Visningskomponenter';
+import { InfoSeksjon } from './Visningskomponenter';
 import { useBehandling } from '../../../../context/BehandlingContext';
-import { hovedytelseTilTekst } from '../../../../typer/behandling/behandlingFakta/faktaHovedytelse';
 import { formaterDato } from '../../../../utils/dato';
-import { tekstEllerKode } from '../../../../utils/tekstformatering';
 
 const Oppsummering: React.FC = () => {
     const { behandlingFakta } = useBehandling();
@@ -18,33 +18,22 @@ const Oppsummering: React.FC = () => {
     return (
         <VStack gap="8">
             {behandlingFakta.søknadMottattTidspunkt && (
-                <InfoSeksjon label="Søknadsdato">
-                    <Informasjonsrad
-                        kilde={Informasjonskilde.SØKNAD}
-                        verdi={formaterDato(behandlingFakta.søknadMottattTidspunkt)}
-                    />
-                </InfoSeksjon>
-            )}
-            <InfoSeksjon label="Ytelse/situasjon">
-                <Informasjonsrad
-                    kilde={Informasjonskilde.SØKNAD}
-                    verdi={behandlingFakta.hovedytelse.søknadsgrunnlag?.hovedytelse
-                        ?.map((hovedytelse) => tekstEllerKode(hovedytelseTilTekst, hovedytelse))
-                        ?.join(', ')}
-                />
-            </InfoSeksjon>
-            {behandlingFakta.hovedytelse.søknadsgrunnlag?.arbeidOgOpphold && (
-                <InfoSeksjon label={'Arbeid og opphold'}>
-                    <ArbeidOgOpphold
-                        fakta={behandlingFakta.hovedytelse.søknadsgrunnlag.arbeidOgOpphold}
-                    />
+                <InfoSeksjon label="Søknadsdato" ikon={<CalendarIcon />}>
+                    <BodyShort size="small">
+                        {formaterDato(behandlingFakta.søknadMottattTidspunkt)}
+                    </BodyShort>
                 </InfoSeksjon>
             )}
 
-            <InfoSeksjon label="Aktivitet">
-                {/* TODO: Legg inn info om aktiviteter*/}
-                <Aktivitet aktivitet={behandlingFakta.aktivitet}></Aktivitet>
-            </InfoSeksjon>
+            <Hovedytelse faktaHovedytelse={behandlingFakta.hovedytelse} />
+
+            {behandlingFakta.hovedytelse.søknadsgrunnlag?.arbeidOgOpphold && (
+                <ArbeidOgOpphold
+                    fakta={behandlingFakta.hovedytelse.søknadsgrunnlag.arbeidOgOpphold}
+                />
+            )}
+
+            <Aktivitet aktivitet={behandlingFakta.aktivitet}></Aktivitet>
 
             {behandlingFakta.barn.map((barn) => (
                 <BarnDetaljer barn={barn} key={barn.barnId} />

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringSøknad.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringSøknad.tsx
@@ -12,7 +12,7 @@ import { InfoSeksjon } from './Visningskomponenter';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { formaterDato } from '../../../../utils/dato';
 
-const Oppsummering: React.FC = () => {
+const OppsummeringSøknad: React.FC = () => {
     const { behandlingFakta } = useBehandling();
 
     return (
@@ -44,4 +44,4 @@ const Oppsummering: React.FC = () => {
     );
 };
 
-export default Oppsummering;
+export default OppsummeringSøknad;

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Vedlegg.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Vedlegg.tsx
@@ -1,28 +1,25 @@
 import React from 'react';
 
-import { Link } from '@navikt/ds-react';
+import { PaperclipIcon } from '@navikt/aksel-icons';
+import { BodyShort, Link } from '@navikt/ds-react';
 
-import { Informasjonskilde, Informasjonsrad, InfoSeksjon } from './Visningskomponenter';
+import { InfoSeksjon } from './Visningskomponenter';
 import { FaktaDokumentasjon } from '../../../../typer/behandling/behandlingFakta/faktaDokumentasjon';
 
 const Vedlegg: React.FC<{ fakta?: FaktaDokumentasjon }> = ({ fakta }) => {
     if (!fakta) return null;
     return (
-        <InfoSeksjon label={`Vedlegg`}>
+        <InfoSeksjon label={`Vedlegg`} ikon={<PaperclipIcon />}>
             {fakta.dokumentasjon.flatMap((dokumentasjon) =>
                 dokumentasjon.dokumenter.map((dokument) => (
-                    <Informasjonsrad
-                        key={dokument.dokumentInfoId}
-                        kilde={Informasjonskilde.SØKNAD}
-                        verdi={
-                            <Link
-                                target="_blank"
-                                href={`/dokument/journalpost/${fakta.journalpostId}/dokument-pdf/${dokument.dokumentInfoId}`}
-                            >
-                                {dokumentasjon.type}
-                            </Link>
-                        }
-                    />
+                    <BodyShort size="small" key={dokument.dokumentInfoId}>
+                        <Link
+                            target="_blank"
+                            href={`/dokument/journalpost/${fakta.journalpostId}/dokument-pdf/${dokument.dokumentInfoId}`}
+                        >
+                            {dokumentasjon.type}
+                        </Link>
+                    </BodyShort>
                 ))
             )}
         </InfoSeksjon>

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Visningskomponenter.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Visningskomponenter.tsx
@@ -1,43 +1,20 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 
-import { DatabaseIcon, FileTextIcon } from '@navikt/aksel-icons';
-import { BodyShort, Heading, HStack, VStack } from '@navikt/ds-react';
+import { HStack, Heading, VStack } from '@navikt/ds-react';
 
-export enum Informasjonskilde {
-    REGISTER = 'REGISTER',
-    SØKNAD = 'SØKNAD',
-}
-
-const mapIkon = (ikon: Informasjonskilde) => {
-    switch (ikon) {
-        case Informasjonskilde.REGISTER:
-            return <DatabaseIcon />;
-        case Informasjonskilde.SØKNAD:
-            return <FileTextIcon />;
-    }
-};
-
-export const Informasjonsrad: React.FC<{
-    kilde: Informasjonskilde;
-    verdi?: string | ReactNode;
-}> = ({ kilde, verdi = 'Ingen data registrert' }) => {
+export const InfoSeksjon: React.FC<{
+    label: string;
+    ikon: React.ReactNode;
+    children?: React.ReactNode;
+}> = ({ label, ikon, children }) => {
     return (
-        <HStack gap="2" wrap={false}>
-            {mapIkon(kilde)}
-            <BodyShort size="small">{verdi}</BodyShort>
-        </HStack>
-    );
-};
-
-export const InfoSeksjon: React.FC<{ label: string; children?: React.ReactNode }> = ({
-    label,
-    children,
-}) => {
-    return (
-        <VStack gap="4">
-            <Heading level={'4'} size={'xsmall'}>
-                {label}
-            </Heading>
+        <VStack gap="2">
+            <HStack gap="2" align="center" wrap={false}>
+                <div style={{ height: '18px' }}>{ikon}</div>
+                <Heading level={'4'} size={'xsmall'}>
+                    {label}
+                </Heading>
+            </HStack>
             {children}
         </VStack>
     );

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Box, Tabs } from '@navikt/ds-react';
 import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 
-import Oppsummering from './Oppsummering/Oppsummering';
+import OppsummeringSøknad from './Oppsummering/OppsummeringSøknad';
 import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
 import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
 
@@ -24,7 +24,7 @@ const tabs = [
     {
         value: 'søknaden',
         label: 'Søknaden',
-        komponent: <Oppsummering />,
+        komponent: <OppsummeringSøknad />,
     },
 ];
 

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -22,8 +22,8 @@ const StickyTablistContainer = styled(Sticky)`
 
 const tabs = [
     {
-        value: 'oppsummering',
-        label: 'Oppsummert',
+        value: 'søknaden',
+        label: 'Søknaden',
         komponent: <Oppsummering />,
     },
 ];
@@ -32,7 +32,7 @@ const VenstreMeny: React.FC = () => {
     return (
         <Container>
             <Totrinnskontroll />
-            <Tabs defaultValue="oppsummering" style={{ width: 'inherit', height: '100%' }}>
+            <Tabs defaultValue="søknaden" style={{ width: 'inherit', height: '100%' }}>
                 <StickyTablistContainer>
                     <Tabs.List>
                         {tabs.map((tab) => (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ikke nødvendig å ha med alle søknad-ikonene når all informasjonen er fra søknaden. [FAVRO](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20852)

Mer vanlig situasjon: 
<img width="326" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/f3a6e903-da68-4335-8d4e-7a351d5508e6">

Mer info: 
<img width="326" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/97140f75-54ee-4f17-8504-19de4e2168aa">
<img width="326" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/100b0aa9-5d34-4b00-81c8-db8ea6d8432a">
