### PR TITLE
Delt opp oppgavetyper i 2 ulike grupper. De viktigste blir vist først

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -18,7 +18,11 @@ import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../../utils/rol
 import { Saksbehandler } from '../../../utils/saksbehandler';
 import { enhetTilTekst, FortroligEnhet, IkkeFortroligEnhet } from '../typer/enhet';
 import { behandlingstemaTilTekst, OppgaveRequest } from '../typer/oppgave';
-import { oppgaveTypeTilTekst } from '../typer/oppgavetema';
+import {
+    oppgaverTyperSomSkalVisesFørst,
+    oppgaveTypeTilTekst,
+    øvrigeOppgaveTyper,
+} from '../typer/oppgavetema';
 
 const FlexDiv = styled.div`
     display: flex;
@@ -99,11 +103,18 @@ export const Oppgavefiltrering = () => {
                     size="small"
                 >
                     <option value="">Alle</option>
-                    {Object.entries(oppgaveTypeTilTekst).map(([type, val]) => (
+                    {oppgaverTyperSomSkalVisesFørst.map((type) => (
                         <option key={type} value={type}>
-                            {val}
+                            {oppgaveTypeTilTekst[type]}
                         </option>
                     ))}
+                    <optgroup label={'Øvrige'}>
+                        {øvrigeOppgaveTyper.map((type) => (
+                            <option key={type} value={type}>
+                                {oppgaveTypeTilTekst[type]}
+                            </option>
+                        ))}
+                    </optgroup>
                 </Select>
                 <Select
                     value={oppgaveRequest.behandlingstema || ''}

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
@@ -43,4 +43,19 @@ export const oppgaveTypeTilTekst: Record<Oppgavetype, string> = {
     VUR_SVAR: 'Vurder svar',
 };
 
+export const oppgaverTyperSomSkalVisesFørst: Oppgavetype[] = [
+    'BEH_SAK',
+    'GOD_VED',
+    'JFR',
+    'KONT_BRUK',
+    'SVAR_IK_MOT',
+    'VUR',
+    'VURD_HENV',
+    'VUR_KONS_YTE',
+];
+
+export const øvrigeOppgaveTyper: Oppgavetype[] = Object.keys(oppgaveTypeTilTekst).filter(
+    (type) => !oppgaverTyperSomSkalVisesFørst.includes(type as Oppgavetype)
+) as Oppgavetype[];
+
 export type Prioritet = 'HOY' | 'NORM' | 'LAV';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20860

Tok i bruk optgroup for å splitte vanlige og øvrige oppgaver. 

Foreslå dette for Marie og hon tyckte ble ok.
<img width="371" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/8a411c67-2563-40c6-9617-04160ef3c4da">
