### PR TITLE
🐛 Skal memoisere parset mellomlagret brev for å unngå evig useEffect loop

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brevmeny.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brevmeny.tsx
@@ -1,4 +1,4 @@
-import React, { SetStateAction, useCallback, useEffect, useState } from 'react';
+import React, { SetStateAction, useCallback, useEffect, useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 import { useDebouncedCallback } from 'use-debounce';
@@ -58,7 +58,7 @@ const Brevmeny: React.FC<Props> = ({
         mellomlagredeFritekstfelt,
         mellomlagredeValgfelt,
         mellomlagredeVariabler,
-    } = parseMellomlagretBrev(mellomlagretBrev);
+    } = useMemo(() => parseMellomlagretBrev(mellomlagretBrev), [mellomlagretBrev]);
 
     const [valgfelt, settValgfelt] = useState<
         Partial<Record<string, Record<Valgfelt['_id'], Valg>>>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fordi `mellomlagredeInkluderteDelmaler` var en dependency i en useEffect, og denne blir kalkulert for hver render ble useEffecten også trigget for hver render 🔁 😞  Dette gjorde at man aldri rakk å generere brev før siden rendres på nytt
