### PR TITLE
Lagt til unleashklient for å kunne hente toggles

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ AZURE_APP_CLIENT_SECRET=<clientSecret>
 # Feilsøking
 Feilmelding ved oppstart av app: 
 ```
-Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<...>/src/backend/build/auth/attachToken' imported from <...>/src/backend/build/server.js 
+Error [ERR_MODULE_NOT_FOUND]: Cannot find module '<...>/src/backend/build/auth/token' imported from <...>/src/backend/build/server.js 
 ```
 Løsning: Du trenger Node-versjon 18. 
 

--- a/README.md
+++ b/README.md
@@ -27,6 +27,19 @@ Lag en `.env` fil i `src/backend` og legg inn:
 AZURE_APP_CLIENT_ID=<clientId>
 AZURE_APP_CLIENT_SECRET=<clientSecret>
 ```
+
+#### Unleash
+Lokalt er unleash mocket. Default er at flagg er enabled. Hvis man ønsker å sette de til false gjøres det i
+[unleashMock.ts](./src/frontend/utils/unleashMock.ts)
+* 
+
+##### Bruke unleash fra lokalt
+Hent token mot unleash
+`kubectl -n tilleggsstonader get secret tilleggsstonader-sak-frontend-unleash-api-token -o json | jq '.data | map_values(@base64d)' | grep TOKEN`
+Legg inn token i `.env`
+* `UNLEASH_SERVER_API_TOKEN` (fra secret)
+* Start app med `BRUK_UNLEASH=true yarn start:dev`
+
 # Feilsøking
 Feilmelding ved oppstart av app: 
 ```

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@navikt/familie-form-elements": "^15.0.0",
     "@portabletext/react": "^3.0.9",
     "@sanity/client": "^6.18.0",
+    "@unleash/proxy-client-react": "^4.2.4",
     "axios": "^1.7.2",
     "constate": "^3.3.2",
     "data-fns": "^1.1.0",
@@ -38,6 +39,7 @@
     "react-router-dom": "^6.23.1",
     "react-router-prompt": "^0.7.0",
     "styled-components": "^6.1.0",
+    "unleash-proxy-client": "^3.4.0",
     "use-debounce": "^10.0.0",
     "uuid": "^9.0.1"
   },

--- a/src/backend/auth/profile.ts
+++ b/src/backend/auth/profile.ts
@@ -1,7 +1,7 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express';
 import { decodeJwt } from 'jose';
 
