### PR TITLE
Saksbehandler skal ikke se Godkjenne vedtak-oppgaver til behandlinger…

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/Oppgaveknapp.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgaveknapp.tsx
@@ -8,6 +8,7 @@ import { Button, Dropdown } from '@navikt/ds-react';
 
 import {
     lagJournalføringUrl,
+    saksbehandlerHarSendtTilGodkjenneVedtak,
     oppgaveErJournalføring,
     oppgaveErSaksbehandling,
 } from './oppgaveutils';
@@ -80,7 +81,9 @@ const Oppgaveknapp: React.FC<Props> = ({ oppgave }) => {
             .then(gåTilOppgaveUtførelse)
             .catch((e) => settFeilmelding(e.message));
 
-    if (oppgaveTilordnetInnloggetSaksbehandler) {
+    if (saksbehandlerHarSendtTilGodkjenneVedtak(oppgave, saksbehandler)) {
+        return null;
+    } else if (oppgaveTilordnetInnloggetSaksbehandler) {
         return (
             <Container>
                 {skalViseFortsettKnapp(oppgave) ? (

--- a/src/frontend/Sider/Oppgavebenk/oppgaveutils.ts
+++ b/src/frontend/Sider/Oppgavebenk/oppgaveutils.ts
@@ -1,5 +1,6 @@
 import { Oppgave } from './typer/oppgave';
 import { Oppgavetype } from './typer/oppgavetema';
+import { Saksbehandler } from '../../utils/saksbehandler';
 
 export const JOURNALPOST_QUERY_STRING = 'journalpostId';
 export const OPPGAVEID_QUERY_STRING = 'oppgaveId';
@@ -15,6 +16,13 @@ export const oppgaveErSaksbehandling = (oppgave: Oppgave): boolean => {
         oppgave.behandlingId
     );
 };
+
+export const saksbehandlerHarSendtTilGodkjenneVedtak = (
+    oppgave: Oppgave,
+    saksbehandler: Saksbehandler
+): boolean =>
+    oppgave.oppgavetype === 'GOD_VED' &&
+    oppgave.sendtTilTotrinnskontrollAv === saksbehandler.navIdent;
 
 export const oppgaveErJournalføring = (oppgave: Oppgave) => oppgave.oppgavetype === 'JFR';
 

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -70,6 +70,7 @@ export interface Oppgave {
      */
     navn?: string;
     behandlingId?: string;
+    sendtTilTotrinnskontrollAv?: string;
 }
 
 export interface IOppgaveIdent {


### PR DESCRIPTION
… som den selv har sendt til beslutter

### Hvorfor er denne endringen nødvendig? ✨
Dette for å unngå at man går inn på behandlinger som man likevel ikke kan beslutte

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21460

Koblet til
* https://github.com/navikt/tilleggsstonader-sak/pull/352

Det kommer en melding i fag-kanalen om spm om dette er greit (har tidligere snakket med M)

<img width="1251" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/937168/d72783a9-da79-4966-b58b-049a5490fb8a">
