### PR TITLE
Vise klagesaker med egen Oppgavetype i Oppgavebenken

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
@@ -5,7 +5,7 @@ import { CopyButton, HStack, Popover, Table } from '@navikt/ds-react';
 import Oppgaveknapp from './Oppgaveknapp';
 import { utledetFolkeregisterIdent } from './Oppgavetabell';
 import { behandlingstemaTilTekst, Oppgave, oppgaveBehandlingstypeTilTekst } from './typer/oppgave';
-import { oppgaveTypeTilTekst } from './typer/oppgavetema';
+import { oppgaveTypeTilVisningstekstSomTarHensynTilKlage } from './typer/oppgavetema';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../utils/dato';
 
 const Oppgaverad: React.FC<{ oppgave: Oppgave }> = ({ oppgave }) => {
@@ -32,7 +32,10 @@ const Oppgaverad: React.FC<{ oppgave: Oppgave }> = ({ oppgave }) => {
         <Table.Row key={oppgave.id}>
             <Table.DataCell>
                 {oppgave.oppgavetype
-                    ? oppgaveTypeTilTekst[oppgave.oppgavetype]
+                    ? oppgaveTypeTilVisningstekstSomTarHensynTilKlage(
+                          oppgave.oppgavetype,
+                          oppgave.behandlingstype
+                      )
                     : 'Mangler oppgavetype'}
             </Table.DataCell>
             <Table.DataCell>{typeBehandling}</Table.DataCell>

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
@@ -1,3 +1,5 @@
+import { OppgaveBehandlingstype } from './oppgave';
+
 export type Oppgavetype =
     | 'BEH_SAK'
     | 'JFR'
@@ -41,6 +43,18 @@ export const oppgaveTypeTilTekst: Record<Oppgavetype, string> = {
     VUR_KONS_YTE: 'Vurder konsekvens for ytelse',
     VURD_LIVS: 'Vurder livshendelse',
     VUR_SVAR: 'Vurder svar',
+};
+
+export const oppgaveTypeTilVisningstekstSomTarHensynTilKlage = (
+    oppgavetype: Oppgavetype,
+    oppgaveBehandlingstype?: OppgaveBehandlingstype
+): string => {
+    if (oppgavetype === 'BEH_SAK') {
+        if (oppgaveBehandlingstype === OppgaveBehandlingstype.Klage) {
+            return 'Behandle sak (klage)';
+        }
+    }
+    return oppgaveTypeTilTekst[oppgavetype];
 };
 
 export const oppgaverTyperSomSkalVisesFørst: Oppgavetype[] = [

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
@@ -49,10 +49,8 @@ export const oppgaveTypeTilVisningstekstSomTarHensynTilKlage = (
     oppgavetype: Oppgavetype,
     oppgaveBehandlingstype?: OppgaveBehandlingstype
 ): string => {
-    if (oppgavetype === 'BEH_SAK') {
-        if (oppgaveBehandlingstype === OppgaveBehandlingstype.Klage) {
-            return 'Behandle sak (klage)';
-        }
+    if (oppgavetype === 'BEH_SAK' && oppgaveBehandlingstype === OppgaveBehandlingstype.Klage) {
+          return 'Behandle sak (klage)';
     }
     return oppgaveTypeTilTekst[oppgavetype];
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I oppgavebenken skal klager vises med "Oppgavetype": "Behandle sak (klage)". Dette gjøres for at det skal være tydelig for saksbehandler at oppgaven gjelder en klage, og at man sendes videre til klage-løsningen dersom man klikker på den.
