### PR TITLE
Skal vise varsel om at det finnes barn under 2 år

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -7,6 +7,7 @@ import { Button, VStack } from '@navikt/ds-react';
 import Beregningsresultat from './Beregningsresultat';
 import OppsummeringStønadsperioder from './OppsummeringStønadsperioder';
 import Utgifter from './Utgifter/Utgifter';
+import { VarselBarnUnder2År } from './VarselBarnUnder2år';
 import { validerInnvilgetVedtakForm, validerPerioder } from './vedtaksvalidering';
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
@@ -128,6 +129,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({ lagretVedtak, vilkårsvur
                         settValideringsFeil={formState.setErrors}
                     />
                     <Skillelinje />
+                    <VarselBarnUnder2År vilkårsvurderteBarn={vilkårsvurderteBarn} />
                     {erStegRedigerbart && (
                         <>
                             <Knapp

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VarselBarnUnder2år.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VarselBarnUnder2år.tsx
@@ -19,7 +19,7 @@ export const VarselBarnUnder2År = (props: { vilkårsvurderteBarn: BarnOppsummer
             <Heading size={'xsmall'} level="3">
                 Mulig kontantstøtte. Søker har barn under 2 år.
             </Heading>
-            Sjekk om det utbetales kontantstøtte for barnet. Meld fra til teamet hvis det er
+            Sjekk om det utbetales kontantstøtte for barnet. Meld fra til utviklingsteamet hvis det er
             tilfelle.
         </Alert>
     );

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VarselBarnUnder2år.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VarselBarnUnder2år.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { Alert, Heading } from '@navikt/ds-react';
+
+import { BarnOppsummering } from '../../../../../typer/vilkårsoppsummering';
+
+const minsteAlder = (vilkårsvurderteBarn: BarnOppsummering[]) => {
+    const alderArray = vilkårsvurderteBarn.map((barn) => barn.alderNårStønadsperiodeBegynner || 0);
+    return Math.min(...alderArray);
+};
+
+export const VarselBarnUnder2År = (props: { vilkårsvurderteBarn: BarnOppsummering[] }) => {
+    if (minsteAlder(props.vilkårsvurderteBarn) > 2) {
+        return null;
+    }
+
+    return (
+        <Alert variant={'warning'} size={'small'}>
+            <Heading size={'xsmall'} level="3">
+                Mulig kontantstøtte. Søker har barn under 2 år.
+            </Heading>
+            Sjekk om det utbetales kontantstøtte for barnet. Meld fra til teamet hvis det er
+            tilfelle.
+        </Alert>
+    );
+};

--- a/src/frontend/typer/behandling/behandlingFakta/faktaBarn.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaBarn.ts
@@ -10,6 +10,7 @@ export interface FaktaBarn {
 interface RegistergrunnlagBarn {
     navn: string;
     dødsdato?: string;
+    alder?: number;
 }
 
 interface SøknadsgrunnlagBarn {

--- a/src/frontend/typer/vilkårsoppsummering.tsx
+++ b/src/frontend/typer/vilkårsoppsummering.tsx
@@ -10,5 +10,6 @@ export interface BarnOppsummering {
     ident: string;
     navn: string;
     alder?: number;
+    alderNårStønadsperiodeBegynner?: number;
     oppfyllerAlleVilkår: boolean;
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal vise varsel om det finnes barn med alder under 2 år. 🤟 
`alder` finnes allerede i fakta. Alder er alder ved tidspunktet grunnlaget blir opprettet. Mulig vi burde forholde oss til et annet dato. Har sendt en melding på slack. https://nav-it.slack.com/archives/C05TU86SU8Y/p1717499817280099

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21255

<img width="851" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/b5fde087-bacc-42b1-84f2-5a53820e21c4">
