### PR TITLE
Skal kunne opprette en revurdering

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingOversikt.tsx
@@ -15,6 +15,7 @@ const Behandlingsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerso
     }, [fagsakPersonId, hentFagsakPerson, hentKlagebehandlinger]);
 
     const rekjørHentKlagebehandlinger = () => hentKlagebehandlinger(fagsakPersonId);
+    const rekjørHentBehandlinger = () => hentFagsakPerson(fagsakPersonId);
 
     return (
         <DataViewer response={{ fagsakPerson, klagebehandlinger }}>
@@ -25,6 +26,7 @@ const Behandlingsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerso
                             fagsak={fagsakPerson.tilsynBarn}
                             klagebehandlinger={klagebehandlinger.barnetilsyn}
                             hentKlagebehandlinger={rekjørHentKlagebehandlinger}
+                            hentBehandlinger={rekjørHentBehandlinger}
                         />
                     )}
                 </>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
@@ -27,12 +27,14 @@ interface Props {
     fagsak: Fagsak;
     klagebehandlinger: KlageBehandling[];
     hentKlagebehandlinger: () => void;
+    hentBehandlinger: () => void;
 }
 
 export const FagsakOversikt: React.FC<Props> = ({
     fagsak,
     klagebehandlinger,
     hentKlagebehandlinger,
+    hentBehandlinger,
 }) => {
     return (
         <Container>
@@ -55,6 +57,7 @@ export const FagsakOversikt: React.FC<Props> = ({
                 <OpprettNyBehandlingModal
                     fagsak={fagsak}
                     hentKlagebehandlinger={hentKlagebehandlinger}
+                    hentBehandlinger={hentBehandlinger}
                 />
             )}
         </Container>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKlageBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKlageBehandling.tsx
@@ -1,28 +1,56 @@
-import React, { Dispatch, SetStateAction } from 'react';
+import React, { useState } from 'react';
 
-import { VStack } from '@navikt/ds-react';
+import { Button, HStack, VStack } from '@navikt/ds-react';
 
+import { useApp } from '../../../../context/AppContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import DateInput from '../../../../komponenter/Skjema/DateInput';
+import { Fagsak } from '../../../../typer/fagsak';
+import { RessursStatus } from '../../../../typer/ressurs';
 
 interface Props {
-    kravMottattDato: string;
-    settKravMottattDato: Dispatch<SetStateAction<string>>;
-    feilmelding: string | undefined;
+    fagsak: Fagsak;
+    hentKlagebehandlinger: () => void;
+    lukkModal: () => void;
 }
 
-const OpprettKlageBehandling: React.FC<Props> = ({
-    kravMottattDato,
-    settKravMottattDato,
-    feilmelding,
-}) => {
+interface OpprettKlageRequest {
+    mottattDato: string;
+}
+
+const OpprettKlageBehandling: React.FC<Props> = ({ fagsak, hentKlagebehandlinger, lukkModal }) => {
+    const { request } = useApp();
+    const [kravMottattDato, settKravMottattDato] = useState('');
+    const [feilmelding, settFeilmelding] = useState<string>();
+
+    const opprett = () => {
+        request<string, OpprettKlageRequest>(`/api/sak/klage/fagsak/${fagsak.id}`, 'POST', {
+            mottattDato: kravMottattDato,
+        }).then((response) => {
+            if (response.status === RessursStatus.SUKSESS) {
+                hentKlagebehandlinger();
+                lukkModal();
+            } else {
+                settFeilmelding(response.frontendFeilmelding || response.melding);
+            }
+        });
+    };
+
     return (
-        <VStack gap="8">
+        <VStack gap="4">
             <DateInput
                 label={'Krav mottatt'}
                 onChange={(dato: string | undefined) => settKravMottattDato(dato || '')}
                 value={kravMottattDato}
             />
+            <HStack gap="4" justify={'end'}>
+                <Button variant="tertiary" onClick={lukkModal} size="small">
+                    Avbryt
+                </Button>
+                <Button variant="primary" onClick={opprett} size="small">
+                    Lagre
+                </Button>
+            </HStack>
             <Feilmelding variant={'alert'}>{feilmelding}</Feilmelding>
         </VStack>
     );

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -3,6 +3,7 @@ import React, { FC, useState } from 'react';
 import { Button, Select, VStack } from '@navikt/ds-react';
 
 import OpprettKlageBehandling from './OpprettKlageBehandling';
+import OpprettRevurderingBehandling from './OpprettRevurderingBehandling';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import {
     BehandlingType,
@@ -39,9 +40,11 @@ const OpprettNyBehandlingModal: FC<Props> = ({ fagsak, hentKlagebehandlinger }) 
                         }}
                     >
                         <option value={''}>Velg</option>
-                        <option value="KLAGE">
-                            {behandlingTypeTilTekst[BehandlingType.KLAGE]}
-                        </option>
+                        {[BehandlingType.REVURDERING, BehandlingType.KLAGE].map((type) => (
+                            <option key={type} value={type}>
+                                {behandlingTypeTilTekst[type]}
+                            </option>
+                        ))}
                     </Select>
                     {behandlingtype === BehandlingType.KLAGE && (
                         <OpprettKlageBehandling
@@ -49,6 +52,9 @@ const OpprettNyBehandlingModal: FC<Props> = ({ fagsak, hentKlagebehandlinger }) 
                             lukkModal={lukkModal}
                             hentKlagebehandlinger={hentKlagebehandlinger}
                         />
+                    )}
+                    {behandlingtype === BehandlingType.REVURDERING && (
+                        <OpprettRevurderingBehandling fagsak={fagsak} lukkModal={lukkModal} />
                     )}
                 </VStack>
             </ModalWrapper>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -14,9 +14,14 @@ import { Fagsak } from '../../../../typer/fagsak';
 interface Props {
     fagsak: Fagsak;
     hentKlagebehandlinger: () => void;
+    hentBehandlinger: () => void;
 }
 
-const OpprettNyBehandlingModal: FC<Props> = ({ fagsak, hentKlagebehandlinger }) => {
+const OpprettNyBehandlingModal: FC<Props> = ({
+    fagsak,
+    hentKlagebehandlinger,
+    hentBehandlinger,
+}) => {
     const [visModal, settVisModal] = useState(false);
     const [behandlingtype, settBehandlingtype] = useState<BehandlingType>();
 
@@ -54,7 +59,11 @@ const OpprettNyBehandlingModal: FC<Props> = ({ fagsak, hentKlagebehandlinger }) 
                         />
                     )}
                     {behandlingtype === BehandlingType.REVURDERING && (
-                        <OpprettRevurderingBehandling fagsak={fagsak} lukkModal={lukkModal} />
+                        <OpprettRevurderingBehandling
+                            fagsak={fagsak}
+                            lukkModal={lukkModal}
+                            hentBehandlinger={hentBehandlinger}
+                        />
                     )}
                 </VStack>
             </ModalWrapper>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -3,18 +3,12 @@ import React, { FC, useState } from 'react';
 import { Button, Select, VStack } from '@navikt/ds-react';
 
 import OpprettKlageBehandling from './OpprettKlageBehandling';
-import { useApp } from '../../../../context/AppContext';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import {
     BehandlingType,
     behandlingTypeTilTekst,
 } from '../../../../typer/behandling/behandlingType';
 import { Fagsak } from '../../../../typer/fagsak';
-import { RessursStatus } from '../../../../typer/ressurs';
-
-interface OpprettKlageRequest {
-    mottattDato: string;
-}
 
 interface Props {
     fagsak: Fagsak;
@@ -22,32 +16,11 @@ interface Props {
 }
 
 const OpprettNyBehandlingModal: FC<Props> = ({ fagsak, hentKlagebehandlinger }) => {
-    const { request } = useApp();
-
     const [visModal, settVisModal] = useState(false);
     const [behandlingtype, settBehandlingtype] = useState<BehandlingType>();
-    const [kravMottattDato, settKravMottattDato] = useState('');
-    const [feilmelding, settFeilmelding] = useState<string>();
-
-    const opprettKlage = (data: OpprettKlageRequest) => {
-        request<string, OpprettKlageRequest>(
-            `/api/sak/klage/fagsak/${fagsak.id}`,
-            'POST',
-            data
-        ).then((response) => {
-            if (response.status === RessursStatus.SUKSESS) {
-                hentKlagebehandlinger();
-                lukkModal();
-            } else {
-                settFeilmelding(response.frontendFeilmelding || response.melding);
-            }
-        });
-    };
 
     const lukkModal = () => {
         settVisModal(false);
-        settFeilmelding('');
-        settKravMottattDato('');
         settBehandlingtype(undefined);
     };
 
@@ -56,24 +29,7 @@ const OpprettNyBehandlingModal: FC<Props> = ({ fagsak, hentKlagebehandlinger }) 
             <Button variant={'secondary'} onClick={() => settVisModal(true)}>
                 Opprett ny behandling
             </Button>
-            <ModalWrapper
-                visModal={visModal}
-                onClose={lukkModal}
-                tittel="Opprett ny behandling"
-                aksjonsknapper={{
-                    hovedKnapp: {
-                        onClick: () =>
-                            opprettKlage({
-                                mottattDato: kravMottattDato,
-                            }),
-                        tekst: 'Opprett',
-                    },
-                    lukkKnapp: {
-                        onClick: () => lukkModal(),
-                        tekst: 'Avbryt',
-                    },
-                }}
-            >
+            <ModalWrapper visModal={visModal} onClose={lukkModal} tittel={'Opprett ny behandling'}>
                 <VStack gap="4">
                     <Select
                         value={behandlingtype}
@@ -89,9 +45,9 @@ const OpprettNyBehandlingModal: FC<Props> = ({ fagsak, hentKlagebehandlinger }) 
                     </Select>
                     {behandlingtype === BehandlingType.KLAGE && (
                         <OpprettKlageBehandling
-                            kravMottattDato={kravMottattDato}
-                            settKravMottattDato={settKravMottattDato}
-                            feilmelding={feilmelding}
+                            fagsak={fagsak}
+                            lukkModal={lukkModal}
+                            hentKlagebehandlinger={hentKlagebehandlinger}
                         />
                     )}
                 </VStack>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
@@ -1,0 +1,52 @@
+import React, { useState } from 'react';
+
+import { Button, HStack, VStack } from '@navikt/ds-react';
+
+import { useApp } from '../../../../context/AppContext';
+import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { Fagsak } from '../../../../typer/fagsak';
+import { RessursStatus } from '../../../../typer/ressurs';
+
+interface Props {
+    fagsak: Fagsak;
+    lukkModal: () => void;
+}
+
+interface OpprettBehandlingRequest {
+    fagsakId: string;
+}
+
+const OpprettRevurderingBehandling: React.FC<Props> = ({ fagsak, lukkModal }) => {
+    const { request } = useApp();
+
+    const [feilmelding, settFeilmelding] = useState<string>();
+
+    const opprett = () => {
+        request<string, OpprettBehandlingRequest>(`/api/sak/behandling`, 'POST', {
+            fagsakId: fagsak.id,
+        }).then((response) => {
+            if (response.status === RessursStatus.SUKSESS) {
+                //hentBehandlinger(); // TODO
+                lukkModal();
+            } else {
+                settFeilmelding(response.frontendFeilmelding || response.melding);
+            }
+        });
+    };
+
+    return (
+        <VStack gap="4">
+            <HStack gap="4" justify={'end'}>
+                <Button variant="tertiary" onClick={lukkModal} size="small">
+                    Avbryt
+                </Button>
+                <Button variant="primary" onClick={opprett} size="small">
+                    Lagre
+                </Button>
+            </HStack>
+            <Feilmelding variant={'alert'}>{feilmelding}</Feilmelding>
+        </VStack>
+    );
+};
+
+export default OpprettRevurderingBehandling;

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
@@ -10,13 +10,14 @@ import { RessursStatus } from '../../../../typer/ressurs';
 interface Props {
     fagsak: Fagsak;
     lukkModal: () => void;
+    hentBehandlinger: () => void;
 }
 
 interface OpprettBehandlingRequest {
     fagsakId: string;
 }
 
-const OpprettRevurderingBehandling: React.FC<Props> = ({ fagsak, lukkModal }) => {
+const OpprettRevurderingBehandling: React.FC<Props> = ({ fagsak, lukkModal, hentBehandlinger }) => {
     const { request } = useApp();
 
     const [feilmelding, settFeilmelding] = useState<string>();
@@ -26,7 +27,7 @@ const OpprettRevurderingBehandling: React.FC<Props> = ({ fagsak, lukkModal }) =>
             fagsakId: fagsak.id,
         }).then((response) => {
             if (response.status === RessursStatus.SUKSESS) {
-                //hentBehandlinger(); // TODO
+                hentBehandlinger();
                 lukkModal();
             } else {
                 settFeilmelding(response.frontendFeilmelding || response.melding);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å kunne opprette revurdering

Har flyttet runt lite kode i `OpprettNyBehandlingModal` fordi jeg ønsker at "ny-<type>-behandling"-komponentene ansvarlige for sitt state, og at det ikke ligger i `OpprettNyBehandlingModal`. En egen commit for det.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21123

Koblet til
* https://github.com/navikt/tilleggsstonader-sak/pull/349

![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/4415cac2-4510-4d62-a48b-a084d815f177)
