### PR TITLE
Viser varsel hvis person finnes i Arena med innvilget vedtak

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -7,6 +7,7 @@ import { Button, Tabs } from '@navikt/ds-react';
 import { ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import { faneErLåst, FanePath, hentBehandlingfaner, isFanePath } from './faner';
+import { VarselVedtakIArena } from './Felles/VarselVedtakIArena';
 import SettPåVentContainer from './SettPåVent/SettPåVentContainer';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
@@ -105,6 +106,8 @@ const BehandlingTabsInnhold = () => {
                     statusPåVentRedigering={statusPåVentRedigering}
                     settStatusPåVentRedigering={settStatusPåVentRedigering}
                 />
+
+                <VarselVedtakIArena />
 
                 {behandlingFaner
                     .filter((fane) => !fane.erLåst)

--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -7,7 +7,6 @@ import { Button, Tabs } from '@navikt/ds-react';
 import { ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 
 import { faneErLåst, FanePath, hentBehandlingfaner, isFanePath } from './faner';
-import { VarselVedtakIArena } from './Felles/VarselVedtakIArena';
 import SettPåVentContainer from './SettPåVent/SettPåVentContainer';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
@@ -106,8 +105,6 @@ const BehandlingTabsInnhold = () => {
                     statusPåVentRedigering={statusPåVentRedigering}
                     settStatusPåVentRedigering={settStatusPåVentRedigering}
                 />
-
-                <VarselVedtakIArena />
 
                 {behandlingFaner
                     .filter((fane) => !fane.erLåst)

--- a/src/frontend/Sider/Behandling/Felles/VarselVedtakIArena.tsx
+++ b/src/frontend/Sider/Behandling/Felles/VarselVedtakIArena.tsx
@@ -1,15 +1,9 @@
 import React from 'react';
 
-import styled from 'styled-components';
-
 import { Alert, Heading } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../context/BehandlingContext';
 import { formaterTilTekstligDato } from '../../../utils/dato';
-
-const Container = styled.div`
-    margin: 1rem 2rem 0 2rem;
-`;
 
 export const VarselVedtakIArena = () => {
     const { behandlingFakta } = useBehandling();
@@ -18,16 +12,15 @@ export const VarselVedtakIArena = () => {
     if (!vedtakTom) {
         return null;
     }
+
     return (
-        <Container>
-            <Alert variant={'warning'} size={'small'}>
-                <Heading size={'xsmall'} level="3">
-                    Søker har vedtak i Arena på tilsyn barn innvilget til og med{' '}
-                    {formaterTilTekstligDato(vedtakTom)}
-                </Heading>
-                Skal du innvilge tilbake i tid? Gå til Arena for å sjekke at det ikke blir
-                overlappende utbetalinger.
-            </Alert>
-        </Container>
+        <Alert variant={'warning'} size={'small'}>
+            <Heading size={'xsmall'} level="3">
+                Søker har vedtak i Arena på tilsyn barn innvilget til og med{' '}
+                {formaterTilTekstligDato(vedtakTom)}
+            </Heading>
+            Skal du innvilge tilbake i tid? Gå til Arena for å sjekke at det ikke blir overlappende
+            utbetalinger.
+        </Alert>
     );
 };

--- a/src/frontend/Sider/Behandling/Felles/VarselVedtakIArena.tsx
+++ b/src/frontend/Sider/Behandling/Felles/VarselVedtakIArena.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Alert, Heading } from '@navikt/ds-react';
+
+import { useBehandling } from '../../../context/BehandlingContext';
+import { formaterTilTekstligDato } from '../../../utils/dato';
+
+const Container = styled.div`
+    margin: 1rem 2rem 0 2rem;
+`;
+
+export const VarselVedtakIArena = () => {
+    const { behandlingFakta } = useBehandling();
+
+    const vedtakTom = behandlingFakta.arena?.vedtakTom;
+    if (!vedtakTom) {
+        return null;
+    }
+    return (
+        <Container>
+            <Alert variant={'warning'} size={'small'}>
+                <Heading size={'xsmall'} level="3">
+                    Søker har vedtak i Arena på tilsyn barn innvilget til og med{' '}
+                    {formaterTilTekstligDato(vedtakTom)}
+                </Heading>
+                Skal du innvilge tilbake i tid? Gå til Arena for å sjekke at det ikke blir
+                overlappende utbetalinger.
+            </Alert>
+        </Container>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -17,6 +17,7 @@ import { Steg } from '../../../typer/behandling/steg';
 import { features } from '../../../utils/features';
 import { erLokalt } from '../../../utils/miljø';
 import { FanePath } from '../faner';
+import { VarselVedtakIArena } from '../Felles/VarselVedtakIArena';
 
 const Container = styled.div`
     display: flex;
@@ -33,7 +34,9 @@ const Inngangsvilkår = () => {
 
     return (
         <Container>
-            {erLokalt() && <FyllUtVilkårKnapp />}
+            <VarselVedtakIArena />
+
+            {!erLokalt() && <FyllUtVilkårKnapp />}
             <DataViewer
                 response={{
                     vilkårperioderResponse,

--- a/src/frontend/Sider/Behandling/SettPåVent/SettPåVentInformasjon.tsx
+++ b/src/frontend/Sider/Behandling/SettPåVent/SettPåVentInformasjon.tsx
@@ -7,7 +7,7 @@ import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
 import { RessursStatus } from '../../../typer/ressurs';
-import { formaterIsoDato, tilTekstligDato } from '../../../utils/dato';
+import { formaterIsoDato, formaterTilTekstligDato } from '../../../utils/dato';
 
 const SettPåVentInformasjon: React.FC<{
     status: StatusSettPåVent;
@@ -21,7 +21,7 @@ const SettPåVentInformasjon: React.FC<{
 
     const frist = status.frist ? formaterIsoDato(status.frist) : '';
 
-    const datoSattPåVent = tilTekstligDato(status.datoSattPåVent);
+    const datoSattPåVent = formaterTilTekstligDato(status.datoSattPåVent);
 
     const taAvVent = () => {
         if (laster) return;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/OppsummeringStønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/OppsummeringStønadsperioder.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { List } from '@navikt/ds-react';
 
-import { tilTekstligDato } from '../../../../../utils/dato';
+import { formaterTilTekstligDato } from '../../../../../utils/dato';
 import { aktivitetTypeTilTekst } from '../../../Inngangsvilkår/typer/aktivitet';
 import { målgruppeTypeTilTekst } from '../../../Inngangsvilkår/typer/målgruppe';
 import { Stønadsperiode } from '../../../Inngangsvilkår/typer/stønadsperiode';
@@ -11,7 +11,7 @@ const OppsummeringStønadsperioder: React.FC<{ stønadsperioder: Stønadsperiode
     stønadsperioder,
 }) => {
     const oppsummerStønadsperiode = (stønadsperiode: Stønadsperiode) => {
-        return `${tilTekstligDato(stønadsperiode.fom)} - ${tilTekstligDato(stønadsperiode.tom)} (${målgruppeTypeTilTekst(stønadsperiode.målgruppe)}, ${aktivitetTypeTilTekst(stønadsperiode.aktivitet)})`;
+        return `${formaterTilTekstligDato(stønadsperiode.fom)} - ${formaterTilTekstligDato(stønadsperiode.tom)} (${målgruppeTypeTilTekst(stønadsperiode.målgruppe)}, ${aktivitetTypeTilTekst(stønadsperiode.aktivitet)})`;
     };
 
     if (stønadsperioder.length === 0) {

--- a/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
@@ -1,4 +1,5 @@
 import { FaktaAktivtet } from './faktaAktivitet';
+import { FaktaArena } from './faktaArena';
 import { FaktaBarn } from './faktaBarn';
 import { FaktaDokumentasjon } from './faktaDokumentasjon';
 import { FaktaHovedytelse } from './faktaHovedytelse';
@@ -9,4 +10,5 @@ export interface BehandlingFakta {
     aktivitet: FaktaAktivtet;
     barn: FaktaBarn[];
     dokumentasjon?: FaktaDokumentasjon;
+    arena?: FaktaArena;
 }

--- a/src/frontend/typer/behandling/behandlingFakta/faktaArena.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaArena.ts
@@ -1,4 +1,3 @@
 export interface FaktaArena {
-    finnesVedtak: boolean;
     vedtakTom?: string;
 }

--- a/src/frontend/typer/behandling/behandlingFakta/faktaArena.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaArena.ts
@@ -1,0 +1,4 @@
+export interface FaktaArena {
+    finnesVedtak: boolean;
+    vedtakTom?: string;
+}

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -77,10 +77,6 @@ export const tilÅrMåned = (date: Date): string => {
     return formatISO(date).substring(0, 7);
 };
 
-export const tilTekstligDato = (dato: string) => {
-    return formaterTilTekstligDato(tilDato(dato));
-};
-
 export const formaterTilTekstligDato = (dato: Date | string): string => {
     return format(tilDato(dato), 'd. MMMM yyyy', { locale: nb });
 };

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -81,8 +81,8 @@ export const tilTekstligDato = (dato: string) => {
     return formaterTilTekstligDato(tilDato(dato));
 };
 
-export const formaterTilTekstligDato = (dato: Date): string => {
-    return format(dato, 'd. MMMM yyyy', { locale: nb });
+export const formaterTilTekstligDato = (dato: Date | string): string => {
+    return format(tilDato(dato), 'd. MMMM yyyy', { locale: nb });
 };
 
 const erGyldigFormat = (verdi: string): boolean => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å unngå at saksbehandler legger inn overlappende vedtak er det ønskelig å vise informasjon om at det finnes vedtak i Arena.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21211

* https://github.com/navikt/tilleggsstonader-sak/pull/335

<img width="939" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/45f09bd0-1de9-4b3c-b908-c221c5fa1e44">
