### PR TITLE
Nais-config for unleash

### DIFF
--- a/.github/workflows/deploy-unleash-api-token-dev.yaml
+++ b/.github/workflows/deploy-unleash-api-token-dev.yaml
@@ -1,0 +1,21 @@
+name: Deploy unleash api-token for dev
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: "write"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: deploy unleash api-token
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: dev-gcp
+          RESOURCE: .nais/unleash-apitoken-preprod.yaml
+          PRINT_PAYLOAD: true

--- a/.github/workflows/deploy-unleash-api-token-prod.yaml
+++ b/.github/workflows/deploy-unleash-api-token-prod.yaml
@@ -1,0 +1,21 @@
+name: Deploy unleash api-token for prod
+
+on:
+  workflow_dispatch:
+
+permissions:
+  id-token: "write"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      - name: deploy unleash api-token
+        uses: nais/deploy/actions/deploy@v2
+        env:
+          CLUSTER: prod-gcp
+          RESOURCE: .nais/unleash-apitoken-prod.yaml
+          PRINT_PAYLOAD: true

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -57,6 +57,8 @@ spec:
           - id: "5ef775f2-61f8-4283-bf3d-8d03f428aa14" # 0000-GA-Strengt_Fortrolig_Adresse
           - id: "ea930b6b-9397-44d9-b9e6-f4cf527a632a" # 0000-GA-Fortrolig_Adresse
           - id: "dbe4ad45-320b-4e9a-aaa1-73cca4ee124d" # 0000-GA-Egne_ansatte
+  envFrom:
+    - secret: tilleggsstonader-sak-frontend-unleash-api-token
   env:
     - name: ENV
       value: preprod

--- a/.nais/dev.yaml
+++ b/.nais/dev.yaml
@@ -41,6 +41,8 @@ spec:
         - application: tilleggsstonader-klage
         - application: familie-endringslogg
           namespace: teamfamilie
+      external:
+        - host: tilleggsstonader-unleash-api.nav.cloud.nais.io
   azure:
     sidecar:
       enabled: true

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -40,6 +40,8 @@ spec:
         - application: tilleggsstonader-klage
         - application: familie-endringslogg
           namespace: teamfamilie
+      external:
+        - host: tilleggsstonader-unleash-api.nav.cloud.nais.io
   azure:
     sidecar:
       enabled: true

--- a/.nais/prod.yaml
+++ b/.nais/prod.yaml
@@ -56,6 +56,8 @@ spec:
           - id: "ad7b87a6-9180-467c-affc-20a566b0fec0" # 0000-GA-Strengt_Fortrolig_Adresse
           - id: "9ec6487d-f37a-4aad-a027-cd221c1ac32b" # 0000-GA-Fortrolig_Adresse
           - id: "e750ceb5-b70b-4d94-b4fa-9d22467b786b" # 0000-GA-Egne_ansatte
+  envFrom:
+    - secret: tilleggsstonader-sak-frontend-unleash-api-token
   env:
     - name: ENV
       value: prod

--- a/.nais/unleash-apitoken-preprod.yaml
+++ b/.nais/unleash-apitoken-preprod.yaml
@@ -1,0 +1,18 @@
+apiVersion: unleash.nais.io/v1
+kind: ApiToken
+metadata:
+  name: tilleggsstonader-sak-frontend
+  namespace: tilleggsstonader
+  labels:
+    team: tilleggsstonader
+spec:
+  unleashInstance:
+    apiVersion: unleash.nais.io/v1
+    kind: RemoteUnleash
+    name: tilleggsstonader
+  secretName: tilleggsstonader-sak-frontend-unleash-api-token
+
+  # Specify which environment the API token should be created for.
+  # Can be one of: development, or production.
+  environment: development
+  type: FRONTEND

--- a/.nais/unleash-apitoken-prod.yaml
+++ b/.nais/unleash-apitoken-prod.yaml
@@ -1,0 +1,18 @@
+apiVersion: unleash.nais.io/v1
+kind: ApiToken
+metadata:
+  name: tilleggsstonader-sak-frontend
+  namespace: tilleggsstonader
+  labels:
+    team: tilleggsstonader
+spec:
+  unleashInstance:
+    apiVersion: unleash.nais.io/v1
+    kind: RemoteUnleash
+    name: tilleggsstonader
+  secretName: tilleggsstonader-sak-frontend-unleash-api-token
+
+  # Specify which environment the API token should be created for.
+  # Can be one of: development, or production.
+  environment: production
+  type: FRONTEND


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lagt til token for unleash.
Forskjellen mot sak er at `type: FRONTEND` som gir en litt annen type token sånn at man kan bruke `FlagProvider` fra https://github.com/Unleash/proxy-client-react

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21494

Koblet til:
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/386