### PR TITLE
Når en behandling er til beslutning skal brevet forhåndsvises med bes…

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/BrevLesevisning.tsx
+++ b/src/frontend/Sider/Behandling/Brev/BrevLesevisning.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import PdfVisning from '../../../komponenter/PdfVisning';
+import { BehandlingStatus } from '../../../typer/behandling/behandlingStatus';
 import { byggTomRessurs } from '../../../typer/ressurs';
 
 const Container = styled.div`
@@ -18,8 +19,13 @@ const BrevLesevisning: React.FC = () => {
     const [brevPdf, settBrevPdf] = useState(byggTomRessurs<string>());
 
     const hentBrevCallback = useCallback(() => {
-        request<string, unknown>(`/api/sak/brev/${behandling.id}`).then(settBrevPdf);
-    }, [request, behandling.id]);
+        const url =
+            behandling.status === BehandlingStatus.FATTER_VEDTAK
+                ? `/api/sak/brev/beslutter/${behandling.id}`
+                : `/api/sak/brev/${behandling.id}`;
+
+        request<string, unknown>(url).then(settBrevPdf);
+    }, [behandling.status, behandling.id, request]);
 
     useEffect(hentBrevCallback, [hentBrevCallback]);
 


### PR DESCRIPTION
…lutterdato og signatur

Skulle undersøke hvor mye jobb [denne](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21286) var, men fant ut at vi allerede hadde endepunkt. Dette er bare en quickfix, men tenker det er en forbedring. Ulempen er at saksbehandler som sender til beslutter vil se brevet med egen signatur to ganger, men tenker vi kan leve med det.
