### PR TITLE
🐛 AktivitetFraRegister må settes til undefined så ny manuell aktivitet …

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -23,13 +23,15 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
 
     const [radIRedigeringsmodus, settRadIRedigeringsmodus] = useState<string>();
     const [feilmelding, settFeilmelding] = useState<string>();
-    const { leggerTilNyAktivitet, settLeggerTilNyAktivitet } = useInngangsvilkår();
+    const { leggerTilNyAktivitet, settLeggerTilNyAktivitet, settAktivitetFraRegister } =
+        useInngangsvilkår();
 
     const fjernRadIRedigeringsmodus = () => {
         settFeilmelding(undefined);
         settRadIRedigeringsmodus(undefined);
         settLeggerTilNyAktivitet(false);
         nullstillUlagretKomponent(UlagretKomponent.AKTIVITET);
+        settAktivitetFraRegister(undefined);
     };
 
     const kanSetteNyRadIRedigeringsmodus =
@@ -81,7 +83,10 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
                                 </React.Fragment>
                             ))}
                             {leggerTilNyAktivitet && (
-                                <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
+                                <EndreAktivitetRad
+                                    key="ny"
+                                    avbrytRedigering={fjernRadIRedigeringsmodus}
+                                />
                             )}
                         </>
                     )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -83,10 +83,7 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
                                 </React.Fragment>
                             ))}
                             {leggerTilNyAktivitet && (
-                                <EndreAktivitetRad
-                                    key="ny"
-                                    avbrytRedigering={fjernRadIRedigeringsmodus}
-                                />
+                                <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
                             )}
                         </>
                     )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -52,13 +52,8 @@ const EndreAktivitetRad: React.FC<{
 }> = ({ aktivitet, avbrytRedigering }) => {
     const { request } = useApp();
     const { behandling, behandlingFakta } = useBehandling();
-    const {
-        oppdaterAktivitet,
-        leggTilAktivitet,
-        settStønadsperiodeFeil,
-        aktivitetFraRegister,
-        settAktivitetFraRegister,
-    } = useInngangsvilkår();
+    const { oppdaterAktivitet, leggTilAktivitet, settStønadsperiodeFeil, aktivitetFraRegister } =
+        useInngangsvilkår();
     const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
         useTriggRerendringAvDateInput();
     const { keyDato: tomKeyDato, oppdaterDatoKey: oppdaterTomDatoKey } =
@@ -103,7 +98,6 @@ const EndreAktivitetRad: React.FC<{
 
                         if (res.data.stønadsperiodeStatus === StønadsperiodeStatus.Ok) {
                             settStønadsperiodeFeil(undefined);
-                            settAktivitetFraRegister(undefined);
                         } else {
                             settStønadsperiodeFeil(res.data.stønadsperiodeFeil);
                         }


### PR DESCRIPTION
…ikke preutfylles

### Hvorfor er denne endringen nødvendig? ✨
Hvis man velger "bruk" på en aktivitet fra register så preutfylles feltene -> ønsket

Dette ble med videre. Så om man trykket på "legg til manuelt" så ble feltene fortsatt prepopulert --> ikke ønsket. 

Fikset ved å sette aktivitetFraRegister som undefined ved avbryt redigeringsmodus. 

Man kunne også vurdert å sette den til undefined når man trykker på "legg til manuelt" fordi da skal den alltid være undefined. 

⚠️ Mulig dette ble introdusert da jeg flyttet på hvor komponentene lå. Skal se på hvordan dette skal løses på målgruppe og om jeg finner ut at ikke via context er veien å gå da kommer jeg til å ta inn endringen på aktivitet også