### PR TITLE
Oppgavebenk paginering med api kall

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -24,9 +24,9 @@ const AlertContainer = styled.div`
 `;
 
 const OppgavebenkContainer = () => {
-    const { feilmelding, oppgaveRessurs, lasterOppgaveRequestFraLokalt } = useOppgave();
+    const { feilmelding, oppgaveRessurs, lasterOppgaveRequestFraLocaleStorage } = useOppgave();
 
-    if (lasterOppgaveRequestFraLokalt) {
+    if (lasterOppgaveRequestFraLocaleStorage) {
         return <SystemetLaster />;
     }
 

--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -34,7 +34,7 @@ const OppgavebenkContainer = () => {
         <Container>
             <Oppgavefiltrering />
             <DataViewer response={{ oppgaver: oppgaveRessurs }}>
-                {({ oppgaver }) => <Oppgavetabell oppgaver={oppgaver.oppgaver} />}
+                {({ oppgaver }) => <Oppgavetabell oppgaverResponse={oppgaver} />}
             </DataViewer>
             <Feilmelding>{feilmelding}</Feilmelding>
         </Container>

--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -11,6 +11,7 @@ import { useApp } from '../../context/AppContext';
 import { OppgaveProvider, useOppgave } from '../../context/OppgaveContext';
 import DataViewer from '../../komponenter/DataViewer';
 import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
+import SystemetLaster from '../../komponenter/SystemetLaster/SystemetLaster';
 import { erProd } from '../../utils/miljø';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
@@ -23,7 +24,12 @@ const AlertContainer = styled.div`
 `;
 
 const OppgavebenkContainer = () => {
-    const { feilmelding, oppgaveRessurs } = useOppgave();
+    const { feilmelding, oppgaveRessurs, lasterOppgaveRequestFraLokalt } = useOppgave();
+
+    if (lasterOppgaveRequestFraLokalt) {
+        return <SystemetLaster />;
+    }
+
     return (
         <Container>
             <Oppgavefiltrering />

--- a/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
@@ -3,23 +3,31 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { Pagination, Table } from '@navikt/ds-react';
+import { SortState } from '@navikt/ds-react/src/table/types';
 
 import Oppgaverad from './Oppgaverad';
-import { IdentGruppe, Oppgave } from './typer/oppgave';
-import { usePagineringState } from '../../hooks/felles/usePaginerState';
-import { useSorteringState } from '../../hooks/felles/useSorteringState';
+import { defaultSortering, utledAntallSider, utledSide } from './oppgaverequestUtil';
+import {
+    IdentGruppe,
+    Oppgave,
+    OppgaveOrderBy,
+    OppgaveRequest,
+    OppgaverResponse,
+} from './typer/oppgave';
+import { useOppgave } from '../../context/OppgaveContext';
 import { PartialRecord } from '../../typer/common';
+
 const Tabell = styled(Table)`
     width: 1100px;
 `;
 interface Props {
-    oppgaver: Oppgave[];
+    oppgaverResponse: OppgaverResponse;
 }
 
-const tabellHeaders: PartialRecord<keyof Oppgave, { tittel: string; erSorterbar?: boolean }> = {
-    oppgavetype: { tittel: 'Oppgavetype', erSorterbar: false },
-    behandlingstema: { tittel: 'Stønad', erSorterbar: false },
-    opprettetTidspunkt: { tittel: 'Opprettet', erSorterbar: true },
+const tabellHeaders: PartialRecord<keyof Oppgave, { tittel: string; orderBy?: OppgaveOrderBy }> = {
+    oppgavetype: { tittel: 'Oppgavetype' },
+    behandlingstema: { tittel: 'Stønad' },
+    opprettetTidspunkt: { tittel: 'Opprettet', orderBy: 'OPPRETTET_TIDSPUNKT' },
     identer: { tittel: 'Ident' },
     tilordnetRessurs: { tittel: 'Saksbehandler' },
 };
@@ -28,24 +36,52 @@ export const utledetFolkeregisterIdent = (oppgave: Oppgave) =>
     oppgave.identer?.filter((i) => i.gruppe === IdentGruppe.FOLKEREGISTERIDENT)[0].ident ||
     'Ukjent ident';
 
-const Oppgavetabell: React.FC<Props> = ({ oppgaver }) => {
-    const { sortertListe, settSortering, sortState } = useSorteringState<Oppgave>(oppgaver, {
-        orderBy: 'opprettetTidspunkt',
-        direction: 'ascending',
-    });
+const utledKeyForOrderBy = (oppgaveRequest: OppgaveRequest): keyof Oppgave => {
+    const orderBy = Object.entries(tabellHeaders).find(
+        ([, { orderBy }]) => orderBy && orderBy === oppgaveRequest.orderBy
+    )?.[0] as keyof Oppgave;
+    return orderBy ?? 'opprettetTidspunkt';
+};
 
-    const { valgtSide, settValgtSide, slicedListe, antallSider } = usePagineringState(
-        sortertListe,
-        1,
-        15
-    );
+const utledOrderByFraKey = (oppgaveKey: keyof Oppgave): OppgaveOrderBy =>
+    Object.entries(tabellHeaders).find(([key]) => key === oppgaveKey)?.[1].orderBy ??
+    defaultSortering.orderBy;
+
+const utledTabellSort = (oppgaveRequest: OppgaveRequest): SortState => ({
+    orderBy: utledKeyForOrderBy(oppgaveRequest),
+    direction: oppgaveRequest.order === 'ASC' ? 'ascending' : 'descending',
+});
+
+const Oppgavetabell: React.FC<Props> = ({ oppgaverResponse }) => {
+    const { oppgaveRequest, settOppgaveRequest, hentOppgaver } = useOppgave();
+    const side = utledSide(oppgaveRequest);
+    const antallSider = utledAntallSider(oppgaverResponse);
+
+    const oppdaterValgtSide = (valgtSide: number) => {
+        const oppdatertOppgaveRequest: OppgaveRequest = {
+            ...oppgaveRequest,
+            offset: (valgtSide - 1) * defaultSortering.offset,
+        };
+        settOppgaveRequest(oppdatertOppgaveRequest);
+        hentOppgaver(oppdatertOppgaveRequest);
+    };
+
+    const oppdaterSortering = (orderKey: keyof Oppgave) => {
+        const oppdatertOppgaveRequest: OppgaveRequest = {
+            ...oppgaveRequest,
+            orderBy: utledOrderByFraKey(orderKey),
+            order: oppgaveRequest.order === 'ASC' ? 'DESC' : 'ASC',
+        };
+        settOppgaveRequest(oppdatertOppgaveRequest);
+        hentOppgaver(oppdatertOppgaveRequest);
+    };
 
     return (
         <>
             <Tabell
                 size="small"
-                sort={sortState}
-                onSortChange={(sortKey) => settSortering(sortKey as keyof Oppgave)}
+                sort={utledTabellSort(oppgaveRequest)}
+                onSortChange={(sortKey) => oppdaterSortering(sortKey as keyof Oppgave)}
                 zebraStripes
             >
                 <Table.Header>
@@ -54,7 +90,7 @@ const Oppgavetabell: React.FC<Props> = ({ oppgaver }) => {
                             <Table.ColumnHeader
                                 key={`${indeks}${key}`}
                                 sortKey={key}
-                                sortable={value.erSorterbar}
+                                sortable={!!value.orderBy}
                             >
                                 {value.tittel}
                             </Table.ColumnHeader>
@@ -62,16 +98,16 @@ const Oppgavetabell: React.FC<Props> = ({ oppgaver }) => {
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                    {slicedListe.map((oppgave) => (
+                    {oppgaverResponse.oppgaver.map((oppgave) => (
                         <Oppgaverad key={oppgave.id} oppgave={oppgave} />
                     ))}
                 </Table.Body>
             </Tabell>
             {antallSider > 1 && (
                 <Pagination
-                    page={valgtSide}
+                    page={side}
                     count={antallSider}
-                    onPageChange={settValgtSide}
+                    onPageChange={oppdaterValgtSide}
                     size="small"
                 />
             )}

--- a/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
@@ -32,23 +32,25 @@ const tabellHeaders: PartialRecord<keyof Oppgave, { tittel: string; orderBy?: Op
     tilordnetRessurs: { tittel: 'Saksbehandler' },
 };
 
+const orderByTilHeader: Record<OppgaveOrderBy, keyof Oppgave> = Object.entries(
+    tabellHeaders
+).reduce(
+    (prev, [key, { orderBy }]) => ({
+        ...prev,
+        ...(orderBy ? { [orderBy]: key } : {}),
+    }),
+    {} as Record<OppgaveOrderBy, keyof Oppgave>
+);
+
 export const utledetFolkeregisterIdent = (oppgave: Oppgave) =>
     oppgave.identer?.filter((i) => i.gruppe === IdentGruppe.FOLKEREGISTERIDENT)[0].ident ||
     'Ukjent ident';
 
-const utledKeyForOrderBy = (oppgaveRequest: OppgaveRequest): keyof Oppgave => {
-    const orderBy = Object.entries(tabellHeaders).find(
-        ([, { orderBy }]) => orderBy && orderBy === oppgaveRequest.orderBy
-    )?.[0] as keyof Oppgave;
-    return orderBy ?? 'opprettetTidspunkt';
-};
-
 const utledOrderByFraKey = (oppgaveKey: keyof Oppgave): OppgaveOrderBy =>
-    Object.entries(tabellHeaders).find(([key]) => key === oppgaveKey)?.[1].orderBy ??
-    defaultSortering.orderBy;
+    tabellHeaders[oppgaveKey]?.orderBy ?? defaultSortering.orderBy;
 
 const utledTabellSort = (oppgaveRequest: OppgaveRequest): SortState => ({
-    orderBy: utledKeyForOrderBy(oppgaveRequest),
+    orderBy: orderByTilHeader[oppgaveRequest.orderBy] ?? 'opprettetTidspunkt',
     direction: oppgaveRequest.order === 'ASC' ? 'ascending' : 'descending',
 });
 

--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -4,13 +4,17 @@ import styled from 'styled-components';
 
 import { Button, Select, TextField, VStack } from '@navikt/ds-react';
 
-import { oppdaterFilter, oppgaveRequestMedDefaultEnhet } from './filterutils';
+import { oppdaterFilter } from './filterutils';
 import { lagreTilLocalStorage, oppgaveRequestKey } from './oppgavefilterStorage';
 import SaksbehandlerVelger from './SaksbehandlerVelger';
 import { useApp } from '../../../context/AppContext';
 import { useOppgave } from '../../../context/OppgaveContext';
 import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../../utils/roller';
-import { defaultOppgaveRequest, nullstillSortering } from '../oppgaverequestUtil';
+import {
+    defaultOppgaveRequest,
+    nullstillSortering,
+    oppgaveRequestMedDefaultEnhet,
+} from '../oppgaverequestUtil';
 import { enhetTilTekst } from '../typer/enhet';
 import { behandlingstemaTilTekst, OppgaveRequest } from '../typer/oppgave';
 import {

--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -4,13 +4,14 @@ import styled from 'styled-components';
 
 import { Button, Select, TextField, VStack } from '@navikt/ds-react';
 
-import { oppdaterFilter } from './filterutils';
+import { oppdaterFilter, oppgaveRequestMedDefaultEnhet } from './filterutils';
 import { lagreTilLocalStorage, oppgaveRequestKey } from './oppgavefilterStorage';
 import SaksbehandlerVelger from './SaksbehandlerVelger';
 import { useApp } from '../../../context/AppContext';
 import { useOppgave } from '../../../context/OppgaveContext';
 import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../../utils/roller';
-import { enhetTilTekst, FortroligEnhet, IkkeFortroligEnhet } from '../typer/enhet';
+import { defaultOppgaveRequest } from '../oppgaverequestUtil';
+import { enhetTilTekst } from '../typer/enhet';
 import { behandlingstemaTilTekst, OppgaveRequest } from '../typer/oppgave';
 import {
     oppgaverTyperSomSkalVisesFørst,
@@ -37,9 +38,6 @@ export const Oppgavefiltrering = () => {
 
     const harSaksbehandlerStrengtFortroligRolle = harStrengtFortroligRolle(appEnv, saksbehandler);
     const harSaksbehandlerEgenAnsattRolle = harEgenAnsattRolle(appEnv, saksbehandler);
-    const tomOppgaveRequest = harSaksbehandlerStrengtFortroligRolle
-        ? { enhet: FortroligEnhet.VIKAFOSSEN }
-        : { enhet: IkkeFortroligEnhet.NAY };
 
     const oppdaterOppgave = (key: keyof OppgaveRequest) => (val?: string | number) =>
         settOppgaveRequest((prevState) => oppdaterFilter(prevState, key, val));
@@ -54,6 +52,10 @@ export const Oppgavefiltrering = () => {
     };
 
     const nullstillFiltrering = () => {
+        const tomOppgaveRequest = oppgaveRequestMedDefaultEnhet(
+            defaultOppgaveRequest,
+            harSaksbehandlerStrengtFortroligRolle
+        );
         lagreTilLocalStorage(oppgaveRequestKey(saksbehandler.navIdent), tomOppgaveRequest);
         settOppgaveRequest(tomOppgaveRequest);
     };

--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -10,7 +10,7 @@ import SaksbehandlerVelger from './SaksbehandlerVelger';
 import { useApp } from '../../../context/AppContext';
 import { useOppgave } from '../../../context/OppgaveContext';
 import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../../utils/roller';
-import { defaultOppgaveRequest } from '../oppgaverequestUtil';
+import { defaultOppgaveRequest, nullstillSortering } from '../oppgaverequestUtil';
 import { enhetTilTekst } from '../typer/enhet';
 import { behandlingstemaTilTekst, OppgaveRequest } from '../typer/oppgave';
 import {
@@ -47,8 +47,10 @@ export const Oppgavefiltrering = () => {
             oppdaterOppgave(key)(e.target.value);
 
     const sjekkFeilOgHentOppgaver = () => {
-        lagreTilLocalStorage(oppgaveRequestKey(saksbehandler.navIdent), oppgaveRequest);
-        hentOppgaver(oppgaveRequest);
+        const nullstiltSortering = nullstillSortering(oppgaveRequest);
+        settOppgaveRequest(nullstiltSortering);
+        lagreTilLocalStorage(oppgaveRequestKey(saksbehandler.navIdent), nullstiltSortering);
+        hentOppgaver(nullstiltSortering);
     };
 
     const nullstillFiltrering = () => {

--- a/src/frontend/Sider/Oppgavebenk/filter/filterutils.ts
+++ b/src/frontend/Sider/Oppgavebenk/filter/filterutils.ts
@@ -9,6 +9,7 @@ export const oppdaterFilter = (
     if (!val || val === '') {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { [key]: setNull, ...remainder } = object;
+        // @ts-ignore
         return remainder;
     }
     return {

--- a/src/frontend/Sider/Oppgavebenk/filter/filterutils.ts
+++ b/src/frontend/Sider/Oppgavebenk/filter/filterutils.ts
@@ -1,4 +1,3 @@
-import { FortroligEnhet, IkkeFortroligEnhet } from '../typer/enhet';
 import { OppgaveRequest } from '../typer/oppgave';
 
 export const oppdaterFilter = (
@@ -16,22 +15,4 @@ export const oppdaterFilter = (
         ...object,
         [key]: val,
     };
-};
-
-export const oppgaveRequestMedDefaultEnhet = (
-    oppgaveRequest: OppgaveRequest,
-    harSaksbehandlerStrengtFortroligRolle: boolean
-): OppgaveRequest => {
-    if (harSaksbehandlerStrengtFortroligRolle) {
-        return {
-            ...oppgaveRequest,
-            enhet: FortroligEnhet.VIKAFOSSEN,
-        };
-    } else {
-        const enhet = oppgaveRequest.enhet;
-        return {
-            ...oppgaveRequest,
-            enhet: enhet || IkkeFortroligEnhet.NAY,
-        };
-    }
 };

--- a/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
+++ b/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
@@ -1,6 +1,9 @@
-import { oppgaveRequestMedDefaultEnhet } from './filterutils';
 import { Saksbehandler } from '../../../utils/saksbehandler';
-import { defaultOppgaveRequest, defaultSortering } from '../oppgaverequestUtil';
+import {
+    defaultOppgaveRequest,
+    defaultSortering,
+    oppgaveRequestMedDefaultEnhet,
+} from '../oppgaverequestUtil';
 import { OppgaveRequest } from '../typer/oppgave';
 
 export const oppgaveRequestKeyPrefix = 'oppgaveFiltreringRequest';

--- a/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
+++ b/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
@@ -1,3 +1,8 @@
+import { oppgaveRequestMedDefaultEnhet } from './filterutils';
+import { Saksbehandler } from '../../../utils/saksbehandler';
+import { defaultOppgaveRequest, defaultSortering } from '../oppgaverequestUtil';
+import { OppgaveRequest } from '../typer/oppgave';
+
 export const oppgaveRequestKeyPrefix = 'oppgaveFiltreringRequest';
 
 export const oppgaveRequestKey = (innloggetIdent: string): string => {
@@ -19,4 +24,27 @@ export const hentFraLocalStorage = <T>(key: string, fallbackVerdi: T): T => {
     } catch {
         return fallbackVerdi;
     }
+};
+
+export const hentLagretOppgaveRequest = (
+    saksbehandler: Saksbehandler,
+    harSaksbehandlerStrengtFortroligRolle: boolean
+): OppgaveRequest => {
+    const fraLocalStorage = hentFraLocalStorage<Partial<OppgaveRequest>>(
+        oppgaveRequestKey(saksbehandler.navIdent),
+        defaultOppgaveRequest
+    );
+
+    const fraLocalStorageMedDefaultVerdier: OppgaveRequest = {
+        ...fraLocalStorage,
+        limit: fraLocalStorage.limit ?? defaultSortering.limit,
+        offset: fraLocalStorage.offset ?? defaultSortering.offset,
+        order: defaultSortering.order,
+        orderBy: defaultSortering.orderBy,
+    };
+
+    return oppgaveRequestMedDefaultEnhet(
+        fraLocalStorageMedDefaultVerdier,
+        harSaksbehandlerStrengtFortroligRolle
+    );
 };

--- a/src/frontend/Sider/Oppgavebenk/oppgaverequestUtil.ts
+++ b/src/frontend/Sider/Oppgavebenk/oppgaverequestUtil.ts
@@ -1,3 +1,4 @@
+import { FortroligEnhet, IkkeFortroligEnhet } from './typer/enhet';
 import { OppgaveRequest, OppgaverResponse } from './typer/oppgave';
 
 const OPPGAVE_SIDE_STØRRELSE = 15;
@@ -16,6 +17,24 @@ export const nullstillSortering = (oppgaveRequest: OppgaveRequest): OppgaveReque
 
 export const defaultOppgaveRequest: OppgaveRequest = {
     ...defaultSortering,
+};
+
+export const oppgaveRequestMedDefaultEnhet = (
+    oppgaveRequest: OppgaveRequest,
+    harSaksbehandlerStrengtFortroligRolle: boolean
+): OppgaveRequest => {
+    if (harSaksbehandlerStrengtFortroligRolle) {
+        return {
+            ...oppgaveRequest,
+            enhet: FortroligEnhet.VIKAFOSSEN,
+        };
+    } else {
+        const enhet = oppgaveRequest.enhet;
+        return {
+            ...oppgaveRequest,
+            enhet: enhet || IkkeFortroligEnhet.NAY,
+        };
+    }
 };
 
 export const utledSide = (oppgaveRequest: OppgaveRequest | undefined) =>

--- a/src/frontend/Sider/Oppgavebenk/oppgaverequestUtil.ts
+++ b/src/frontend/Sider/Oppgavebenk/oppgaverequestUtil.ts
@@ -1,4 +1,4 @@
-import { OppgaveRequest } from './typer/oppgave';
+import { OppgaveRequest, OppgaverResponse } from './typer/oppgave';
 
 const OPPGAVE_SIDE_STØRRELSE = 15;
 
@@ -17,3 +17,9 @@ export const nullstillSortering = (oppgaveRequest: OppgaveRequest): OppgaveReque
 export const defaultOppgaveRequest: OppgaveRequest = {
     ...defaultSortering,
 };
+
+export const utledSide = (oppgaveRequest: OppgaveRequest | undefined) =>
+    oppgaveRequest?.offset ? Math.ceil(oppgaveRequest.offset / OPPGAVE_SIDE_STØRRELSE) + 1 : 1;
+
+export const utledAntallSider = (oppgaverResponse: OppgaverResponse) =>
+    Math.ceil(oppgaverResponse.antallTreffTotalt / OPPGAVE_SIDE_STØRRELSE);

--- a/src/frontend/Sider/Oppgavebenk/oppgaverequestUtil.ts
+++ b/src/frontend/Sider/Oppgavebenk/oppgaverequestUtil.ts
@@ -1,0 +1,19 @@
+import { OppgaveRequest } from './typer/oppgave';
+
+const OPPGAVE_SIDE_STØRRELSE = 15;
+
+export const defaultSortering: Pick<OppgaveRequest, 'offset' | 'limit' | 'order' | 'orderBy'> = {
+    offset: 0,
+    limit: OPPGAVE_SIDE_STØRRELSE,
+    orderBy: 'OPPRETTET_TIDSPUNKT',
+    order: 'ASC',
+};
+
+export const nullstillSortering = (oppgaveRequest: OppgaveRequest): OppgaveRequest => ({
+    ...oppgaveRequest,
+    ...defaultSortering,
+});
+
+export const defaultOppgaveRequest: OppgaveRequest = {
+    ...defaultSortering,
+};

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -22,7 +22,15 @@ export interface OppgaveRequest {
     fristTom?: string;
     erUtenMappe?: boolean;
     ident?: string;
+
+    limit?: number;
+    offset?: number;
+    orderBy?: OppgaveOrderBy;
+    order?: OppgaveOrder;
 }
+
+export type OppgaveOrderBy = 'OPPRETTET_TIDSPUNKT' | 'AKTIV_DATO' | 'FRIST' | 'ENDRET_TIDSPUNKT';
+export type OppgaveOrder = 'ASC' | 'DESC';
 
 export interface OppgaverResponse {
     antallTreffTotalt: number;

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -23,10 +23,10 @@ export interface OppgaveRequest {
     erUtenMappe?: boolean;
     ident?: string;
 
-    limit?: number;
-    offset?: number;
-    orderBy?: OppgaveOrderBy;
-    order?: OppgaveOrder;
+    limit: number;
+    offset: number;
+    orderBy: OppgaveOrderBy;
+    order: OppgaveOrder;
 }
 
 export type OppgaveOrderBy = 'OPPRETTET_TIDSPUNKT' | 'AKTIV_DATO' | 'FRIST' | 'ENDRET_TIDSPUNKT';

--- a/src/frontend/context/OppgaveContext.ts
+++ b/src/frontend/context/OppgaveContext.ts
@@ -21,7 +21,7 @@ export const [OppgaveProvider, useOppgave] = constate(() => {
     const [oppgaveRessurs, settOppgaveRessurs] =
         useState<Ressurs<OppgaverResponse>>(byggTomRessurs());
     const [laster, settLaster] = useState<boolean>(false);
-    const [lasterOppgaveRequestFraLokalt, settLasterOppgaveRequestFraLokalt] =
+    const [lasterOppgaveRequestFraLocaleStorage, settLasterOppgaveRequestFraLocaleStorage] =
         useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
@@ -45,7 +45,7 @@ export const [OppgaveProvider, useOppgave] = constate(() => {
             harSaksbehandlerStrengtFortroligRolle
         );
         settOppgaveRequest(lagretFiltrering);
-        settLasterOppgaveRequestFraLokalt(false);
+        settLasterOppgaveRequestFraLocaleStorage(false);
         hentOppgaver(lagretFiltrering);
     }, [hentOppgaver, harSaksbehandlerStrengtFortroligRolle, saksbehandler]);
 
@@ -121,7 +121,7 @@ export const [OppgaveProvider, useOppgave] = constate(() => {
         tilbakestillFordeling,
         settOppgaveTilSaksbehandler,
         oppdaterOppgaveEtterTilbakestilling,
-        lasterOppgaveRequestFraLokalt,
+        lasterOppgaveRequestFraLocaleStorage,
         oppgaveRequest,
         settOppgaveRequest,
     };

--- a/src/frontend/context/OppgaveContext.ts
+++ b/src/frontend/context/OppgaveContext.ts
@@ -3,11 +3,7 @@ import { useCallback, useEffect, useState } from 'react';
 import constate from 'constate';
 
 import { useApp } from './AppContext';
-import { oppgaveRequestMedDefaultEnhet } from '../Sider/Oppgavebenk/filter/filterutils';
-import {
-    hentFraLocalStorage,
-    oppgaveRequestKey,
-} from '../Sider/Oppgavebenk/filter/oppgavefilterStorage';
+import { hentLagretOppgaveRequest } from '../Sider/Oppgavebenk/filter/oppgavefilterStorage';
 import { Oppgave, OppgaveRequest, OppgaverResponse } from '../Sider/Oppgavebenk/typer/oppgave';
 import {
     byggHenterRessurs,
@@ -18,19 +14,6 @@ import {
     RessursSuksess,
 } from '../typer/ressurs';
 import { harStrengtFortroligRolle } from '../utils/roller';
-import { Saksbehandler } from '../utils/saksbehandler';
-
-const hentLagretOppgaveRequest = (
-    saksbehandler: Saksbehandler,
-    harSaksbehandlerStrengtFortroligRolle: boolean
-): OppgaveRequest => {
-    const fraLocalStorage = hentFraLocalStorage<OppgaveRequest>(
-        oppgaveRequestKey(saksbehandler.navIdent),
-        {}
-    );
-
-    return oppgaveRequestMedDefaultEnhet(fraLocalStorage, harSaksbehandlerStrengtFortroligRolle);
-};
 
 export const [OppgaveProvider, useOppgave] = constate(() => {
     const { request, saksbehandler, appEnv } = useApp();

--- a/src/frontend/context/OppgaveContext.ts
+++ b/src/frontend/context/OppgaveContext.ts
@@ -22,7 +22,7 @@ export const [OppgaveProvider, useOppgave] = constate(() => {
         useState<Ressurs<OppgaverResponse>>(byggTomRessurs());
     const [laster, settLaster] = useState<boolean>(false);
     const [lasterOppgaveRequestFraLocaleStorage, settLasterOppgaveRequestFraLocaleStorage] =
-        useState<boolean>(false);
+        useState<boolean>(true);
     const [feilmelding, settFeilmelding] = useState<string>();
 
     const [oppgaveRequest, settOppgaveRequest] = useState<OppgaveRequest>(defaultOppgaveRequest);

--- a/src/frontend/context/OppgaveContext.ts
+++ b/src/frontend/context/OppgaveContext.ts
@@ -4,6 +4,7 @@ import constate from 'constate';
 
 import { useApp } from './AppContext';
 import { hentLagretOppgaveRequest } from '../Sider/Oppgavebenk/filter/oppgavefilterStorage';
+import { defaultOppgaveRequest } from '../Sider/Oppgavebenk/oppgaverequestUtil';
 import { Oppgave, OppgaveRequest, OppgaverResponse } from '../Sider/Oppgavebenk/typer/oppgave';
 import {
     byggHenterRessurs,
@@ -24,7 +25,7 @@ export const [OppgaveProvider, useOppgave] = constate(() => {
         useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const [oppgaveRequest, settOppgaveRequest] = useState<OppgaveRequest>({});
+    const [oppgaveRequest, settOppgaveRequest] = useState<OppgaveRequest>(defaultOppgaveRequest);
 
     const harSaksbehandlerStrengtFortroligRolle = harStrengtFortroligRolle(appEnv, saksbehandler);
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tidligere hentet vi 150 oppgaver fra oppgavesystemet, som oppgavebenken selv hadde paginering og sortering av.
Ulempen er hvis det finnes totalt 1000 oppgaver. Då får man bare hentet 150 uansett. hvis man endrer sorteringen i frontend vil man fortsatt kun gjøre den sorteringen på de siste 150 oppgavene, og ikke alle 1000.

Var litt vanskelig å splitte opp commitsen. Den mest spesielle er kanskje
* https://github.com/navikt/tilleggsstonader-sak-frontend/commit/bff25fd838dd0b56fe68f08dd368c6fb5ae24e98

Jeg kan godt ta en gjennomgang hvis det er ønskelig. 

https://github.com/navikt/tilleggsstonader-sak/pull/319
Litt koblet til Litt koblet til https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20858 men er mer som et steg 1 i den endringen.