-import { getTokenFromHeader } from './attachToken';
+import { getTokenFromHeader } from './token';
 
 export const getProfile = (): RequestHandler => {
     return async (req: Request, res: Response, next: NextFunction) => {

--- a/src/backend/auth/token.ts
+++ b/src/backend/auth/token.ts
@@ -8,7 +8,7 @@ import { redirectResponseToLogin } from './util';
 import { logWarn } from '../logger';
 import { ApplicationName, miljø } from '../miljø';
 
-const AUTHORIZATION_HEADER = 'authorization';
+export const AUTHORIZATION_HEADER = 'authorization';
 const WONDERWALL_ID_TOKEN_HEADER = 'x-wonderwall-id-token';
 
 export const validateToken = (redirectToLogin: boolean = false): RequestHandler => {
@@ -92,6 +92,17 @@ const getValidatedTokenFromHeader = async (req: Request) => {
     }
     return token;
 };
+
+export const getUserIdFromToken = (req: Request) => {
+    const token = getTokenFromHeader(req);
+    if (token == null) {
+        return null;
+    }
+    const payload = decodeJwt(token);
+
+    return payload.NAVident;
+};
+
 const prepareSecuredRequest = async (req: Request, applicationName: ApplicationName) => {
     const token = await getValidatedTokenFromHeader(req);
     if (!token) return null;

--- a/src/backend/miljø.ts
+++ b/src/backend/miljø.ts
@@ -10,6 +10,7 @@ export enum ApplicationName {
     sak = 'sak',
     klage = 'klage',
     endringslogg = 'endringslogg',
+    unleash = 'unleash',
 }
 
 type Rolle = 'veileder' | 'saksbehandler' | 'beslutter' | 'kode6' | 'kode7' | 'egenAnsatt';
@@ -33,10 +34,16 @@ type ClientConfig = {
     };
 };
 
+interface UnleashSettings {
+    token: string;
+    environment: string;
+}
+
 interface Miljø {
     buildPath: string;
     clients: ClientConfig;
     azure: AzureSettings;
+    unleash: UnleashSettings;
     roller: Roller;
 }
 
@@ -56,6 +63,14 @@ const devProdAzure = (): AzureSettings => ({
     issuer: envVar('AZURE_OPENID_CONFIG_ISSUER'),
     token_endpoint: envVar('AZURE_OPENID_CONFIG_TOKEN_ENDPOINT'),
     openid_config_jwks_uri: envVar('AZURE_OPENID_CONFIG_JWKS_URI'),
+});
+
+/**
+ * @param environment skal være den samme som i unleash-apitoken-preprod.yaml
+ */
+const unleash = (environment: 'development' | 'production'): UnleashSettings => ({
+    token: envVar('UNLEASH_SERVER_API_TOKEN'),
+    environment: environment,
 });
 
 const devRoller: Roller = {
@@ -89,6 +104,10 @@ const clientsLocal = (): ClientConfig => ({
         url: 'https://familie-endringslogg.intern.dev.nav.no',
         audience: 'dev-gcp.teamfamilie.familie-endringslogg',
     },
+    [ApplicationName.unleash]: {
+        url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io/api/frontend',
+        audience: '',
+    },
 });
 
 const clientsLocalPreprod = (): ClientConfig => ({
@@ -104,12 +123,17 @@ const clientsLocalPreprod = (): ClientConfig => ({
         url: 'https://familie-endringslogg.intern.dev.nav.no',
         audience: 'dev-gcp.teamfamilie.familie-endringslogg',
     },
+    [ApplicationName.unleash]: {
+        url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io',
+        audience: '',
+    },
 });
 
 const lokaltMiljø = (clients: ClientConfig): Miljø => ({
     buildPath: '../../dist_development',
     clients: clients,
     azure: lokalAzure(),
+    unleash: unleash('development'),
     roller: devRoller,
 });
 
@@ -128,8 +152,13 @@ const devMiljø = (): Miljø => ({
             url: 'http://familie-endringslogg.teamfamilie',
             audience: 'dev-gcp.teamfamilie.familie-endringslogg',
         },
+        [ApplicationName.unleash]: {
+            url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io',
+            audience: '',
+        },
     },
     azure: devProdAzure(),
+    unleash: unleash('development'),
     roller: devRoller,
 });
 
@@ -148,8 +177,13 @@ const prodMiljø = (): Miljø => ({
             url: 'http://familie-endringslogg.teamfamilie',
             audience: 'prod-gcp.teamfamilie.familie-endringslogg',
         },
+        [ApplicationName.unleash]: {
+            url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io',
+            audience: '',
+        },
     },
     azure: devProdAzure(),
+    unleash: unleash('production'),
     roller: prodRoller,
 });
 

--- a/src/backend/miljø.ts
+++ b/src/backend/miljø.ts
@@ -1,5 +1,6 @@
 import dotenv from 'dotenv';
 
+import logger from './logger';
 import { envVar } from './utils';
 
 if (process.env.NODE_ENV === 'development') {
@@ -124,7 +125,7 @@ const clientsLocalPreprod = (): ClientConfig => ({
         audience: 'dev-gcp.teamfamilie.familie-endringslogg',
     },
     [ApplicationName.unleash]: {
-        url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io',
+        url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io/api/frontend',
         audience: '',
     },
 });
