### PR TITLE
Stønadsperioder inn i panel og aktivitet før målgruppe

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -33,6 +33,16 @@ const StønadsperiodeRad: React.FC<Props> = ({
             <SelectMedOptions
                 className="kolonne1"
                 erLesevisning={erLeservisning}
+                valg={aktivitetTypeOptionsForStønadsperiode}
+                label={'Aktivitet'}
+                hideLabel
+                value={stønadsperide.aktivitet}
+                onChange={(e) => oppdaterStønadsperiode('aktivitet', e.target.value)}
+                size="small"
+                error={finnFeilmelding('aktivitet')}
+            />
+            <SelectMedOptions
+                erLesevisning={erLeservisning}
                 valg={målgruppeTypeOptionsForStønadsperiode}
                 label={'Målgruppe'}
                 hideLabel
@@ -42,16 +52,6 @@ const StønadsperiodeRad: React.FC<Props> = ({
                 error={finnFeilmelding('målgruppe')}
             />
 
-            <SelectMedOptions
-                erLesevisning={erLeservisning}
-                valg={aktivitetTypeOptionsForStønadsperiode}
-                label={'Aktivitet'}
-                hideLabel
-                value={stønadsperide.aktivitet}
-                onChange={(e) => oppdaterStønadsperiode('aktivitet', e.target.value)}
-                size="small"
-                error={finnFeilmelding('aktivitet')}
-            />
             <DateInputMedLeservisning
                 erLesevisning={erLeservisning}
                 label={'Fra'}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -3,7 +3,7 @@ import React, { useEffect, useState } from 'react';
 import styled from 'styled-components';
 
 import { SealCheckmarkIcon } from '@navikt/aksel-icons';
-import { Label, VStack } from '@navikt/ds-react';
+import { BodyShort, Label, VStack } from '@navikt/ds-react';
 
 import Aksjonsknapper from './Aksjonsknapper';
 import StønadsperiodeRad from './StønadsperiodeRad';
@@ -136,6 +136,11 @@ const Stønadsperioder: React.FC = () => {
 
     return (
         <Panel tittel="Stønadsperioder" ikon={<SealCheckmarkIcon />}>
+            {stønadsperioderState.value.length === 0 && !erStegRedigerbart && (
+                <BodyShort>
+                    Det ble ikke registrert noen stønadsperioder i denne behandlingen
+                </BodyShort>
+            )}
             <form onSubmit={formState.onSubmit(handleSubmit)}>
                 <VStack gap="4">
                     {stønadsperioderState.value.length !== 0 && (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -2,7 +2,8 @@ import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { Heading, Label, VStack } from '@navikt/ds-react';
+import { SealCheckmarkIcon } from '@navikt/aksel-icons';
+import { Label, VStack } from '@navikt/ds-react';
 
 import Aksjonsknapper from './Aksjonsknapper';
 import StønadsperiodeRad from './StønadsperiodeRad';
@@ -15,14 +16,9 @@ import useFormState, { FormErrors, FormState } from '../../../../hooks/felles/us
 import { ListState } from '../../../../hooks/felles/useListState';
 import { UlagretKomponent } from '../../../../hooks/useUlagredeKomponenter';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import Panel from '../../../../komponenter/Panel/Panel';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Stønadsperiode } from '../typer/stønadsperiode';
-
-const Container = styled.div`
-    display: flex;
-    flex-direction: column;
-    gap: 1rem;
-`;
 
 const Grid = styled.div`
     display: grid;
@@ -139,16 +135,13 @@ const Stønadsperioder: React.FC = () => {
     };
 
     return (
-        <Container>
-            <Heading spacing size="small">
-                Sett stønadsperioder
-            </Heading>
+        <Panel tittel="Stønadsperioder" ikon={<SealCheckmarkIcon />}>
             <form onSubmit={formState.onSubmit(handleSubmit)}>
                 <VStack gap="4">
                     {stønadsperioderState.value.length !== 0 && (
                         <Grid>
-                            <Label>Målgruppe</Label>
                             <Label>Aktivitet</Label>
+                            <Label>Målgruppe</Label>
                             <Label>Fra</Label>
                             <Label>Til</Label>
 
@@ -185,7 +178,7 @@ const Stønadsperioder: React.FC = () => {
                     )}
                 </VStack>
             </form>
-        </Container>
+        </Panel>
     );
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
En del av [dette](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21411) kortet. 

**Gjort:**
- Lagt til panel
- Aktivitet før målgruppe
- Vise tekst om at ingen stønadsperioder ble laget dersom steg ikke er redigerbart (denne var ikke en del av skissene, men tenkte det var greit å ikke ha et tomt panel)

**Ikke gjort:**
- Endring av knapper. Dette krever en samtale om hva man faktisk ønsker. Kan ikke fjerne "lagret visning" fordi det da ikke visualiseres for sb at endringer er lagret. Drar kortet tilbake til avklar behov og tar en prat med marie

Lagret: 
<img width="1339" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/bb22dcd7-65a5-4d1d-810f-d756bc7dcd77">

Under redigering: 
<img width="1339" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/9a4109cf-0ece-42f7-be97-905dac26adf2">

Ikke redigerbar behandling uten stønadsperioder: 
<img width="1339" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/38d0a17c-ec3b-4533-9e1d-3af4c0665c2a">