### PR TITLE
Presentere hjemler under opprettelse av klage

### DIFF
--- a/src/frontend/Sider/Klage/App/api/klage-stubs.ts
+++ b/src/frontend/Sider/Klage/App/api/klage-stubs.ts
@@ -1,7 +1,13 @@
 import { ISaksbehandler } from '../typer/saksbehandler';
 import { Folkeregisterpersonstatus, IPersonopplysninger } from '../typer/personopplysninger';
 import { kjønnType } from '../../familie-felles-frontend/familie-typer/person';
-import { Behandling, BehandlingResultat, Fagsystem, PåklagetVedtakstype, StegType } from '../typer/fagsak';
+import {
+    Behandling,
+    BehandlingResultat,
+    Fagsystem,
+    PåklagetVedtakstype,
+    StegType,
+} from '../typer/fagsak';
 import { BehandlingStatus } from '../typer/behandlingstatus';
 import { Stønadstype } from '../typer/stønadstype';
 import {
@@ -11,9 +17,10 @@ import {
     VilkårStatus,
 } from '../../Komponenter/Behandling/Formkrav/typer';
 import { FagsystemVedtak } from '../typer/fagsystemVedtak';
-import { IVurdering, VedtakValg } from '../../Komponenter/Behandling/Vurdering/vurderingValg';
-import { FolketrygdHjemmel } from '../../Komponenter/Behandling/Vurdering/hjemmel';
-import { EBrevmottakerRolle, IBrevmottakere } from '../../Komponenter/Behandling/Brevmottakere/typer';
+import {
+    EBrevmottakerRolle,
+    IBrevmottakere,
+} from '../../Komponenter/Behandling/Brevmottakere/typer';
 import { IBehandlingshistorikk } from '../../Komponenter/Behandling/Høyremeny/behandlingshistorikk';
 
 export const saksbehandlerStub: ISaksbehandler = {
@@ -43,16 +50,16 @@ export const personopplysningerStub: IPersonopplysninger = {
     fullmakt: [],
     egenAnsatt: false,
     vergemål: [],
-    navEnhet: "FA1",
+    navEnhet: 'FA1',
 };
 
 export const behandlingStub: Behandling = {
-    id: "56694255-4a4a-407e-9079-8b14a7acbe80",
-    fagsakId: "c0656c5b-878e-470e-864f-dbafbae9cd82",
+    id: '56694255-4a4a-407e-9079-8b14a7acbe80',
+    fagsakId: 'c0656c5b-878e-470e-864f-dbafbae9cd82',
     steg: StegType.FORMKRAV, // Map to StegType enum
     status: BehandlingStatus.OPPRETTET, // Map to BehandlingStatus enum
-    sistEndret: "2024-05-27T17:25:49",
-    opprettet: "2024-05-27T17:25:48.658",
+    sistEndret: '2024-05-27T17:25:49',
+    opprettet: '2024-05-27T17:25:48.658',
     resultat: BehandlingResultat.IKKE_SATT, // Map to BehandlingResultat enum
     vedtakDato: undefined,
     stønadstype: Stønadstype.OVERGANGSSTØNAD, // Assuming this is imported from somewhere
@@ -63,85 +70,75 @@ export const behandlingStub: Behandling = {
         fagsystemVedtak: undefined,
         manuellVedtaksdato: undefined,
     },
-    eksternFagsystemFagsakId: "200054236",
+    eksternFagsystemFagsakId: '200054236',
     fagsystem: Fagsystem.EF, // Map to Fagsystem enum
-    klageMottatt: "2024-05-22",
-    fagsystemRevurdering: undefined
+    klageMottatt: '2024-05-22',
+    fagsystemRevurdering: undefined,
 };
 
 export const formkravVilkårStub: IFormkravVilkår = {
-    behandlingId: "56694255-4a4a-407e-9079-8b14a7acbe80",
+    behandlingId: '56694255-4a4a-407e-9079-8b14a7acbe80',
     klagePart: VilkårStatus.OPPFYLT,
     klageKonkret: VilkårStatus.OPPFYLT,
     klagefristOverholdt: VilkårStatus.OPPFYLT,
     klagefristOverholdtUnntak: FormkravFristUnntak.IKKE_SATT,
     klageSignert: VilkårStatus.OPPFYLT,
-    saksbehandlerBegrunnelse: "",
-    endretTid: "2024-05-28T08:14:20.478",
+    saksbehandlerBegrunnelse: '',
+    endretTid: '2024-05-28T08:14:20.478',
     påklagetVedtak: {
-        eksternFagsystemBehandlingId: "17934",
+        eksternFagsystemBehandlingId: '17934',
         påklagetVedtakstype: PåklagetVedtakstype.VEDTAK,
         fagsystemVedtak: {
-            eksternBehandlingId: "17934",
-            behandlingstype: "Førstegangsbehandling",
-            resultat: "Innvilget",
-            vedtakstidspunkt: "2024-01-22T17:13:23.621",
+            eksternBehandlingId: '17934',
+            behandlingstype: 'Førstegangsbehandling',
+            resultat: 'Innvilget',
+            vedtakstidspunkt: '2024-01-22T17:13:23.621',
             fagsystemType: FagsystemType.ORDNIÆR,
             //regelverk: "NASJONAL"
         },
         manuellVedtaksdato: undefined,
         //regelverk: "NASJONAL"
-    }
-}
+    },
+};
 
 export const fagsystemVedakStub: FagsystemVedtak[] = [
     {
-        eksternBehandlingId: "17934",
-        behandlingstype: "Førstegangsbehandling",
-        resultat: "Innvilget",
-        vedtakstidspunkt: "2024-01-22T17:13:23.621",
+        eksternBehandlingId: '17934',
+        behandlingstype: 'Førstegangsbehandling',
+        resultat: 'Innvilget',
+        vedtakstidspunkt: '2024-01-22T17:13:23.621',
         fagsystemType: FagsystemType.ORDNIÆR,
-    }
-] 
-
-export const vurderingStub: IVurdering = {
-    behandlingId: "56694255-4a4a-407e-9079-8b14a7acbe80",
-    vedtak: VedtakValg.OPPRETTHOLD_VEDTAK,
-    årsak: undefined ,
-    begrunnelseOmgjøring: undefined ,
-    hjemmel: FolketrygdHjemmel.FT_FEMTEN_TO,
-    innstillingKlageinstans: "Dette er fritekst",
-    interntNotat: undefined
-}
+    },
+];
 
 export const brevmottakereStub: IBrevmottakere = {
     personer: [
         {
-            personIdent: "25518735813",
-            navn: "HURTIG PLEIE",
-            mottakerRolle: EBrevmottakerRolle.BRUKER
-        }
+            personIdent: '25518735813',
+            navn: 'HURTIG PLEIE',
+            mottakerRolle: EBrevmottakerRolle.BRUKER,
+        },
     ],
