### PR TITLE
Lagt til behandlingId på oppgave for å enklere kunne gå til behandlin…

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/oppgaveutils.ts
+++ b/src/frontend/Sider/Oppgavebenk/oppgaveutils.ts
@@ -5,12 +5,14 @@ export const JOURNALPOST_QUERY_STRING = 'journalpostId';
 export const OPPGAVEID_QUERY_STRING = 'oppgaveId';
 
 const behandlingssakerForSaksbehandling: Oppgavetype[] = ['BEH_SAK', 'GOD_VED', 'BEH_UND_VED'];
-export const oppgaveErSaksbehandling = (oppgave: Oppgave) => {
+
+export const oppgaveErSaksbehandling = (oppgave: Oppgave): boolean => {
     const { behandlesAvApplikasjon, oppgavetype } = oppgave;
-    return (
+    return !!(
         behandlesAvApplikasjon === 'tilleggsstonader-sak' &&
         oppgavetype &&
-        behandlingssakerForSaksbehandling.includes(oppgavetype)
+        behandlingssakerForSaksbehandling.includes(oppgavetype) &&
+        oppgave.behandlingId
     );
 };
 

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -75,6 +75,7 @@ export interface Oppgave {
     Ekstra felter som er lagt til i backend
      */
     navn?: string;
+    behandlingId?: string;
 }
 
 export interface IOppgaveIdent {


### PR DESCRIPTION
…gen fra oppgavebenken

### Hvorfor er denne endringen nødvendig? ✨
Når jeg satt med å populere navn innså jeg at det hadde vært fint å populere oppgaven med behandlingId for å forenkle frontend litt

Og får då fjernet at man henter behandlingId når man klikker på en oppgave, for å sen gå til behandlingen.
Her får man gått til behandlingen direkte. Og unngår all kode i `gåTilBehandleSakOppgave`