### PR TITLE
✨ Vis relevante ytelser på inngangsvilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -50,7 +50,7 @@ const Inngangsvilkår = () => {
                                 hentedeStønadsperioder={stønadsperioder}
                             >
                                 <Aktivitet grunnlag={vilkårperioderResponse.grunnlag} />
-                                <Målgruppe />
+                                <Målgruppe grunnlag={vilkårperioderResponse.grunnlag} />
                                 <Stønadsperioder />
                             </InngangsvilkårProvider>
                         )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -1,19 +1,22 @@
 import React, { useState } from 'react';
 
 import { CardIcon, PlusCircleIcon } from '@navikt/aksel-icons';
-import { Button } from '@navikt/ds-react';
+import { Button, Label } from '@navikt/ds-react';
 
 import EndreMålgruppeRad from './EndreMålgruppeRad';
+import RegisterYtelser from './RegisterYtelser';
 import { useApp } from '../../../../context/AppContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../../context/StegContext';
 import { UlagretKomponent } from '../../../../hooks/useUlagredeKomponenter';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
+import { FlexColumn } from '../../../../komponenter/Visningskomponenter/Flex';
 import { paragraflenkerMålgruppe, rundskrivMålgruppe } from '../../lenker';
+import { VilkårperioderGrunnlag } from '../typer/vilkårperiode';
 import VilkårperiodeRad from '../Vilkårperioder/VilkårperiodeRad';
 