-    organisasjoner: []
-}
+    organisasjoner: [],
+};
 
 export const behandlingshistorikkStub: IBehandlingshistorikk[] = [
     {
-        behandlingId: "56694255-4a4a-407e-9079-8b14a7acbe80",
+        behandlingId: '56694255-4a4a-407e-9079-8b14a7acbe80',
         steg: StegType.VURDERING,
-        opprettetAv: "Z994781",
-        endretTid: "2024-05-28T08:24:17.341055"
+        opprettetAv: 'Z994781',
+        endretTid: '2024-05-28T08:24:17.341055',
     },
     {
-        behandlingId: "56694255-4a4a-407e-9079-8b14a7acbe80",
+        behandlingId: '56694255-4a4a-407e-9079-8b14a7acbe80',
         steg: StegType.FORMKRAV,
-        opprettetAv: "Z994781",
-        endretTid: "2024-05-28T08:16:29.451124"
+        opprettetAv: 'Z994781',
+        endretTid: '2024-05-28T08:16:29.451124',
     },
     {
-        behandlingId: "56694255-4a4a-407e-9079-8b14a7acbe80",
+        behandlingId: '56694255-4a4a-407e-9079-8b14a7acbe80',
         steg: StegType.FORMKRAV,
-        opprettetAv: "Z994781",
-        endretTid: "2024-05-28T08:15:29.345039"
+        opprettetAv: 'Z994781',
+        endretTid: '2024-05-28T08:15:29.345039',
     },
-]
+];

