### PR TITLE
✨ Grupper dokumeneter etter journalpostId, og sorter på tid

### DIFF
--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { Link, Table } from '@navikt/ds-react';
+import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 
 import { DokumentInfo } from '../../../typer/dokument';
 import { journalstatuserTilTekst } from '../../../typer/journalpost';
@@ -8,7 +9,7 @@ import { formaterNullableIsoDatoTid } from '../../../utils/dato';
 
 const DokumentRad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
     return (
-        <Table.Row>
+        <Table.Row style={{ backgroundColor: `${AGray50}` }}>
             <Table.DataCell>{formaterNullableIsoDatoTid(dokument.dato)}</Table.DataCell>
             <Table.DataCell>{dokument.journalposttype}</Table.DataCell>
             <Table.DataCell>

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentTabell.tsx
@@ -1,0 +1,53 @@
+import React from 'react';
+
+import { Table } from '@navikt/ds-react';
+
+import DokumentRad from './DokumentRad';
+import { Underrad } from './Underrad';
+import { DokumentInfo } from '../../../typer/dokument';
+import { groupBy } from '../../../utils/utils';
+
+export const DokumentTabell: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
+    const dokumentterGrupperPåJournalpost = groupBy(
+        dokumenter,
+        (dokument) => dokument.journalpostId
+    );
+
+    const journalposterSortertPåTid = Object.keys(dokumentterGrupperPåJournalpost).sort(
+        function (a, b) {
+            const datoA = dokumentterGrupperPåJournalpost[a][0].dato;
+            const datoB = dokumentterGrupperPåJournalpost[b][0].dato;
+            if (!datoA) {
+                return -1;
+            } else if (!datoB) {
+                return 1;
+            }
+            return datoA > datoB ? -1 : 1;
+        }
+    );
+    return (
+        <Table size="small">
+            <Table.Header>
+                <Table.Row>
+                    <Table.HeaderCell>Dato</Table.HeaderCell>
+                    <Table.HeaderCell>Inn/ut</Table.HeaderCell>
+                    <Table.HeaderCell>Tittel</Table.HeaderCell>
+                    <Table.HeaderCell>Avsender/mottaker</Table.HeaderCell>
+                    <Table.HeaderCell>Tema</Table.HeaderCell>
+                    <Table.HeaderCell>Status</Table.HeaderCell>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {journalposterSortertPåTid.map((journalpost) =>
+                    dokumentterGrupperPåJournalpost[journalpost].map((dokument, indeks) =>
+                        indeks === 0 ? (
+                            <DokumentRad key={dokument.dokumentInfoId} dokument={dokument} />
+                        ) : (
+                            <Underrad key={dokument.dokumentInfoId} dokument={dokument} />
+                        )
+                    )
+                )}
+            </Table.Body>
+        </Table>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -1,12 +1,12 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Heading, Table } from '@navikt/ds-react';
+import { Heading } from '@navikt/ds-react';
 
-import DokumentRad from './DokumentRad';
+import { DokumentTabell } from './DokumentTabell';
 import { useApp } from '../../../context/AppContext';
 import DataViewer from '../../../komponenter/DataViewer';
 import { DokumentInfo, Tema } from '../../../typer/dokument';
-import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
+import { byggTomRessurs, Ressurs } from '../../../typer/ressurs';
 
 type VedleggRequest = {
     tema?: Tema[]; // Arkiv
@@ -40,25 +40,7 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                 Dokumentoversikt
             </Heading>
             <DataViewer response={{ dokumenter }}>
-                {({ dokumenter }) => (
-                    <Table size="small" zebraStripes>
-                        <Table.Header>
-                            <Table.Row>
-                                <Table.HeaderCell>Dato</Table.HeaderCell>
-                                <Table.HeaderCell>Inn/ut</Table.HeaderCell>
-                                <Table.HeaderCell>Tittel</Table.HeaderCell>
-                                <Table.HeaderCell>Avsender/mottaker</Table.HeaderCell>
-                                <Table.HeaderCell>Tema</Table.HeaderCell>
-                                <Table.HeaderCell>Status</Table.HeaderCell>
-                            </Table.Row>
-                        </Table.Header>
-                        <Table.Body>
-                            {dokumenter.map((dokument) => (
-                                <DokumentRad key={dokument.dokumentInfoId} dokument={dokument} />
-                            ))}
-                        </Table.Body>
-                    </Table>
-                )}
+                {({ dokumenter }) => <DokumentTabell dokumenter={dokumenter} />}
             </DataViewer>
         </>
     );

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Underrad.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Underrad.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+
+import { Link, Table } from '@navikt/ds-react';
+
+import { DokumentInfo } from '../../../typer/dokument';
+
+export const Underrad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
+    return (
+        <Table.Row>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell style={{ paddingLeft: '3rem' }}>
+                <Link
+                    target="_blank"
+                    href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentInfoId}`}
+                >
+                    {dokument.tittel}
+                </Link>
+            </Table.DataCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell></Table.DataCell>
+            <Table.DataCell></Table.DataCell>
+        </Table.Row>
+    );
+};

--- a/src/frontend/utils/utils.ts
+++ b/src/frontend/utils/utils.ts
@@ -20,3 +20,15 @@ export const åpneFilIEgenTab = (
         }
     }, 500);
 };
+
+// eslint-disable-next-line
+export const groupBy = <T, K extends keyof any>(list: T[], getKey: (item: T) => K) =>
+    list.reduce(
+        (previous, currentItem) => {
+            const group = getKey(currentItem);
+            if (!previous[group]) previous[group] = [];
+            previous[group].push(currentItem);
+            return previous;
+        },
+        {} as Record<K, T[]>
+    );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
for å vise at vedlegg ble sendt sammen med en søknad.

I stor grad kopiert fra ef-sak-frontend, men litt annerledes fordi vi bruker tabell fra aksel.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20753

<img width="1283" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/674eab60-5489-4ee4-afc0-730982ea427c">
