### PR TITLE
✨ Filtrering brevmaler

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -15,7 +15,7 @@ import { useVedtak } from '../../../hooks/useVedtak';
 import DataViewer from '../../../komponenter/DataViewer';
 import PdfVisning from '../../../komponenter/PdfVisning';
 import { RessursStatus } from '../../../typer/ressurs';
-import { erVedtakInnvilgelse } from '../../../typer/vedtak';
+import { erVedtakInnvilgelse, typeVedtakTilSanitytype } from '../../../typer/vedtak';
 import SendTilBeslutterKnapp from '../Totrinnskontroll/SendTilBeslutterKnapp';
 
 const Container = styled.div`
@@ -42,7 +42,7 @@ const Brev: React.FC = () => {
         malStruktur,
         fil,
         settFil,
-    } = useBrev(behandling.stønadstype, 'INNVILGET', behandling);
+    } = useBrev(behandling.stønadstype, behandling);
 
     const { mellomlagretBrev } = useMellomlagrignBrev();
 
@@ -55,10 +55,10 @@ const Brev: React.FC = () => {
     }, [mellomlagretBrev, settBrevmal]);
 
     useEffect(() => {
-        if (behandlingErRedigerbar) {
-            hentBrevmaler();
+        if (behandlingErRedigerbar && vedtak.status === RessursStatus.SUKSESS) {
+            hentBrevmaler(typeVedtakTilSanitytype(vedtak.data.type));
         }
-    }, [behandlingErRedigerbar, hentBrevmaler]);
+    }, [behandlingErRedigerbar, hentBrevmaler, vedtak, vedtak.status]);
 
     useEffect(() => {
         if (behandlingErRedigerbar) {

--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -49,10 +49,15 @@ const Brev: React.FC = () => {
     const { vedtak } = useVedtak();
 
     useEffect(() => {
-        if (mellomlagretBrev.status === RessursStatus.SUKSESS) {
+        const brevmalFraMellomlagerErGyldigForResultat =
+            mellomlagretBrev.status === RessursStatus.SUKSESS &&
+            brevmaler.status === RessursStatus.SUKSESS &&
+            brevmaler.data.map((mal) => mal._id).includes(mellomlagretBrev.data.brevmal);
+
+        if (brevmalFraMellomlagerErGyldigForResultat) {
             settBrevmal(mellomlagretBrev.data.brevmal);
         }
-    }, [mellomlagretBrev, settBrevmal]);
+    }, [brevmaler, mellomlagretBrev, settBrevmal]);
 
     useEffect(() => {
         if (behandlingErRedigerbar && vedtak.status === RessursStatus.SUKSESS) {

--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -33,11 +33,16 @@ const ToKolonner = styled.div`
 
 const Brev: React.FC = () => {
     const { behandling, behandlingErRedigerbar } = useBehandling();
-    const { brevmaler, brevmal, settBrevmal, malStruktur, fil, settFil } = useBrev(
-        behandling.stønadstype,
-        'INNVILGET',
-        behandling
-    ); // TODO ikke bruk hardkodet resultat
+    const {
+        brevmaler,
+        brevmal,
+        settBrevmal,
+        hentBrevmaler,
+        hentMalStruktur,
+        malStruktur,
+        fil,
+        settFil,
+    } = useBrev(behandling.stønadstype, 'INNVILGET', behandling);
 
     const { mellomlagretBrev } = useMellomlagrignBrev();
 
@@ -48,6 +53,18 @@ const Brev: React.FC = () => {
             settBrevmal(mellomlagretBrev.data.brevmal);
         }
     }, [mellomlagretBrev, settBrevmal]);
