### PR TITLE
Fjerner uønsket whitespace. Gir overskrift samme størrelse som andre …

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Button, Table } from '@navikt/ds-react';
+import { Button, Heading, Table } from '@navikt/ds-react';
 
 import { Registeraktivitet } from '../../../typer/registeraktivitet';
 import { formaterNullableIsoDato } from '../../../utils/dato';
@@ -13,8 +13,8 @@ const Tabell = styled(Table)`
 
 const RegisterAktiviteter: React.FC<{ aktiviteter: Registeraktivitet[] }> = ({ aktiviteter }) => {
     return (
-        <>
-            <h2>Brukers registrerte aktiviteter</h2>
+        <div>
+            <Heading size="small">Brukers registrerte aktiviteter</Heading>
             <Tabell size={'small'}>
                 <Table.Header>
                     <Table.Row>
@@ -55,7 +55,7 @@ const RegisterAktiviteter: React.FC<{ aktiviteter: Registeraktivitet[] }> = ({ a
                     })}
                 </Table.Body>
             </Tabell>
-        </>
+        </div>
     );
 };
 


### PR DESCRIPTION
…overskrifter på siden. Bruker <div> for at overskrift skal regnes som samme enhet i Kolonnen for å unngå GAP mellom overskrift og tabell.

### Hvorfor er denne endringen nødvendig? ✨

### FØR:

![Skjermbilde 2024-05-21 kl  14 29 13](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/28704275/5d0fdeb5-5eb7-4d37-bc32-c0666258c419)

****

### ETTER:

![Skjermbilde 2024-05-21 kl  14 30 06](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/28704275/1489b178-9dc2-4a8f-aa02-e77050732b72)