-const Målgruppe: React.FC = () => {
+const Målgruppe: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = ({ grunnlag }) => {
     const { settUlagretKomponent, nullstillUlagretKomponent } = useApp();
     const { målgrupper } = useInngangsvilkår();
     const { erStegRedigerbart } = useSteg();
@@ -53,45 +56,53 @@ const Målgruppe: React.FC = () => {
             paragraflenker={paragraflenkerMålgruppe}
             rundskrivlenke={rundskrivMålgruppe}
         >
-            {skalViseMålgrupper && (
-                <>
-                    {målgrupper.map((målgruppe) => (
-                        <React.Fragment key={målgruppe.id}>
-                            {målgruppe.id === radIRedigeringsmodus ? (
-                                <EndreMålgruppeRad
-                                    målgruppe={målgruppe}
-                                    avbrytRedigering={fjernRadIRedigeringsmodus}
-                                />
-                            ) : (
-                                <VilkårperiodeRad
-                                    vilkårperiode={målgruppe}
-                                    startRedigering={() => settNyRadIRedigeringsmodus(målgruppe.id)}
-                                />
+            <FlexColumn gap={2}>
+                <RegisterYtelser grunnlag={grunnlag} />
+                <FlexColumn>
+                    <Label>Målgrupper knyttet til denne behandlingen</Label>
+                    {skalViseMålgrupper && (
+                        <>
+                            {målgrupper.map((målgruppe) => (
+                                <React.Fragment key={målgruppe.id}>
+                                    {målgruppe.id === radIRedigeringsmodus ? (
+                                        <EndreMålgruppeRad
+                                            målgruppe={målgruppe}
+                                            avbrytRedigering={fjernRadIRedigeringsmodus}
+                                        />
+                                    ) : (
+                                        <VilkårperiodeRad
+                                            vilkårperiode={målgruppe}
+                                            startRedigering={() =>
+                                                settNyRadIRedigeringsmodus(målgruppe.id)
+                                            }
+                                        />
+                                    )}
+                                </React.Fragment>
+                            ))}
+                            {leggerTilNyPeriode && (
+                                <EndreMålgruppeRad avbrytRedigering={fjernRadIRedigeringsmodus} />
                             )}
-                        </React.Fragment>
-                    ))}
-                    {leggerTilNyPeriode && (
-                        <EndreMålgruppeRad avbrytRedigering={fjernRadIRedigeringsmodus} />
+                        </>
                     )}
-                </>
-            )}
 
-            <Feilmelding>{feilmelding}</Feilmelding>
+                    <Feilmelding>{feilmelding}</Feilmelding>
 
-            {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
-                <Button
-                    onClick={() => {
-                        settLeggerTilNyPeriode(true);
-                        settUlagretKomponent(UlagretKomponent.MÅLGRUPPE);
-                    }}
-                    size="xsmall"
-                    style={{ maxWidth: 'fit-content' }}
-                    variant="secondary"
-                    icon={<PlusCircleIcon />}
-                >
-                    Legg til ny målgruppe
-                </Button>
-            )}
+                    {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
+                        <Button
+                            onClick={() => {
+                                settLeggerTilNyPeriode(true);
+                                settUlagretKomponent(UlagretKomponent.MÅLGRUPPE);
+                            }}
+                            size="xsmall"
+                            style={{ maxWidth: 'fit-content' }}
+                            variant="secondary"
+                            icon={<PlusCircleIcon />}
+                        >
+                            Legg til ny målgruppe
+                        </Button>
+                    )}
+                </FlexColumn>
+            </FlexColumn>
         </VilkårPanel>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -1,21 +1,11 @@
 import React from 'react';
 
-import { styled } from 'styled-components';
+import { Alert, Detail, HStack, HelpText, VStack } from '@navikt/ds-react';
 
-import { Alert, Detail, HStack, HelpText, Table, VStack } from '@navikt/ds-react';
-import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
-
+import RegisterYtelserTabell from './RegisterYtelserTabell';
 import ExpansionCard from '../../../../komponenter/ExpansionCard';
-import { registerYtelseTilTekst } from '../../../../typer/registerytelser';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../../utils/dato';
 import { VilkårperioderGrunnlag } from '../typer/vilkårperiode';
-
-const TabellContainer = styled(Table)`
-    background: white;
-    --ac-table-row-border: ${ABorderDivider};
-    --ac-table-row-hover: none;
-    --ac-table-cell-hover-border: ${ABorderDivider};
-`;
 
 const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = ({
     grunnlag,
@@ -48,34 +38,7 @@ const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined 
         <VStack>
             <ExpansionCard tittel="Relevante ytelser registrert på bruker" maxWidth={600}>
                 <VStack gap="4">
-                    <TabellContainer>
-                        <Table size={'small'}>
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.HeaderCell scope="col">Ytelse</Table.HeaderCell>
-                                    <Table.HeaderCell scope="col">Startdato</Table.HeaderCell>
-                                    <Table.HeaderCell scope="col">Sluttdato</Table.HeaderCell>
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {perioderMedYtelse.map((ytelse, indeks) => {
-                                    return (
-                                        <Table.Row key={indeks}>
-                                            <Table.DataCell>
-                                                {registerYtelseTilTekst[ytelse.type]}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {formaterNullableIsoDato(ytelse.fom)}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {formaterNullableIsoDato(ytelse.tom)}
-                                            </Table.DataCell>
-                                        </Table.Row>
-                                    );
-                                })}
-                            </Table.Body>
-                        </Table>
-                    </TabellContainer>
+                    <RegisterYtelserTabell perioderMedYtelse={perioderMedYtelse} />
                     <HStack gap="2" align="center">
                         <Detail>
                             <strong>{opplysningerHentetTekst}</strong>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -46,7 +46,7 @@ const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined 
 
     return (
         <VStack>
-            <ExpansionCard tittel="Relevante ytelser registrert på bruker" maxWidth={800}>
+            <ExpansionCard tittel="Relevante ytelser registrert på bruker" maxWidth={600}>
                 <VStack gap="4">
                     <TabellContainer>
                         <Table size={'small'}>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Alert, Detail, Table, VStack } from '@navikt/ds-react';
+import { Alert, Detail, HStack, HelpText, Table, VStack } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
 import ExpansionCard from '../../../../komponenter/ExpansionCard';
@@ -22,7 +22,7 @@ const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined 
 }) => {
     if (grunnlag === undefined) {
         return (
-            <Alert variant={'info'} inline>
+            <Alert variant={'info'} inline size="small">
                 Det ble ikke hentet ytelser fra register for denne behandlingen
             </Alert>
         );
@@ -31,11 +31,11 @@ const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined 
     const perioderMedYtelse = grunnlag.ytelse.perioder;
     const hentetInformasjon = grunnlag.hentetInformasjon;
 
-    const opplysningerHentetTekst = `Opplysninger hentet fra Arena ${formaterNullableIsoDatoTid(hentetInformasjon.tidspunktHentet)}`;
+    const opplysningerHentetTekst = `Opplysninger hentet fra Arena ${formaterNullableIsoDatoTid(hentetInformasjon.tidspunktHentet)} for perioden ${formaterNullableIsoDato(hentetInformasjon.fom)} - ${formaterNullableIsoDato(hentetInformasjon.tom)}`;
 
     if (perioderMedYtelse.length === 0) {
         return (
-            <Alert variant={'info'} inline>
+            <Alert variant={'info'} inline size="small">
                 Vi finner ingen relevante ytelser registrert på bruker fra og med{' '}
                 {formaterNullableIsoDato(hentetInformasjon.fom)} til og med{' '}
                 {formaterNullableIsoDato(hentetInformasjon.tom)}
@@ -76,9 +76,15 @@ const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined 
                             </Table.Body>
                         </Table>
                     </TabellContainer>
-                    <Detail>
-                        <strong>{opplysningerHentetTekst}</strong>
-                    </Detail>
+                    <HStack gap="2" align="center">
+                        <Detail>
+                            <strong>{opplysningerHentetTekst}</strong>
+                        </Detail>
+                        <HelpText>
+                            Vi henter kun perioder med arbeidsavklaringspenger, rett til
+                            overgangsstønad og omstillingsstønad.
+                        </HelpText>
+                    </HStack>
                 </VStack>
             </ExpansionCard>
         </VStack>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -10,7 +10,7 @@ import { VilkårperioderGrunnlag } from '../typer/vilkårperiode';
 const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = ({
     grunnlag,
 }) => {
-    if (grunnlag === undefined) {
+    if (!grunnlag) {
         return (
             <Alert variant={'info'} inline size="small">
                 Det ble ikke hentet ytelser fra register for denne behandlingen

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -1,0 +1,88 @@
+import React from 'react';
+
+import { styled } from 'styled-components';
+
+import { Alert, Detail, Table, VStack } from '@navikt/ds-react';
+import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
+
+import ExpansionCard from '../../../../komponenter/ExpansionCard';
+import { registerYtelseTilTekst } from '../../../../typer/registerytelser';
+import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../../utils/dato';
+import { VilkårperioderGrunnlag } from '../typer/vilkårperiode';
+
+const TabellContainer = styled(Table)`
+    background: white;
+    --ac-table-row-border: ${ABorderDivider};
+    --ac-table-row-hover: none;
+    --ac-table-cell-hover-border: ${ABorderDivider};
+`;
+
+const RegisterYtelser: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = ({
+    grunnlag,
+}) => {
+    if (grunnlag === undefined) {
+        return (
+            <Alert variant={'info'} inline>
+                Det ble ikke hentet ytelser fra register for denne behandlingen
+            </Alert>
+        );
+    }
+
+    const perioderMedYtelse = grunnlag.ytelse.perioder;
+    const hentetInformasjon = grunnlag.hentetInformasjon;
+
+    const opplysningerHentetTekst = `Opplysninger hentet fra Arena ${formaterNullableIsoDatoTid(hentetInformasjon.tidspunktHentet)}`;
+
+    if (perioderMedYtelse.length === 0) {
+        return (
+            <Alert variant={'info'} inline>
+                Vi finner ingen relevante ytelser registrert på bruker fra og med{' '}
+                {formaterNullableIsoDato(hentetInformasjon.fom)} til og med{' '}
+                {formaterNullableIsoDato(hentetInformasjon.tom)}
+                <Detail>{opplysningerHentetTekst}</Detail>
+            </Alert>
+        );
+    }
+
+    return (
+        <VStack>
+            <ExpansionCard tittel="Relevante ytelser registrert på bruker" maxWidth={800}>
+                <VStack gap="4">
+                    <TabellContainer>
+                        <Table size={'small'}>
+                            <Table.Header>
+                                <Table.Row>
+                                    <Table.HeaderCell scope="col">Ytelse</Table.HeaderCell>
+                                    <Table.HeaderCell scope="col">Startdato</Table.HeaderCell>
+                                    <Table.HeaderCell scope="col">Sluttdato</Table.HeaderCell>
+                                </Table.Row>
+                            </Table.Header>
+                            <Table.Body>
+                                {perioderMedYtelse.map((ytelse, indeks) => {
+                                    return (
+                                        <Table.Row key={indeks}>
+                                            <Table.DataCell>
+                                                {registerYtelseTilTekst[ytelse.type]}
+                                            </Table.DataCell>
+                                            <Table.DataCell>
+                                                {formaterNullableIsoDato(ytelse.fom)}
+                                            </Table.DataCell>
+                                            <Table.DataCell>
+                                                {formaterNullableIsoDato(ytelse.tom)}
+                                            </Table.DataCell>
+                                        </Table.Row>
+                                    );
+                                })}
+                            </Table.Body>
+                        </Table>
+                    </TabellContainer>
+                    <Detail>
+                        <strong>{opplysningerHentetTekst}</strong>
+                    </Detail>
+                </VStack>
+            </ExpansionCard>
+        </VStack>
+    );
+};
+
+export default RegisterYtelser;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
@@ -6,7 +6,7 @@ import { Table } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
 import { registerYtelseTilTekst } from '../../../../typer/registerytelser';
-import { formaterNullableIsoDato } from '../../../../utils/dato';
+import { formaterIsoDato, formaterNullableIsoDato } from '../../../../utils/dato';
 import { PeriodeGrunnlagYtelse } from '../typer/vilkårperiode';
 
 const HvitTabell = styled(Table)`
@@ -33,7 +33,7 @@ const RegisterYtelserTabell: React.FC<{ perioderMedYtelse: PeriodeGrunnlagYtelse
                     return (
                         <Table.Row key={indeks}>
                             <Table.DataCell>{registerYtelseTilTekst[ytelse.type]}</Table.DataCell>
-                            <Table.DataCell>{formaterNullableIsoDato(ytelse.fom)}</Table.DataCell>
+                            <Table.DataCell>{formaterIsoDato(ytelse.fom)}</Table.DataCell>
                             <Table.DataCell>{formaterNullableIsoDato(ytelse.tom)}</Table.DataCell>
                         </Table.Row>
                     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Table } from '@navikt/ds-react';
+import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
+
+import { registerYtelseTilTekst } from '../../../../typer/registerytelser';
+import { formaterNullableIsoDato } from '../../../../utils/dato';
+import { PeriodeGrunnlagYtelse } from '../typer/vilkårperiode';
+
+const HvitTabell = styled(Table)`
+    background: white;
+    --ac-table-row-border: ${ABorderDivider};
+    --ac-table-row-hover: none;
+    --ac-table-cell-hover-border: ${ABorderDivider};
+`;
+
+const RegisterYtelserTabell: React.FC<{ perioderMedYtelse: PeriodeGrunnlagYtelse[] }> = ({
+    perioderMedYtelse,
+}) => {
+    return (
+        <HvitTabell size="small">
+            <Table.Header>
+                <Table.Row>
+                    <Table.HeaderCell scope="col">Ytelse</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Startdato</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Sluttdato</Table.HeaderCell>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {perioderMedYtelse.map((ytelse, indeks) => {
+                    return (
+                        <Table.Row key={indeks}>
+                            <Table.DataCell>{registerYtelseTilTekst[ytelse.type]}</Table.DataCell>
+                            <Table.DataCell>{formaterNullableIsoDato(ytelse.fom)}</Table.DataCell>
+                            <Table.DataCell>{formaterNullableIsoDato(ytelse.tom)}</Table.DataCell>
+                        </Table.Row>
+                    );
+                })}
+            </Table.Body>
+        </HvitTabell>
+    );
+};
+
+export default RegisterYtelserTabell;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
@@ -10,7 +10,7 @@ import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../ut
 const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = ({
     grunnlag,
 }) => {
-    if (grunnlag === undefined) {
+    if (!grunnlag) {
         return (
             <Alert variant={'info'} inline size="small">
                 Det ble ikke hentet aktiviteter fra register for denne behandlingen

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
@@ -57,7 +57,7 @@ const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefi
                         <Table size={'small'}>
                             <Table.Header>
                                 <Table.Row>
-                                    <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+                                    <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
                                     <Table.HeaderCell scope="col">Status</Table.HeaderCell>
                                     <Table.HeaderCell scope="col">Startdato</Table.HeaderCell>
                                     <Table.HeaderCell scope="col">Sluttdato</Table.HeaderCell>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Alert, Button, Detail, Table, VStack } from '@navikt/ds-react';
+import { Alert, Button, Detail, HStack, HelpText, Table, VStack } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
 import { VilkårperioderGrunnlag } from './typer/vilkårperiode';
@@ -27,7 +27,7 @@ const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefi
 
     if (grunnlag === undefined) {
         return (
-            <Alert variant={'info'} inline>
+            <Alert variant={'info'} inline size="small">
                 Det ble ikke hentet aktiviteter fra register for denne behandlingen
             </Alert>
         );
@@ -36,14 +36,12 @@ const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefi
     const aktiviteter = grunnlag.aktivitet.aktiviteter;
     const hentetInformasjon = grunnlag.hentetInformasjon;
 
-    const opplysningerHentetTekst = `Opplysninger hentet fra Arena ${formaterNullableIsoDatoTid(hentetInformasjon.tidspunktHentet)}`;
+    const opplysningerHentetTekst = `Opplysninger hentet fra Arena ${formaterNullableIsoDatoTid(hentetInformasjon.tidspunktHentet)} for perioden ${formaterNullableIsoDato(hentetInformasjon.fom)} - ${formaterNullableIsoDato(hentetInformasjon.tom)}`;
 
     if (aktiviteter.length === 0) {
         return (
-            <Alert variant={'info'} inline>
-                Bruker har ingen registrerte aktiviteter fra og med{' '}
-                {formaterNullableIsoDato(hentetInformasjon.fom)} til og med{' '}
-                {formaterNullableIsoDato(hentetInformasjon.tom)}
+            <Alert variant={'info'} inline size="small">
+                Vi fant ingen stønadsberettigede aktiviteteter registrert på bruker.
                 <Detail>{opplysningerHentetTekst}</Detail>
             </Alert>
         );
@@ -86,7 +84,7 @@ const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefi
                                             <Table.DataCell>
                                                 {erStegRedigerbart && (
                                                     <Button
-                                                        size={'small'}
+                                                        size="xsmall"
                                                         onClick={() =>
                                                             leggTilAktivitetFraRegister(aktivitet)
                                                         }
@@ -101,9 +99,15 @@ const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefi
                             </Table.Body>
                         </Table>
                     </TabellContainer>
-                    <Detail>
-                        <strong>{opplysningerHentetTekst}</strong>
-                    </Detail>
+                    <HStack gap="2" align="center">
+                        <Detail>
+                            <strong>{opplysningerHentetTekst}</strong>
+                        </Detail>
+                        <HelpText>
+                            Vi henter kun stønadsberettigede aktiviteter fra Arena. Du finner alle
+                            aktiviteter i personoversikten.
+                        </HelpText>
+                    </HStack>
                 </VStack>
             </ExpansionCard>
         </VStack>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
@@ -1,30 +1,15 @@
 import React from 'react';
 
-import { styled } from 'styled-components';
+import { Alert, Detail, HStack, HelpText, VStack } from '@navikt/ds-react';
 
-import { Alert, Button, Detail, HStack, HelpText, Table, VStack } from '@navikt/ds-react';
-import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
-
+import RegisterAktiviteterTabell from './RegisterAktivteterTabell';
 import { VilkårperioderGrunnlag } from './typer/vilkårperiode';
-import { useInngangsvilkår } from '../../../context/InngangsvilkårContext';
-import { useSteg } from '../../../context/StegContext';
 import ExpansionCard from '../../../komponenter/ExpansionCard';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../utils/dato';
-import { formaterEnumVerdi } from '../../../utils/tekstformatering';
-
-const TabellContainer = styled(Table)`
-    background: white;
-    --ac-table-row-border: ${ABorderDivider};
-    --ac-table-row-hover: none;
-    --ac-table-cell-hover-border: ${ABorderDivider};
-`;
 
 const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = ({
     grunnlag,
 }) => {
-    const { erStegRedigerbart } = useSteg();
-    const { leggTilAktivitetFraRegister } = useInngangsvilkår();
-
     if (grunnlag === undefined) {
         return (
             <Alert variant={'info'} inline size="small">
@@ -51,54 +36,7 @@ const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefi
         <VStack>
             <ExpansionCard tittel="Aktiviteter registrert på bruker" maxWidth={800}>
                 <VStack gap="4">
-                    <TabellContainer>
-                        <Table size={'small'}>
-                            <Table.Header>
-                                <Table.Row>
-                                    <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
-                                    <Table.HeaderCell scope="col">Status</Table.HeaderCell>
-                                    <Table.HeaderCell scope="col">Startdato</Table.HeaderCell>
-                                    <Table.HeaderCell scope="col">Sluttdato</Table.HeaderCell>
-                                    <Table.HeaderCell scope="col">Aktivitetsdager</Table.HeaderCell>
-                                    <Table.HeaderCell scope="col"></Table.HeaderCell>
-                                </Table.Row>
-                            </Table.Header>
-                            <Table.Body>
-                                {aktiviteter.map((aktivitet) => {
-                                    return (
-                                        <Table.Row key={aktivitet.id}>
-                                            <Table.DataCell>{aktivitet.typeNavn}</Table.DataCell>
-                                            <Table.DataCell>
-                                                {aktivitet.status &&
-                                                    formaterEnumVerdi(aktivitet.status)}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {formaterNullableIsoDato(aktivitet.fom)}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {formaterNullableIsoDato(aktivitet.tom)}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {aktivitet.antallDagerPerUke}
-                                            </Table.DataCell>
-                                            <Table.DataCell>
-                                                {erStegRedigerbart && (
-                                                    <Button
-                                                        size="xsmall"
-                                                        onClick={() =>
-                                                            leggTilAktivitetFraRegister(aktivitet)
-                                                        }
-                                                    >
-                                                        Bruk
-                                                    </Button>
-                                                )}
-                                            </Table.DataCell>
-                                        </Table.Row>
-                                    );
-                                })}
-                            </Table.Body>
-                        </Table>
-                    </TabellContainer>
+                    <RegisterAktiviteterTabell aktiviteter={aktiviteter} />
                     <HStack gap="2" align="center">
                         <Detail>
                             <strong>{opplysningerHentetTekst}</strong>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteterTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteterTabell.tsx
@@ -1,0 +1,72 @@
+import React from 'react';
+
+import { styled } from 'styled-components';
+
+import { Button, Table } from '@navikt/ds-react';
+import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
+
+import { useInngangsvilkår } from '../../../context/InngangsvilkårContext';
+import { useSteg } from '../../../context/StegContext';
+import { Registeraktivitet } from '../../../typer/registeraktivitet';
+import { formaterNullableIsoDato } from '../../../utils/dato';
+import { formaterEnumVerdi } from '../../../utils/tekstformatering';
+
+const Tabell = styled(Table)`
+    background: white;
+    --ac-table-row-border: ${ABorderDivider};
+    --ac-table-row-hover: none;
+    --ac-table-cell-hover-border: ${ABorderDivider};
+`;
+
+const RegisterAktiviteterTabell: React.FC<{ aktiviteter: Registeraktivitet[] }> = ({
+    aktiviteter,
+}) => {
+    const { erStegRedigerbart } = useSteg();
+    const { leggTilAktivitetFraRegister } = useInngangsvilkår();
+
+    return (
+        <Tabell size={'small'}>
+            <Table.Header>
+                <Table.Row>
+                    <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Status</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Startdato</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Sluttdato</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Aktivitetsdager</Table.HeaderCell>
+                    <Table.HeaderCell scope="col"></Table.HeaderCell>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {aktiviteter.map((aktivitet) => {
+                    return (
+                        <Table.Row key={aktivitet.id}>
+                            <Table.DataCell>{aktivitet.typeNavn}</Table.DataCell>
+                            <Table.DataCell>
+                                {aktivitet.status && formaterEnumVerdi(aktivitet.status)}
+                            </Table.DataCell>
+                            <Table.DataCell>
+                                {formaterNullableIsoDato(aktivitet.fom)}
+                            </Table.DataCell>
+                            <Table.DataCell>
+                                {formaterNullableIsoDato(aktivitet.tom)}
+                            </Table.DataCell>
+                            <Table.DataCell>{aktivitet.antallDagerPerUke}</Table.DataCell>
+                            <Table.DataCell>
+                                {erStegRedigerbart && (
+                                    <Button
+                                        size="xsmall"
+                                        onClick={() => leggTilAktivitetFraRegister(aktivitet)}
+                                    >
+                                        Bruk
+                                    </Button>
+                                )}
+                            </Table.DataCell>
+                        </Table.Row>
+                    );
+                })}
+            </Table.Body>
+        </Tabell>
+    );
+};
+
+export default RegisterAktiviteterTabell;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
@@ -1,6 +1,7 @@
 import { Aktivitet, AktivitetType, AktivitetTypeTilTekst } from './aktivitet';
 import { Målgruppe, MålgruppeType, MålgruppeTypeTilTekst } from './målgruppe';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
+import { TypeRegisterYtelse } from '../../../../typer/registerytelser';
 import { Periode } from '../../../../utils/periode';
 
 export interface VilkårperioderResponse {
@@ -14,11 +15,22 @@ export interface Vilkårperioder {
 
 export interface VilkårperioderGrunnlag {
     aktivitet: AktivitetGrunnlag;
+    ytelse: YtelseGrunnlag;
     hentetInformasjon: HentetInformasjon;
 }
 
 interface AktivitetGrunnlag {
     aktiviteter: Registeraktivitet[];
+}
+
+interface YtelseGrunnlag {
+    perioder: PeriodeGrunnlagYtelse[];
+}
+
+interface PeriodeGrunnlagYtelse {
+    type: TypeRegisterYtelse;
+    fom: string;
+    tom?: string;
 }
 
 interface HentetInformasjon {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
@@ -27,7 +27,7 @@ interface YtelseGrunnlag {
     perioder: PeriodeGrunnlagYtelse[];
 }
 
-interface PeriodeGrunnlagYtelse {
+export interface PeriodeGrunnlagYtelse {
     type: TypeRegisterYtelse;
     fom: string;
     tom?: string;

--- a/src/frontend/typer/registerytelser.ts
+++ b/src/frontend/typer/registerytelser.ts
@@ -22,7 +22,7 @@ export enum TypeRegisterYtelse {
 }
 
 export const registerYtelseTilTekst: Record<TypeRegisterYtelse, string> = {
-    AAP: 'AAP',
-    ENSLIG_FORSØRGER: 'Enslig forsørger',
+    AAP: 'Arbeidsavklaringspenger',
+    ENSLIG_FORSØRGER: 'Overgangsstønad',
     OMSTILLINGSSTØNAD: 'Omstillingsstønad',
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Viser frem alle registrerte ytelser for en bruker på inngangsvilkårside for å hjelpe saksbehandler

⚠️ "Bruk" ytelse kommer senere. Det bør testes før det brukes i prod så dette er kun en tabell som viser frem informasjonen. 

### Bilder 🎨 
<img width="1354" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/6e076bed-39ae-43cc-8d14-1b8a447b3ed3">

Hvis ingen registrerte perioder: 
<img width="1354" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/f0f850d7-a3a6-490d-8e3c-8246a402c800">

Hvis grunnlagsdata ikke laget (behandlinger som er ferdigstilt før vi begynte med dette):
<img width="1354" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/441cc5bf-557b-401d-a7e6-af59bd8f259c">