+
+    useEffect(() => {
+        if (behandlingErRedigerbar) {
+            hentBrevmaler();
+        }
+    }, [behandlingErRedigerbar, hentBrevmaler]);
+
+    useEffect(() => {
+        if (behandlingErRedigerbar) {
+            hentMalStruktur();
+        }
+    }, [behandlingErRedigerbar, hentMalStruktur]);
 
     return (
         <Container>

--- a/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
@@ -2,8 +2,6 @@ import groq from 'groq';
 
 export const hentMalerQuery = groq`*[ytelse == $ytelse && resultat == $resultat]`;
 
-export const hentAlleMalerQuery = groq`*[ytelse == $ytelse]`;
-
 export const malQuery = (id: string, målform: 'bokmål' = 'bokmål') => groq`*[_id == "${id}"][0]{
 ...,
     "brevtittel": brevtittel.${målform === 'bokmål' ? 'tittelNB' : ''},

--- a/src/frontend/Sider/Behandling/Brev/useBrev.ts
+++ b/src/frontend/Sider/Behandling/Brev/useBrev.ts
@@ -1,7 +1,7 @@
 import { useCallback, useEffect, useState } from 'react';
 
 import { Brevmottakere } from './Brevmottakere/brevmottakereTyper';
-import { hentAlleMalerQuery, malQuery } from './Sanity/queries';
+import { hentMalerQuery, malQuery } from './Sanity/queries';
 import { useSanityClient } from './Sanity/useSanityClient';
 import { Brevmal, MalStruktur } from './typer';
 import { useApp } from '../../../context/AppContext';
@@ -14,7 +14,7 @@ import {
     Ressurs,
 } from '../../../typer/ressurs';
 
-const useBrev = (ytelse: Stønadstype, resultat: string, behandling?: Behandling) => {
+const useBrev = (ytelse: Stønadstype, behandling?: Behandling) => {
     const sanityClient = useSanityClient();
     const { request } = useApp();
 
@@ -24,10 +24,10 @@ const useBrev = (ytelse: Stønadstype, resultat: string, behandling?: Behandling
     const [brevmottakere, settBrevmottakere] = useState<Ressurs<Brevmottakere>>(byggTomRessurs());
     const [fil, settFil] = useState<Ressurs<string>>(byggTomRessurs());
 
-    const hentBrevmaler = useCallback(() => {
+    const hentBrevmaler = useCallback((resultat: string) => {
         sanityClient
-            // TODO: bruk hentMalerQuery og send med resultat
-            .fetch<Brevmal[]>(hentAlleMalerQuery, {
+            .fetch<Brevmal[]>(hentMalerQuery, {
+                resultat: resultat,
                 ytelse: ytelse,
             })
             .then((data) => {

--- a/src/frontend/Sider/Behandling/Brev/useBrev.ts
+++ b/src/frontend/Sider/Behandling/Brev/useBrev.ts
@@ -56,11 +56,11 @@ const useBrev = (ytelse: Stønadstype, resultat: string, behandling?: Behandling
         }
     }, [request, behandling]);
 
-    useEffect(hentBrevmaler, [hentBrevmaler]);
-    useEffect(hentMalStruktur, [hentMalStruktur]);
     useEffect(hentBrevmottakere, [hentBrevmottakere]);
 
     return {
+        hentBrevmaler,
+        hentMalStruktur,
         brevmaler,
         brevmal,
         settBrevmal,

--- a/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
+++ b/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
@@ -32,10 +32,17 @@ const FrittståendeBrev: React.FC<{ valgtStønadstype: Stønadstype; fagsakId: s
 }) => {
     const { request, settToast } = useApp();
 
-    const { brevmaler, brevmal, settBrevmal, malStruktur, settMalStruktur, fil, settFil } = useBrev(
-        valgtStønadstype,
-        'FRITTSTAENDE'
-    );
+    const {
+        brevmaler,
+        brevmal,
+        settBrevmal,
+        malStruktur,
+        settMalStruktur,
+        fil,
+        settFil,
+        hentMalStruktur,
+        hentBrevmaler,
+    } = useBrev(valgtStønadstype);
 
     const { mellomlagretBrev, settMellomlagretBrev } = useMellomlagringFrittståendeBrev(fagsakId);
 
@@ -44,6 +51,16 @@ const FrittståendeBrev: React.FC<{ valgtStønadstype: Stønadstype; fagsakId: s
             settBrevmal(mellomlagretBrev.data.brevmal);
         }
     }, [mellomlagretBrev, settBrevmal]);
+
+    useEffect(() => {
+        hentBrevmaler('FRITTSTAENDE');
+    }, [hentBrevmaler]);
+
+    useEffect(() => {
+        if (brevmal) {
+            hentMalStruktur();
+        }
+    }, [brevmal, hentMalStruktur]);
 
     const [feilmelding, settFeilmelding] = useState<string>();
 

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -10,6 +10,18 @@ export const typeVedtakTilTekst: Record<TypeVedtak, string> = {
     AVSLAG: 'Avslag',
 };
 
+/**
+ * Mapper fra type vedtak til typen malen er definert som i Sanity.
+ */
+export const typeVedtakTilSanitytype = (type: TypeVedtak): string => {
+    switch (type) {
+        case TypeVedtak.INNVILGELSE:
+            return 'INNVILGET';
+        default:
+            return type;
+    }
+};
+
 export type VedtakBarnetilsyn = InnvilgelseBarnetilsyn | AvslagBarnetilsyn;
 
 export const erVedtakInnvilgelse = (vedtak: VedtakBarnetilsyn): vedtak is InnvilgelseBarnetilsyn =>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Så saksbehandler kun skal kunne velge relevante brevmaler

#### Innvilget
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/0904809b-08a3-4747-a1f6-bc58e900486b)


#### Avslag
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/f7834b6b-1596-419b-8c27-62a7802f60a3)

#### Frittstående
![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/4fe9d861-8def-4335-bf23-a9146bf62d7e)