--- a/src/frontend/Sider/Klage/Komponenter/Behandling/Vurdering/HjemmelVelger.tsx
+++ b/src/frontend/Sider/Klage/Komponenter/Behandling/Vurdering/HjemmelVelger.tsx
@@ -1,16 +1,9 @@
 import * as React from 'react';
+import { Dispatch, SetStateAction } from 'react';
 import { Heading, Select } from '@navikt/ds-react';
 import styled from 'styled-components';
-import { Dispatch, SetStateAction } from 'react';
 import { IVurdering } from './vurderingValg';
-import {
-    Hjemmel,
-    alleHjemlerTilVisningstekst,
-    folketrygdlovenHjemmelTilVisningstekst,
-} from './hjemmel';
-import { useBehandling } from '../../../App/context/BehandlingContext';
-import { RessursStatus } from '../../../App/typer/ressurs';
-import { Stønadstype } from '../../../App/typer/stønadstype';
+import { alleHjemlerTilVisningstekst, Hjemmel } from './hjemmel';
 
 const HjemmelStyled = styled.div`
     margin: 2rem 4rem 2rem 4rem;
@@ -28,20 +21,6 @@ interface IHjemmel {
 }
 
 export const HjemmelVelger: React.FC<IHjemmel> = ({ settHjemmel, hjemmelValgt, endring }) => {
-    const { behandling, settVurderingEndret } = useBehandling();
-    const hjemmelValgmuligheter: Record<string, string> = React.useMemo(() => {
-        if (behandling.status === RessursStatus.SUKSESS) {
-            switch (behandling.data.stønadstype) {
-                case Stønadstype.BARNETILSYN:
-                case Stønadstype.OVERGANGSSTØNAD:
-                case Stønadstype.SKOLEPENGER:
-                    return folketrygdlovenHjemmelTilVisningstekst;
-                default:
-                    return alleHjemlerTilVisningstekst;
-            }
-        }
-        return alleHjemlerTilVisningstekst;
-    }, [behandling]);
     return (
         <HjemmelStyled>
             <Heading spacing size="medium" level="5">
@@ -61,16 +40,17 @@ export const HjemmelVelger: React.FC<IHjemmel> = ({ settHjemmel, hjemmelValgt, e
                                     hjemmel: e.target.value,
                                 }) as IVurdering
                         );
-                        settVurderingEndret(true);
                     }}
                     hideLabel
                 >
                     <option value={''}>Velg</option>
-                    {Object.keys(hjemmelValgmuligheter).map((nøkkel, index) => (
-                        <option value={nøkkel} key={index}>
-                            {hjemmelValgmuligheter[nøkkel]}
-                        </option>
-                    ))}
+                    {Object.keys(alleHjemlerTilVisningstekst).map(
+                        (hjemmel: string, index: number) => (
+                            <option value={hjemmel as Hjemmel} key={index}>
+                                {alleHjemlerTilVisningstekst[hjemmel as Hjemmel]}
+                            </option>
+                        )
+                    )}
                 </Select>
             </HjemmelInnholdStyled>
         </HjemmelStyled>

--- a/src/frontend/Sider/Klage/Komponenter/Behandling/Vurdering/HjemmelVelger.tsx
+++ b/src/frontend/Sider/Klage/Komponenter/Behandling/Vurdering/HjemmelVelger.tsx
@@ -6,9 +6,7 @@ import { IVurdering } from './vurderingValg';
 import {
     Hjemmel,
     alleHjemlerTilVisningstekst,
-    folketrygdHjemmelTilVisningstekst,
-    baHjemlerTilVisningstekst,
-    ksHjemlerTilVisningstekst,
+    folketrygdlovenHjemmelTilVisningstekst,
 } from './hjemmel';
 import { useBehandling } from '../../../App/context/BehandlingContext';
 import { RessursStatus } from '../../../App/typer/ressurs';
@@ -34,14 +32,10 @@ export const HjemmelVelger: React.FC<IHjemmel> = ({ settHjemmel, hjemmelValgt, e
     const hjemmelValgmuligheter: Record<string, string> = React.useMemo(() => {
         if (behandling.status === RessursStatus.SUKSESS) {
             switch (behandling.data.stønadstype) {
-                case Stønadstype.BARNETRYGD:
-                    return baHjemlerTilVisningstekst;
-                case Stønadstype.KONTANTSTØTTE:
-                    return ksHjemlerTilVisningstekst;
                 case Stønadstype.BARNETILSYN:
                 case Stønadstype.OVERGANGSSTØNAD:
                 case Stønadstype.SKOLEPENGER:
-                    return folketrygdHjemmelTilVisningstekst;
+                    return folketrygdlovenHjemmelTilVisningstekst;
                 default:
                     return alleHjemlerTilVisningstekst;
             }

--- a/src/frontend/Sider/Klage/Komponenter/Behandling/Vurdering/hjemmel.ts
+++ b/src/frontend/Sider/Klage/Komponenter/Behandling/Vurdering/hjemmel.ts
@@ -1,134 +1,106 @@
-export enum FolketrygdHjemmel {
-    FT_FEMTEN_TO = 'FT_FEMTEN_TO',
-    FT_FEMTEN_TRE = 'FT_FEMTEN_TRE',
-    FT_FEMTEN_FIRE = 'FT_FEMTEN_FIRE',
-    FT_FEMTEN_FEM = 'FT_FEMTEN_FEM',
-    FT_FEMTEN_SEKS = 'FT_FEMTEN_SEKS',
-    FT_FEMTEN_ÅTTE = 'FT_FEMTEN_ÅTTE',
-    FT_FEMTEN_NI = 'FT_FEMTEN_NI',
-    FT_FEMTEN_TI = 'FT_FEMTEN_TI',
-    FT_FEMTEN_ELLEVE = 'FT_FEMTEN_ELLEVE',
-    FT_FEMTEN_TOLV = 'FT_FEMTEN_TOLV',
-    FT_FEMTEN_TRETTEN = 'FT_FEMTEN_TRETTEN',
-    FT_TJUETO_TOLV = 'FT_TJUETO_TOLV',
-    FT_TJUETO_TRETTEN = 'FT_TJUETO_TRETTEN',
-    FT_TJUETO_FEMTEN = 'FT_TJUETO_FEMTEN',
+enum ArbeidsmarkedslovenHjemmel {
+    ARBML_13 = 'ARBML_13',
+    ARBML_17 = 'ARBML_17',
+    ARBML_22 = 'ARBML_22',
 }
 
-enum BarnetrygdlovenHjemmel {
-    BT_TO = 'BT_TO',
-    BT_FIRE = 'BT_FIRE',
-    BT_FEM = 'BT_FEM',
-    BT_NI = 'BT_NI',
-    BT_TI = 'BT_TI',
-    BT_ELLEVE = 'BT_ELLEVE',
-    BT_TOLV = 'BT_TOLV',
-    BT_TRETTEN = 'BT_TRETTEN',
-    BT_SYTTEN = 'BT_SYTTEN',
-    BT_ATTEN = 'BT_ATTEN',
+enum FolketrygdlovenHjemmel {
+    FTRL_11_A_3 = 'FTRL_11_A_3',
+    FTRL_11_A_4 = 'FTRL_11_A_4',
+    FTRL_11_A_4_3 = 'FTRL_11_A_4_3',
+    FTRL_441 = 'FTRL_441',
+    FTRL_17_10_17_15 = 'FTRL_17_10_17_15',
+    FTRL_21_12 = 'FTRL_21_12',
+    FTRL_1000_022_013 = 'FTRL_1000_022_013',
+    FTRL_1000_022_015 = 'FTRL_1000_022_015',
+    FTRL_22_17A = 'FTRL_22_17A',
 }
 
-enum KontantstøttelovenHjemmel {
-    KS_TO = 'KS_TO',
-    KS_TRE = 'KS_TRE',
-    KS_SEKS = 'KS_SEKS',
-    KS_SYV = 'KS_SYV',
-    KS_ÅTTE = 'KS_ÅTTE',
-    KS_NI = 'KS_NI',
-    KS_TI = 'KS_TI',
-    KS_ELLEVE = 'KS_ELLEVE',
-    KS_TOLV = 'KS_TOLV',
-    KS_TRETTEN = 'KS_TRETTEN',
-    KS_SEKSTEN = 'KS_SEKSTEN',
+enum TilleggsstønadforskriftenHjemmel {
+    FS_TILL_ST_1_3_MOBILITET = 'FS_TILL_ST_1_3_MOBILITET',
+    FS_TILL_ST_3_REISE = 'FS_TILL_ST_3_REISE',
+    FS_TILL_ST_6_FLYTTING = 'FS_TILL_ST_6_FLYTTING',
+    FS_TILL_ST_8_BOLIG = 'FS_TILL_ST_8_BOLIG',
+    FS_TILL_ST_10_TILSYN = 'FS_TILL_ST_10_TILSYN',
+    FS_TILL_ST_12_LAEREMIDLER = 'FS_TILL_ST_12_LAEREMIDLER',
+    FS_TILL_ST_15_2 = 'FS_TILL_ST_15_2',
+    FS_TILL_ST_15_3 = 'FS_TILL_ST_15_3',
 }
 
-enum UtlandsavtalerHjemmel {
-    UTLAND_EØS = 'UTLAND_EØS',
-    UTLAND_EØS_FORORDNINGEN_FEM = 'UTLAND_EØS_FORORDNINGEN_FEM',
-    UTLAND_EØS_FORORDNINGEN_SEKS = 'UTLAND_EØS_FORORDNINGEN_SEKS',
-    UTLAND_NORDISK = 'UTLAND_NORDISK',
-    UTLAND_TRYGDEAVTALER = 'UTLAND_TRYGDEAVTALER',
+enum ForeldeseslovenHjemmel {
+    FL_2_3 = 'FL_2_3',
+    FL_10 = 'FL_10',
+}
+
+enum ForvaltningslovenHjemmel {
+    FVL_11 = 'FVL_11',
+    FVL_17 = 'FVL_17',
+    FVL_18_19 = 'FVL_18_19',
+    FVL_35 = 'FVL_35',
+    FVL_41 = 'FVL_41',
+    FVL_42 = 'FVL_42',
 }
 
 export type Hjemmel =
-    | FolketrygdHjemmel
-    | BarnetrygdlovenHjemmel
-    | KontantstøttelovenHjemmel
-    | UtlandsavtalerHjemmel;
+    | ArbeidsmarkedslovenHjemmel
+    | FolketrygdlovenHjemmel
+    | TilleggsstønadforskriftenHjemmel
+    | ForeldeseslovenHjemmel
+    | ForvaltningslovenHjemmel;
 
-const barnetrygdlovenVisningstekster: Record<BarnetrygdlovenHjemmel, string> = {
-    BT_TO: '§ 2 Hvem som har rett til barnetrygd',
-    BT_FIRE: '§ 4 Bosatt i riket, lovlig opphold mm.',
-    BT_FEM: '§ 5 Medlemskap i folketrygden under utenlandsopphold',
-    BT_NI: '§ 9 Utvidet barnetrygd',
-    BT_TI: '§ 10 Barnetrygdens størrelse',
-    BT_ELLEVE: '§ 11 Stønadsperiode',
-    BT_TOLV: '§ 12 Utbetaling',
-    BT_TRETTEN: '§ 13 Tilbakekreving',
-    BT_SYTTEN: '§ 17 Stønadsmottakers opplysningsplikt',
-    BT_ATTEN: '§ 18 Uriktige opplysninger',
-};
-
-const kontantstøttelovenVisningstekster: Record<KontantstøttelovenHjemmel, string> = {
-    KS_TO: '§ 2 Vilkår knyttet til barnet',
-    KS_TRE: '§ 3 Vilkår knyttet til støttemottaker',
-    KS_SEKS: '§ 6 Barn i fosterhjem eller institusjon',
-    KS_SYV: '§ 7 Kontantstøttens størrelse',
-    KS_ÅTTE: '§ 8 Stønadsperiode',
-    KS_NI: '§ 9 Utbetaling av kontantstøtte - delt bosted',
-    KS_TI: '§ 10 Utbetaling til adopterte barn',
-    KS_ELLEVE: '§ 11 Tilbakekreving',
-    KS_TOLV: '§ 12 Støttemottakerens opplysningsplikt',
-    KS_TRETTEN: '§ 13 Avslag på søknad, stans i utbetalingen',
-    KS_SEKSTEN: '§ 16 Opplysningsplikt',
-};
-
-const utlandsavtalerHjemmelVisningstekster: Record<UtlandsavtalerHjemmel, string> = {
-    UTLAND_EØS: 'EØS-avtalen',
-    UTLAND_EØS_FORORDNINGEN_FEM: 'EØS-forordningen art. 5',
-    UTLAND_EØS_FORORDNINGEN_SEKS: 'EØS-forordningen art. 6',
-    UTLAND_NORDISK: 'Nordisk konvensjon',
-    UTLAND_TRYGDEAVTALER: 'Trygdeavtaler',
-};
-
-export const folketrygdHjemmelTilVisningstekst: Record<FolketrygdHjemmel, string> = {
-    FT_FEMTEN_TO: '§ 15-2 Forutgående medlemskap',
-    FT_FEMTEN_TRE: '§ 15-3 Opphold i Norge',
-    FT_FEMTEN_FIRE: '§ 15-4 Enslig mor eller far',
-    FT_FEMTEN_FEM: '§ 15-5 Overgangsstønad',
-    FT_FEMTEN_SEKS: '§ 15-6 Plikt til yrkesrettet aktivitet',
-    FT_FEMTEN_ÅTTE: '§ 15-8 Stønadsperiode',
-    FT_FEMTEN_NI: '§ 15-9 Avkorting mot inntekt',
-    FT_FEMTEN_TI: '§ 15-10 Stønad til barnetilsyn',
-    FT_FEMTEN_ELLEVE: '§ 15-11 Stønad til skolepenger',
-    FT_FEMTEN_TOLV: '§ 15-12 Sanksjon',
-    FT_FEMTEN_TRETTEN: '§ 15-13 Forholdet til andre folketrygdytelser',
-    FT_TJUETO_TOLV:
-        '§ 22-12 Tidspunkt for utbetaling når rett til en ytelse oppstår eller opphører',
-    FT_TJUETO_TRETTEN:
-        '§ 22-13 Frister for framsetting av krav, virkningstidspunkt og etterbetaling',
-    FT_TJUETO_FEMTEN: '§ 22-15 Tilbakekreving',
-};
-
-export const baHjemlerTilVisningstekst: Record<
-    BarnetrygdlovenHjemmel | UtlandsavtalerHjemmel,
+export const ArbeidsmarkedslovenHjemmelTilVisningstekst: Record<
+    ArbeidsmarkedslovenHjemmel,
     string
 > = {
-    ...barnetrygdlovenVisningstekster,
-    ...utlandsavtalerHjemmelVisningstekster,
+    ARBML_13: 'ARBML_13',
+    ARBML_17: 'ARBML_17',
+    ARBML_22: 'ARBML_22',
 };
 
-export const ksHjemlerTilVisningstekst: Record<
-    KontantstøttelovenHjemmel | UtlandsavtalerHjemmel,
+export const folketrygdlovenHjemmelTilVisningstekst: Record<FolketrygdlovenHjemmel, string> = {
+    FTRL_11_A_3: 'FTRL_11_A_3',
+    FTRL_11_A_4: 'FTRL_11_A_4',
+    FTRL_11_A_4_3: 'FTRL_11_A_4_3',
+    FTRL_441: 'FTRL_441',
+    FTRL_17_10_17_15: 'FTRL_17_10_17_15',
+    FTRL_21_12: 'FTRL_21_12',
+    FTRL_1000_022_013: 'FTRL_1000_022_013',
+    FTRL_1000_022_015: 'FTRL_1000_022_015',
+    FTRL_22_17A: 'FTRL_22_17A',
+};
+
+export const TilleggsstønadforskriftenHjemmelTilVisningstekst: Record<
+    TilleggsstønadforskriftenHjemmel,
     string
 > = {
-    ...kontantstøttelovenVisningstekster,
-    ...utlandsavtalerHjemmelVisningstekster,
+    FS_TILL_ST_1_3_MOBILITET: 'FS_TILL_ST_1_3_MOBILITET',
+    FS_TILL_ST_3_REISE: 'FS_TILL_ST_3_REISE',
+    FS_TILL_ST_6_FLYTTING: 'FS_TILL_ST_6_FLYTTING',
+    FS_TILL_ST_8_BOLIG: 'FS_TILL_ST_8_BOLIG',
+    FS_TILL_ST_10_TILSYN: 'FS_TILL_ST_10_TILSYN',
+    FS_TILL_ST_12_LAEREMIDLER: 'FS_TILL_ST_12_LAEREMIDLER',
+    FS_TILL_ST_15_2: 'FS_TILL_ST_15_2',
+    FS_TILL_ST_15_3: 'FS_TILL_ST_15_3',
+};
+
+export const ForeldeseslovenHjemmelTilVisningstekst: Record<ForeldeseslovenHjemmel, string> = {
+    FL_2_3: 'FL_2_3',
+    FL_10: 'FL_10',
+};
+
+export const ForvaltningslovenHjemmelTilVisningstekst: Record<ForvaltningslovenHjemmel, string> = {
+    FVL_11: 'FVL_11',
+    FVL_17: 'FVL_17',
+    FVL_18_19: 'FVL_18_19',
+    FVL_35: 'FVL_35',
+    FVL_41: 'FVL_41',
+    FVL_42: 'FVL_42',
 };
 
 export const alleHjemlerTilVisningstekst: Record<Hjemmel, string> = {
-    ...folketrygdHjemmelTilVisningstekst,
-    ...barnetrygdlovenVisningstekster,
-    ...kontantstøttelovenVisningstekster,
-    ...utlandsavtalerHjemmelVisningstekster,
+    ...ArbeidsmarkedslovenHjemmelTilVisningstekst,
+    ...folketrygdlovenHjemmelTilVisningstekst,
+    ...TilleggsstønadforskriftenHjemmelTilVisningstekst,
+    ...ForeldeseslovenHjemmelTilVisningstekst,
+    ...ForvaltningslovenHjemmelTilVisningstekst,
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vise hjemler tilknyttet Tilleggsstønader i "Klage frontend". 

Har fjernet noe logikk for gruppering av hjemler

### Viktig:
Må ikke merges før Klage-backend er oppdatert med riktige hjemler

Venter på tilbakemelding fra Kabal angående Hjemler: 

https://nav-it.slack.com/archives/C0769AMND27/p1718115371416699?thread_ts=1717613410.676729&cid=C0769AMND27



![Skjermbilde 2024-06-11 kl  17 02 36](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/28704275/c3e0f5d5-bfe1-4953-81dc-3c791f64ebfd)

