### PR TITLE
💄 Skal scrolle til ny rad og feilmelding på inngangsvilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -39,7 +39,7 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
     const kanSetteNyRadIRedigeringsmodus = radIRedigeringsmodus === undefined && erStegRedigerbart;
 
     const scrollTilFeilmelding = () => {
-        nyPeriodeRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+        feilmeldingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
     };
 
     const settNyRadIRedigeringsmodus = (id?: string, aktivitetFraRegister?: Registeraktivitet) => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -58,7 +58,7 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
 
     useEffect(() => {
         if (radIRedigeringsmodus === 'nyPeriode') {
-            nyPeriodeRef.current?.scrollIntoView({ behavior: 'instant', block: 'center' });
+            nyPeriodeRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
     }, [radIRedigeringsmodus]);
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -111,9 +111,7 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
                         </div>
                     )}
 
-                    <Feilmelding id="aktivitetRedigeringFeilmelding" ref={feilmeldingRef}>
-                        {feilmelding}
-                    </Feilmelding>
+                    <Feilmelding ref={feilmeldingRef}>{feilmelding}</Feilmelding>
 
                     {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
                         <Button

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -60,7 +60,7 @@ const Målgruppe: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = 
 
     useEffect(() => {
         if (radSomRedigeres) {
-            nyPeriodeRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            feilmeldingRef.current?.scrollIntoView({ behavior: 'smooth', block: 'center' });
         }
     }, [radSomRedigeres]);
 

--- a/src/frontend/komponenter/Feil/Feilmelding.tsx
+++ b/src/frontend/komponenter/Feil/Feilmelding.tsx
@@ -5,11 +5,10 @@ import { Alert, ErrorMessage } from '@navikt/ds-react';
 interface Props {
     children: ReactNode | undefined;
     variant?: 'inline' | 'alert';
-    id?: string;
 }
 
 export const Feilmelding = React.forwardRef<HTMLDivElement | HTMLParagraphElement, Props>(
-    ({ children, variant, id }, ref) => {
+    ({ children, variant }, ref) => {
         if (!children) {
             return null;
         }
@@ -17,18 +16,14 @@ export const Feilmelding = React.forwardRef<HTMLDivElement | HTMLParagraphElemen
         switch (variant) {
             case 'alert':
                 return (
-                    <Alert id={id} ref={ref} variant="error">
+                    <Alert ref={ref} variant="error">
                         {children}
                     </Alert>
                 );
 
             case 'inline':
             default:
-                return (
-                    <ErrorMessage id={id} ref={ref}>
-                        {children}
-                    </ErrorMessage>
-                );
+                return <ErrorMessage ref={ref}>{children}</ErrorMessage>;
         }
     }
 );

--- a/src/frontend/komponenter/Feil/Feilmelding.tsx
+++ b/src/frontend/komponenter/Feil/Feilmelding.tsx
@@ -1,22 +1,34 @@
-import { ReactNode } from 'react';
-import React from 'react';
+import React, { ReactNode } from 'react';
 
 import { Alert, ErrorMessage } from '@navikt/ds-react';
 
-export const Feilmelding: React.FC<{
+interface Props {
     children: ReactNode | undefined;
     variant?: 'inline' | 'alert';
-}> = ({ children, variant }) => {
-    if (!children) {
-        return null;
-    }
+    id?: string;
+}
 
-    switch (variant) {
-        case 'alert':
-            return <Alert variant="error">{children}</Alert>;
+export const Feilmelding = React.forwardRef<HTMLDivElement | HTMLParagraphElement, Props>(
+    ({ children, variant, id }, ref) => {
+        if (!children) {
+            return null;
+        }
 
-        case 'inline':
-        default:
-            return <ErrorMessage>{children}</ErrorMessage>;
+        switch (variant) {
+            case 'alert':
+                return (
+                    <Alert id={id} ref={ref} variant="error">
+                        {children}
+                    </Alert>
+                );
+
+            case 'inline':
+            default:
+                return (
+                    <ErrorMessage id={id} ref={ref}>
+                        {children}
+                    </ErrorMessage>
+                );
+        }
     }
-};
+);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis man har mange rader kan det være vanskelig å se feilmelding eller at det kommer en ny rad når man trykker "bruk".

Feilmelding scroll må ligge i `useEffect` fordi første gang feilmeldingen settes så er ref=null , men videre så endres ikke feilmeldingen seg så to-trykk håndteres ved at scroll også ligger i `settNyRadIRedigeringsmodus`