@@ -132,6 +133,8 @@ const clientsLocalPreprod = (): ClientConfig => ({
 const lokaltMiljø = (clients: ClientConfig): Miljø => {
     const brukUnleash = envVar('BRUK_UNLEASH', false, 'false');
     const unleashEnvironment = brukUnleash === 'true' ? 'development' : 'mock';
+    logger.info(`Unleasn, brukUnleash=${brukUnleash} unleashEnv=${unleashEnvironment}`);
+
     return {
         buildPath: '../../dist_development',
         clients: clients,
@@ -157,7 +160,7 @@ const devMiljø = (): Miljø => ({
             audience: 'dev-gcp.teamfamilie.familie-endringslogg',
         },
         [ApplicationName.unleash]: {
-            url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io',
+            url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io/api/frontend',
             audience: '',
         },
     },
@@ -182,7 +185,7 @@ const prodMiljø = (): Miljø => ({
             audience: 'prod-gcp.teamfamilie.familie-endringslogg',
         },
         [ApplicationName.unleash]: {
-            url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io',
+            url: 'https://tilleggsstonader-unleash-api.nav.cloud.nais.io/api/frontend',
             audience: '',
         },
     },

--- a/src/backend/miljø.ts
+++ b/src/backend/miljø.ts
@@ -68,8 +68,8 @@ const devProdAzure = (): AzureSettings => ({
 /**
  * @param environment skal være den samme som i unleash-apitoken-preprod.yaml
  */
-const unleash = (environment: 'development' | 'production'): UnleashSettings => ({
-    token: envVar('UNLEASH_SERVER_API_TOKEN'),
+const unleash = (environment: 'mock' | 'development' | 'production'): UnleashSettings => ({
+    token: environment !== 'mock' ? envVar('UNLEASH_SERVER_API_TOKEN') : 'mock',
     environment: environment,
 });
 
@@ -129,13 +129,17 @@ const clientsLocalPreprod = (): ClientConfig => ({
     },
 });
 
-const lokaltMiljø = (clients: ClientConfig): Miljø => ({
-    buildPath: '../../dist_development',
-    clients: clients,
-    azure: lokalAzure(),
-    unleash: unleash('development'),
-    roller: devRoller,
-});
+const lokaltMiljø = (clients: ClientConfig): Miljø => {
+    const brukUnleash = envVar('BRUK_UNLEASH', false, 'false');
+    const unleashEnvironment = brukUnleash === 'true' ? 'development' : 'mock';
+    return {
+        buildPath: '../../dist_development',
+        clients: clients,
+        azure: lokalAzure(),
+        unleash: unleash(unleashEnvironment),
+        roller: devRoller,
+    };
+};
 
 const devMiljø = (): Miljø => ({
     buildPath: '../../app/build',

--- a/src/backend/toggle.ts
+++ b/src/backend/toggle.ts
@@ -1,0 +1,28 @@
+import { NextFunction, Request, Response } from 'express';
+
+import { AUTHORIZATION_HEADER, getUserIdFromToken } from './auth/token';
+import logger from './logger';
+import { miljø } from './miljø';
+
+export const attachUnleashAuthToken =
+    () => async (req: Request, res: Response, next: NextFunction) => {
+        const userId = getUserIdFromToken(req);
+
+        if (!userId) {
+            return res.status(400).json({ detail: 'userId is required' });
+        }
+
+        if (req.query.userId && req.query.userId !== userId) {
+            logger.error(`UserId på request=${req.query.userId} mens tokenUserId=${userId}`);
+            return res.status(400).json({ detail: 'Feil userId' });
+        }
+        const environment = miljø.unleash.environment;
+        if (req.query.environment && req.query.environment !== environment) {
+            logger.error(
+                `Environment er feil på request=${req.query.environment} mens environment=${environment}`
+            );
+            return res.status(400).json({ detail: 'Feil environment' });
+        }
+        req.headers[AUTHORIZATION_HEADER] = `Bearer ${miljø.unleash.token}`;
+        next();
+    };

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import FlagProvider, { IConfig, useFlag } from '@unleash/proxy-client-react';
 import {
     createBrowserRouter,
     createRoutesFromElements,
@@ -31,6 +32,9 @@ const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
 }) => {
     const { autentisert } = useApp();
 
+    const enabled = useFlag('sak.kan-opprette-revurdering');
+    console.log('sak.kan-opprette-revurdering', enabled);
+
     const router = createBrowserRouter(
         createRoutesFromElements(
             autentisert ? (
@@ -54,6 +58,12 @@ const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
     );
     return <RouterProvider router={router} />;
 };
+const config: IConfig = {
+    appName: 'ts-sak-frontend',
+    url: `${location.origin}/api/toggle`,
+    clientKey: 'settes-i-backend', // A client-side API token OR one of your proxy's designated client keys (previously known as proxy secrets)
+    refreshInterval: 120, // How often (in seconds) the client should poll the proxy for updates
+};
 
 const App: React.FC = () => {
     const [innloggetSaksbehandler, settInnloggetSaksbehandler] = useState<Saksbehandler>();
@@ -66,7 +76,15 @@ const App: React.FC = () => {
     }
     return (
         <AppProvider saksbehandler={innloggetSaksbehandler} appEnv={appEnv}>
-            <AppRoutes innloggetSaksbehandler={innloggetSaksbehandler} />
+            <FlagProvider
+                config={{
+                    ...config,
+                    context: { userId: innloggetSaksbehandler.navIdent },
+                    environment: appEnv.unleashEnv,
+                }}
+            >
+                <AppRoutes innloggetSaksbehandler={innloggetSaksbehandler} />
+            </FlagProvider>
         </AppProvider>
     );
 };

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import FlagProvider, { IConfig, useFlag } from '@unleash/proxy-client-react';
+import FlagProvider, { IConfig } from '@unleash/proxy-client-react';
 import {
     createBrowserRouter,
     createRoutesFromElements,
@@ -26,14 +26,12 @@ import Oppgavebenk from './Sider/Oppgavebenk/Oppgavebenk';
 import Personoversikt from './Sider/Personoversikt/Personoversikt';
 import { AppEnv, hentEnv } from './utils/env';
 import { hentInnloggetSaksbehandler, Saksbehandler } from './utils/saksbehandler';
+import { mockUnleashServer } from './utils/unleashMock';
 
 const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
     innloggetSaksbehandler,
 }) => {
     const { autentisert } = useApp();
-
-    const enabled = useFlag('sak.kan-opprette-revurdering');
-    console.log('sak.kan-opprette-revurdering', enabled);
 
     const router = createBrowserRouter(
         createRoutesFromElements(
@@ -82,6 +80,7 @@ const App: React.FC = () => {
                     context: { userId: innloggetSaksbehandler.navIdent },
                     environment: appEnv.unleashEnv,
                 }}
+                unleashClient={appEnv.unleashEnv === 'mock' ? mockUnleashServer : undefined}
             >
                 <AppRoutes innloggetSaksbehandler={innloggetSaksbehandler} />
             </FlagProvider>

--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -26,7 +26,7 @@ import Oppgavebenk from './Sider/Oppgavebenk/Oppgavebenk';
 import Personoversikt from './Sider/Personoversikt/Personoversikt';
 import { AppEnv, hentEnv } from './utils/env';
 import { hentInnloggetSaksbehandler, Saksbehandler } from './utils/saksbehandler';
-import { mockUnleashServer } from './utils/unleashMock';
+import { mockFlags } from './utils/unleashMock';
 
 const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
     innloggetSaksbehandler,
@@ -59,7 +59,7 @@ const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
 const config: IConfig = {
     appName: 'ts-sak-frontend',
     url: `${location.origin}/api/toggle`,
-    clientKey: 'settes-i-backend', // A client-side API token OR one of your proxy's designated client keys (previously known as proxy secrets)
+    clientKey: 'settes-i-backend',
     refreshInterval: 120, // How often (in seconds) the client should poll the proxy for updates
 };
 
@@ -79,8 +79,9 @@ const App: React.FC = () => {
                     ...config,
                     context: { userId: innloggetSaksbehandler.navIdent },
                     environment: appEnv.unleashEnv,
+                    bootstrap: appEnv.unleashEnv !== 'mock' ? undefined : mockFlags,
                 }}
-                unleashClient={appEnv.unleashEnv === 'mock' ? mockUnleashServer : undefined}
+                startClient={appEnv.unleashEnv !== 'mock'}
             >
                 <AppRoutes innloggetSaksbehandler={innloggetSaksbehandler} />
             </FlagProvider>

--- a/src/frontend/utils/env.ts
+++ b/src/frontend/utils/env.ts
@@ -2,6 +2,7 @@ import { Roller } from '../utils/roller';
 
 export interface AppEnv {
     roller: Roller;
+    unleashEnv: string;
 }
 
 export const hentEnv = (settEnv: (env: AppEnv | undefined) => void) => {

--- a/src/frontend/utils/env.ts
+++ b/src/frontend/utils/env.ts
@@ -2,7 +2,7 @@ import { Roller } from '../utils/roller';
 
 export interface AppEnv {
     roller: Roller;
-    unleashEnv: string;
+    unleashEnv: 'mock' | 'development' | 'production';
 }
 
 export const hentEnv = (settEnv: (env: AppEnv | undefined) => void) => {

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -1,0 +1,3 @@
+export enum Toggle {
+    KAN_OPPRETTE_REVURDERING = 'sak.kan-opprette-revurdering',
+}

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -1,11 +1,13 @@
 import { IToggle } from 'unleash-proxy-client';
 
+import { Toggle } from './toggles';
+
 /**
  * Feature flags er automatisk enabled, hvis man ønsker å overskreve de brukes eks
- * 'sak.kan-opprette-revurdering': false,
+ * [Toggle.KAN_OPPRETTE_REVURDERING]: false,
  */
-const featureFlags: { [name: string]: boolean } = {
-    'sak.kan-opprette-revurdering': true,
+const featureFlags: Partial<Record<Toggle, boolean>> = {
+    [Toggle.KAN_OPPRETTE_REVURDERING]: true,
 };
 
 export const mockFlags: IToggle[] = Object.entries(featureFlags).map(([name, enabled]) => ({

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -1,0 +1,20 @@
+import { UnleashClient } from 'unleash-proxy-client';
+
+/**
+ * Feature flags er automatisk enabled, hvis man ønsker å overskreve de brukes eks
+ * 'sak.kan-opprette-revurdering': false,
+ */
+const featureFlags: { [key: string]: boolean } = {
+    'sak.kan-opprette-revurdering': true,
+};
+
+export const mockUnleashServer: UnleashClient = {
+    isEnabled: (toggleName: string): boolean => featureFlags[toggleName] ?? true,
+    // @ts-ignore
+    on: () => {},
+    // @ts-ignore
+    off: () => {},
+    // @ts-ignore
+    start: () => {},
+    stop: () => {},
+};

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -1,20 +1,16 @@
-import { UnleashClient } from 'unleash-proxy-client';
+import { IToggle } from 'unleash-proxy-client';
 
 /**
  * Feature flags er automatisk enabled, hvis man ønsker å overskreve de brukes eks
  * 'sak.kan-opprette-revurdering': false,
  */
-const featureFlags: { [key: string]: boolean } = {
+const featureFlags: { [name: string]: boolean } = {
     'sak.kan-opprette-revurdering': true,
 };
 
-export const mockUnleashServer: UnleashClient = {
-    isEnabled: (toggleName: string): boolean => featureFlags[toggleName] ?? true,
-    // @ts-ignore
-    on: () => {},
-    // @ts-ignore
-    off: () => {},
-    // @ts-ignore
-    start: () => {},
-    stop: () => {},
-};
+export const mockFlags: IToggle[] = Object.entries(featureFlags).map(([name, enabled]) => ({
+    name: name,
+    enabled: enabled,
+    variant: { name: name, enabled: enabled },
+    impressionData: false,
+}));

--- a/yarn.lock
+++ b/yarn.lock
@@ -1706,6 +1706,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.2.0.tgz#756641adb587851b5ccb3e095daf27ae581c8406"
   integrity sha512-zuVdFrMJiuCDQUMCzQaD6KL28MjnqqN8XnAqiEq9PNm/hCPTSGfrXCOfwj1ow4LFb/tNymJPwsNbVePc1xFqrQ==
 
+"@unleash/proxy-client-react@^4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@unleash/proxy-client-react/-/proxy-client-react-4.2.4.tgz#0342e5b101cdf1ce2dca8c111701fe39c47d0599"
+  integrity sha512-FWzKDqE28ZmogdXgL9caqMJTWnrVEMJWly8Ofbo1xNZHsk7R9jcWgozIXCWEPto/qijfyCBoat5xjsduT09l1g==
+
 "@webassemblyjs/ast@1.12.1", "@webassemblyjs/ast@^1.12.1":
   version "1.12.1"
   resolved "https://registry.yarnpkg.com/@webassemblyjs/ast/-/ast-1.12.1.tgz#bb16a0e8b1914f979f45864c23819cc3e3f0d4bb"
@@ -5509,6 +5514,11 @@ through2@~2.0.3:
     readable-stream "~2.3.6"
     xtend "~4.0.1"
 
+tiny-emitter@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.1.0.tgz#1d1a56edfc51c43e863cbb5382a72330e3555423"
+  integrity sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==
+
 tiny-invariant@^1.0.0:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/tiny-invariant/-/tiny-invariant-1.3.3.tgz#46680b7a873a0d5d10005995eb90a70d74d60127"
@@ -5677,6 +5687,14 @@ unit-fns@^0.1.6:
   version "0.1.9"
   resolved "https://registry.yarnpkg.com/unit-fns/-/unit-fns-0.1.9.tgz#975f20a779cbd7a0ec9eeb3efde5c572534f7edb"
   integrity sha512-bxceIkc7n2icQmgQx8u3vX98ZBIcpL2YJDKIsWDFK7ZX1TTuLvtNWVNd9/oARCDHd7QQRzwc+zxabO0HSK8X0w==
+
+unleash-proxy-client@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/unleash-proxy-client/-/unleash-proxy-client-3.4.0.tgz#c9c4a8b0f18d77dc0b041eb76478c6ce74c98c1e"
+  integrity sha512-ivCzm//z+S2T3gSBSZY7HN+5GfoLXZIovMyH6lIZRe2/vCicEdXtXD6cnLTQ2LAiXGV7DpoSM1m8WZGoiLRzkw==
+  dependencies:
+    tiny-emitter "^2.1.0"
+    uuid "^9.0.1"
 
 update-browserslist-db@^1.0.13:
   version "1.0.16"


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å kunne toggle frontendfunksjonalitet med toggles. 

En forskjell mot EF er at jeg har tatt i bruk `FlagProvider`. Fra https://github.com/Unleash/proxy-client-react 
Bruker frackend for å proxya kall mot unleash direkte i stedet for å ha et endepunkt i sak-backend.
Fordelen med dette er at vi får metrics på kallene som utføres fra frontend og hvilke toggles som faktiskt er i bruk.
Den håndterer også refreshing av toggles jevnlig. Nå er den satt på 120s, men kan justeres. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21494

Koblet til
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/385