### PR TITLE
Viser navn på bruker i oppgavetabellen for å unngå at man plukker en …

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
@@ -50,6 +50,7 @@ const Oppgaverad: React.FC<{ oppgave: Oppgave }> = ({ oppgave }) => {
                 </Popover>
             </Table.DataCell>
             <Table.DataCell>{utledetFolkeregisterIdent(oppgave)}</Table.DataCell>
+            <Table.DataCell>{oppgave.navn}</Table.DataCell>
             <Table.DataCell>
                 <Oppgaveknapp oppgave={oppgave} />
             </Table.DataCell>

--- a/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
@@ -21,6 +21,7 @@ const tabellHeaders: PartialRecord<keyof Oppgave, { tittel: string; erSorterbar?
     behandlingstema: { tittel: 'Stønad', erSorterbar: false },
     opprettetTidspunkt: { tittel: 'Opprettet', erSorterbar: true },
     identer: { tittel: 'Ident' },
+    navn: { tittel: 'Navn' },
     tilordnetRessurs: { tittel: 'Saksbehandler' },
 };
 

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -62,6 +62,11 @@ export interface Oppgave {
     endretTidspunkt?: string;
     prioritet?: Prioritet;
     status?: string;
+
+    /*
+    Ekstra felter som er lagt til i backend
+     */
+    navn?: string;
 }
 
 export interface IOppgaveIdent {


### PR DESCRIPTION
…oppgave på en person man kjenner

### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20858

* https://github.com/navikt/tilleggsstonader-sak/pull/320

Vil se bedre ut i dev, men sånn her vil det se ut: (fornavnet er identen på personen)
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/1a62caed-fd8e-4c8a-b20b-28a77d93c1a8)
