### PR TITLE
♻️ Bruk register aktivitet skal skje utenfor context

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -23,40 +23,29 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
     const { erStegRedigerbart } = useSteg();
 
     const [radIRedigeringsmodus, settRadIRedigeringsmodus] = useState<string>();
-    const [leggerTilNyAktivitet, settLeggerTilNyAktivitet] = useState<boolean>(false);
     const [aktivitetFraRegister, settAktivitetFraRegister] = useState<Registeraktivitet>();
     const [feilmelding, settFeilmelding] = useState<string>();
 
     const fjernRadIRedigeringsmodus = () => {
         settFeilmelding(undefined);
         settRadIRedigeringsmodus(undefined);
-        settLeggerTilNyAktivitet(false);
         nullstillUlagretKomponent(UlagretKomponent.AKTIVITET);
         settAktivitetFraRegister(undefined);
     };
 
-    const kanSetteNyRadIRedigeringsmodus =
-        radIRedigeringsmodus === undefined && !leggerTilNyAktivitet;
+    const kanSetteNyRadIRedigeringsmodus = radIRedigeringsmodus === undefined && erStegRedigerbart;
 
-    const skalViseAktiviteter = aktiviteter.length > 0 || leggerTilNyAktivitet;
-
-    const settNyRadIRedigeringsmodus = (id: string) => {
+    const settNyRadIRedigeringsmodus = (id?: string, aktivitetFraRegister?: Registeraktivitet) => {
         if (kanSetteNyRadIRedigeringsmodus) {
             settFeilmelding(undefined);
-            settRadIRedigeringsmodus(id);
+            settRadIRedigeringsmodus(id || 'nyPeriode');
+            settAktivitetFraRegister(aktivitetFraRegister);
             settUlagretKomponent(UlagretKomponent.AKTIVITET);
         } else {
             settFeilmelding(
                 'Det er kun mulig redigere en rad om gangen. Lagre eller avbryt pågående redigering.'
             );
         }
-    };
-
-    const leggTilAktivitetFraRegister = (aktivitet: Registeraktivitet) => {
-        if (leggerTilNyAktivitet) return;
-
-        settAktivitetFraRegister(aktivitet);
-        settLeggerTilNyAktivitet(true);
     };
 
     return (
@@ -69,47 +58,41 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
             <FlexColumn gap={2}>
                 <RegisterAktiviteter
                     grunnlag={grunnlag}
-                    leggTilAktivitetFraRegister={leggTilAktivitetFraRegister}
+                    leggTilAktivitetFraRegister={(valgtAktivitet: Registeraktivitet) =>
+                        settNyRadIRedigeringsmodus(undefined, valgtAktivitet)
+                    }
                 />
 
                 <FlexColumn>
                     <Label>Aktiviteter knyttet til behandling</Label>
-                    {skalViseAktiviteter && (
-                        <>
-                            {aktiviteter.map((aktivitet) => (
-                                <React.Fragment key={aktivitet.id}>
-                                    {aktivitet.id === radIRedigeringsmodus ? (
-                                        <EndreAktivitetRad
-                                            aktivitet={aktivitet}
-                                            avbrytRedigering={fjernRadIRedigeringsmodus}
-                                        />
-                                    ) : (
-                                        <VilkårperiodeRad
-                                            vilkårperiode={aktivitet}
-                                            startRedigering={() =>
-                                                settNyRadIRedigeringsmodus(aktivitet.id)
-                                            }
-                                        />
-                                    )}
-                                </React.Fragment>
-                            ))}
-                            {leggerTilNyAktivitet && (
+
+                    {aktiviteter.map((aktivitet) => (
+                        <React.Fragment key={aktivitet.id}>
+                            {aktivitet.id === radIRedigeringsmodus ? (
                                 <EndreAktivitetRad
+                                    aktivitet={aktivitet}
                                     avbrytRedigering={fjernRadIRedigeringsmodus}
-                                    aktivitetFraRegister={aktivitetFraRegister}
+                                />
+                            ) : (
+                                <VilkårperiodeRad
+                                    vilkårperiode={aktivitet}
+                                    startRedigering={() => settNyRadIRedigeringsmodus(aktivitet.id)}
                                 />
                             )}
-                        </>
+                        </React.Fragment>
+                    ))}
+                    {radIRedigeringsmodus === 'nyPeriode' && (
+                        <EndreAktivitetRad
+                            avbrytRedigering={fjernRadIRedigeringsmodus}
+                            aktivitetFraRegister={aktivitetFraRegister}
+                        />
                     )}
 
                     <Feilmelding>{feilmelding}</Feilmelding>
 
                     {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
                         <Button
-                            onClick={() => {
-                                settLeggerTilNyAktivitet((prevState) => !prevState);
-                                settUlagretKomponent(UlagretKomponent.AKTIVITET);
-                            }}
+                            onClick={() => settNyRadIRedigeringsmodus()}
                             size="xsmall"
                             style={{ maxWidth: 'fit-content' }}
                             variant="secondary"

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -11,6 +11,7 @@ import { UlagretKomponent } from '../../../../hooks/useUlagredeKomponenter';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
 import { FlexColumn } from '../../../../komponenter/Visningskomponenter/Flex';
+import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { paragraflenkerAktivitet, rundskrivAktivitet } from '../../lenker';
 import RegisterAktiviteter from '../RegisterAktivteter';
 import { VilkårperioderGrunnlag } from '../typer/vilkårperiode';
@@ -22,9 +23,9 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
     const { erStegRedigerbart } = useSteg();
 
     const [radIRedigeringsmodus, settRadIRedigeringsmodus] = useState<string>();
+    const [leggerTilNyAktivitet, settLeggerTilNyAktivitet] = useState<boolean>(false);
+    const [aktivitetFraRegister, settAktivitetFraRegister] = useState<Registeraktivitet>();
     const [feilmelding, settFeilmelding] = useState<string>();
-    const { leggerTilNyAktivitet, settLeggerTilNyAktivitet, settAktivitetFraRegister } =
-        useInngangsvilkår();
 
     const fjernRadIRedigeringsmodus = () => {
         settFeilmelding(undefined);
@@ -51,6 +52,13 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
         }
     };
 
+    const leggTilAktivitetFraRegister = (aktivitet: Registeraktivitet) => {
+        if (leggerTilNyAktivitet) return;
+
+        settAktivitetFraRegister(aktivitet);
+        settLeggerTilNyAktivitet(true);
+    };
+
     return (
         <VilkårPanel
             ikon={<BriefcaseIcon />}
@@ -59,7 +67,10 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
             rundskrivlenke={rundskrivAktivitet}
         >
             <FlexColumn gap={2}>
-                <RegisterAktiviteter grunnlag={grunnlag} />
+                <RegisterAktiviteter
+                    grunnlag={grunnlag}
+                    leggTilAktivitetFraRegister={leggTilAktivitetFraRegister}
+                />
 
                 <FlexColumn>
                     <Label>Aktiviteter knyttet til behandling</Label>
@@ -83,7 +94,10 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
                                 </React.Fragment>
                             ))}
                             {leggerTilNyAktivitet && (
-                                <EndreAktivitetRad avbrytRedigering={fjernRadIRedigeringsmodus} />
+                                <EndreAktivitetRad
+                                    avbrytRedigering={fjernRadIRedigeringsmodus}
+                                    aktivitetFraRegister={aktivitetFraRegister}
+                                />
                             )}
                         </>
                     )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -49,11 +49,11 @@ const initaliserForm = (
 const EndreAktivitetRad: React.FC<{
     aktivitet?: Aktivitet;
     avbrytRedigering: () => void;
-}> = ({ aktivitet, avbrytRedigering }) => {
+    aktivitetFraRegister?: Registeraktivitet;
+}> = ({ aktivitet, avbrytRedigering, aktivitetFraRegister }) => {
     const { request } = useApp();
     const { behandling, behandlingFakta } = useBehandling();
-    const { oppdaterAktivitet, leggTilAktivitet, settStønadsperiodeFeil, aktivitetFraRegister } =
-        useInngangsvilkår();
+    const { oppdaterAktivitet, leggTilAktivitet, settStønadsperiodeFeil } = useInngangsvilkår();
     const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
         useTriggRerendringAvDateInput();
     const { keyDato: tomKeyDato, oppdaterDatoKey: oppdaterTomDatoKey } =

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteter.tsx
@@ -5,11 +5,13 @@ import { Alert, Detail, HStack, HelpText, VStack } from '@navikt/ds-react';
 import RegisterAktiviteterTabell from './RegisterAktivteterTabell';
 import { VilkårperioderGrunnlag } from './typer/vilkårperiode';
 import ExpansionCard from '../../../komponenter/ExpansionCard';
+import { Registeraktivitet } from '../../../typer/registeraktivitet';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../utils/dato';
 
-const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = ({
-    grunnlag,
-}) => {
+const RegisterAktiviteter: React.FC<{
+    grunnlag: VilkårperioderGrunnlag | undefined;
+    leggTilAktivitetFraRegister: (aktivitet: Registeraktivitet) => void;
+}> = ({ grunnlag, leggTilAktivitetFraRegister }) => {
     if (!grunnlag) {
         return (
             <Alert variant={'info'} inline size="small">
@@ -36,7 +38,10 @@ const RegisterAktiviteter: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefi
         <VStack>
             <ExpansionCard tittel="Aktiviteter registrert på bruker" maxWidth={800}>
                 <VStack gap="4">
-                    <RegisterAktiviteterTabell aktiviteter={aktiviteter} />
+                    <RegisterAktiviteterTabell
+                        aktiviteter={aktiviteter}
+                        leggTilAktivitetFraRegister={leggTilAktivitetFraRegister}
+                    />
                     <HStack gap="2" align="center">
                         <Detail>
                             <strong>{opplysningerHentetTekst}</strong>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteterTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/RegisterAktivteterTabell.tsx
@@ -5,7 +5,6 @@ import { styled } from 'styled-components';
 import { Button, Table } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
-import { useInngangsvilkår } from '../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../context/StegContext';
 import { Registeraktivitet } from '../../../typer/registeraktivitet';
 import { formaterNullableIsoDato } from '../../../utils/dato';
@@ -18,11 +17,11 @@ const Tabell = styled(Table)`
     --ac-table-cell-hover-border: ${ABorderDivider};
 `;
 
-const RegisterAktiviteterTabell: React.FC<{ aktiviteter: Registeraktivitet[] }> = ({
-    aktiviteter,
-}) => {
+const RegisterAktiviteterTabell: React.FC<{
+    aktiviteter: Registeraktivitet[];
+    leggTilAktivitetFraRegister: (aktivitet: Registeraktivitet) => void;
+}> = ({ aktiviteter, leggTilAktivitetFraRegister }) => {
     const { erStegRedigerbart } = useSteg();
-    const { leggTilAktivitetFraRegister } = useInngangsvilkår();
 
     return (
         <Tabell size={'small'}>

--- a/src/frontend/context/InngangsvilkårContext.ts
+++ b/src/frontend/context/InngangsvilkårContext.ts
@@ -1,4 +1,4 @@
-import React, { SetStateAction, useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 
 import constate from 'constate';
 
@@ -6,7 +6,6 @@ import { Aktivitet } from '../Sider/Behandling/Inngangsvilkår/typer/aktivitet';
 import { Målgruppe } from '../Sider/Behandling/Inngangsvilkår/typer/målgruppe';
 import { Stønadsperiode } from '../Sider/Behandling/Inngangsvilkår/typer/stønadsperiode';
 import { Vilkårperioder } from '../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode';
-import { Registeraktivitet } from '../typer/registeraktivitet';
 
 interface UseInngangsvilkår {
     målgrupper: Målgruppe[];
@@ -19,11 +18,6 @@ interface UseInngangsvilkår {
     stønadsperiodeFeil: string | undefined;
     settStønadsperiodeFeil: (feilmelding: string | undefined) => void;
     oppdaterStønadsperioder: (oppdaterteStønadsperioder: Stønadsperiode[]) => void;
-    leggTilAktivitetFraRegister: (aktivitet: Registeraktivitet) => void;
-    leggerTilNyAktivitet: boolean;
-    settLeggerTilNyAktivitet: React.Dispatch<SetStateAction<boolean>>;
-    aktivitetFraRegister?: Registeraktivitet;
-    settAktivitetFraRegister: React.Dispatch<SetStateAction<Registeraktivitet | undefined>>;
 }
 
 interface Props {
@@ -35,7 +29,6 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
     ({ vilkårperioder, hentedeStønadsperioder }: Props): UseInngangsvilkår => {
         const [målgrupper, settMålgrupper] = useState<Målgruppe[]>(vilkårperioder.målgrupper);
         const [aktiviteter, settAktiviteter] = useState<Aktivitet[]>(vilkårperioder.aktiviteter);
-        const [leggerTilNyAktivitet, settLeggerTilNyAktivitet] = useState<boolean>(false);
         const [stønadsperioder, settStønadsperioder] =
             useState<Stønadsperiode[]>(hentedeStønadsperioder);
         const [stønadsperiodeFeil, settStønadsperiodeFeil] = useState<string>();
@@ -60,15 +53,6 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             settAktiviteter((prevState) => [...prevState, nyPeriode]);
         };
 
-        const leggTilAktivitetFraRegister = (aktivitet: Registeraktivitet) => {
-            if (leggerTilNyAktivitet) return;
-
-            settAktivitetFraRegister(aktivitet);
-            settLeggerTilNyAktivitet(true);
-        };
-
-        const [aktivitetFraRegister, settAktivitetFraRegister] = useState<Registeraktivitet>();
-
         const oppdaterAktivitet = (oppdatertPeriode: Aktivitet) => {
             settAktiviteter((prevState) =>
                 prevState.map((aktivitet) =>
@@ -87,13 +71,8 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             stønadsperioder,
             stønadsperiodeFeil,
             settStønadsperiodeFeil,
-            leggTilAktivitetFraRegister,
             oppdaterStønadsperioder: (oppdaterteStønadsperioder: Stønadsperiode[]) =>
                 settStønadsperioder(oppdaterteStønadsperioder),
-            leggerTilNyAktivitet,
-            settLeggerTilNyAktivitet,
-            aktivitetFraRegister,
-            settAktivitetFraRegister,
         };
     }
 );


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
En omskrivning av hvordan "bruk register aktivitet" fungerer for å forklare bedre hva som skjer i #380.

Eneste endringen i funksjonalitet er at hvis du har en rad i redigeringsmodus får du beskjed om at du ikke kan legge til en ny ved trykk på "bruk", mens før skjedde det bare ikke noe. Her burde det kanskje ikke være mulig å trykke på knappen eller liknende, men må høre med noen™️ hva som er ønskelig oppførsel her siden disabled ikke er så poplært å bruke. Se bilde for forklaring.

Les commit for commit:
1. Trekk "bruk" ut av context
2. Slå sammen states for å holde styr på hvilken rad som redigeres

<img width="1325" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/aebf035e-fedb-4858-a4c5-9aeaec6eec26">
