### PR TITLE
✨ Skal kunne filtrere på teamer i dokumentoversikten.

### DIFF
--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -1,44 +1,74 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Heading } from '@navikt/ds-react';
+import styled from 'styled-components';
+
+import { UNSAFE_Combobox } from '@navikt/ds-react';
 
 import { DokumentTabell } from './DokumentTabell';
 import { useApp } from '../../../context/AppContext';
 import DataViewer from '../../../komponenter/DataViewer';
-import { DokumentInfo, Tema } from '../../../typer/dokument';
-import { byggTomRessurs, Ressurs } from '../../../typer/ressurs';
+import { Arkivtema, arkivtemaerTilTekst, relevanteArkivtemaer } from '../../../typer/arkivtema';
+import { DokumentInfo } from '../../../typer/dokument';
+import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
 
 type VedleggRequest = {
-    tema?: Tema[]; // Arkiv
+    tema: Arkivtema[];
     journalposttype?: string;
     journalstatus?: string;
 };
+
+const ComboBox = styled(UNSAFE_Combobox)`
+    width: 35rem;
+`;
 
 const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     const { request } = useApp();
 
     const [dokumenter, settDokumenter] = useState<Ressurs<DokumentInfo[]>>(byggTomRessurs());
 
+    const [vedleggRequest, settVedleggRequest] = useState<VedleggRequest>({
+        tema: [Arkivtema.TSO, Arkivtema.TSR],
+    });
+
     const hentDokumenter = useCallback(
         (fagsakPersonId: string) => {
+            settDokumenter(byggHenterRessurs());
             request<DokumentInfo[], VedleggRequest>(
                 `/api/sak/vedlegg/fagsak-person/${fagsakPersonId}`,
                 'POST',
-                { tema: [Tema.TSO, Tema.TSR] }
+                {
+                    ...vedleggRequest,
+                    tema: vedleggRequest.tema,
+                }
             ).then(settDokumenter);
         },
-        [request]
+        [request, vedleggRequest]
     );
 
     useEffect(() => {
         hentDokumenter(fagsakPersonId);
     }, [fagsakPersonId, hentDokumenter]);
 
+    const arkivtemaTilOption = (t: Arkivtema) => ({
+        value: t,
+        label: arkivtemaerTilTekst[t],
+    });
+    const onToggleSelected = (option: string, isSelected: boolean) =>
+        settVedleggRequest((prevState) => ({
+            ...prevState,
+            tema: isSelected
+                ? [...(prevState.tema ?? []), option as Arkivtema]
+                : (prevState.tema ?? []).filter((t) => t !== option),
+        }));
     return (
         <>
-            <Heading size="medium" level="1">
-                Dokumentoversikt
-            </Heading>
+            <ComboBox
+                label={'Filtrer tema(er)'}
+                options={relevanteArkivtemaer.map(arkivtemaTilOption)}
+                isMultiSelect
+                onToggleSelected={onToggleSelected}
+                selectedOptions={vedleggRequest.tema?.map(arkivtemaTilOption) ?? []}
+            />
             <DataViewer response={{ dokumenter }}>
                 {({ dokumenter }) => <DokumentTabell dokumenter={dokumenter} />}
             </DataViewer>

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { UNSAFE_Combobox } from '@navikt/ds-react';
@@ -15,6 +16,7 @@ import {
     byggTomRessurs,
     Ressurs,
 } from '../../../typer/ressurs';
+import { Toggle } from '../../../utils/toggles';
 
 type VedleggRequest = {
     tema: Arkivtema[];
@@ -70,15 +72,20 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                 ? [...(prevState.tema ?? []), option as Arkivtema]
                 : (prevState.tema ?? []).filter((t) => t !== option),
         }));
+
+    const visFiltrering = useFlag(Toggle.FILTRERING_DOKUMENTOVERSIKT);
+
     return (
         <>
-            <ComboBox
-                label={'Filtrer tema(er)'}
-                options={relevanteArkivtemaer.map(arkivtemaTilOption)}
-                isMultiSelect
-                onToggleSelected={onToggleSelected}
-                selectedOptions={vedleggRequest.tema?.map(arkivtemaTilOption) ?? []}
-            />
+            {visFiltrering && (
+                <ComboBox
+                    label={'Filtrer tema(er)'}
+                    options={relevanteArkivtemaer.map(arkivtemaTilOption)}
+                    isMultiSelect
+                    onToggleSelected={onToggleSelected}
+                    selectedOptions={vedleggRequest.tema?.map(arkivtemaTilOption) ?? []}
+                />
+            )}
             <DataViewer response={{ dokumenter }}>
                 {({ dokumenter }) => <DokumentTabell dokumenter={dokumenter} />}
             </DataViewer>

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -9,7 +9,12 @@ import { useApp } from '../../../context/AppContext';
 import DataViewer from '../../../komponenter/DataViewer';
 import { Arkivtema, arkivtemaerTilTekst, relevanteArkivtemaer } from '../../../typer/arkivtema';
 import { DokumentInfo } from '../../../typer/dokument';
-import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
+import {
+    byggHenterRessurs,
+    byggRessursSuksess,
+    byggTomRessurs,
+    Ressurs,
+} from '../../../typer/ressurs';
 
 type VedleggRequest = {
     tema: Arkivtema[];
@@ -32,6 +37,11 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
 
     const hentDokumenter = useCallback(
         (fagsakPersonId: string) => {
+            if (vedleggRequest.tema.length === 0) {
+                settDokumenter(byggRessursSuksess([]));
+                return;
+            }
+
             settDokumenter(byggHenterRessurs());
             request<DokumentInfo[], VedleggRequest>(
                 `/api/sak/vedlegg/fagsak-person/${fagsakPersonId}`,

--- a/src/frontend/typer/arkivtema.ts
+++ b/src/frontend/typer/arkivtema.ts
@@ -128,5 +128,16 @@ export const arkivtemaerTilTekst: Record<Arkivtema, string> = {
     YRK: 'Yrkesskade',
 };
 
+export const relevanteArkivtemaer: Arkivtema[] = [
+    Arkivtema.TSO,
+    Arkivtema.TSR,
+    Arkivtema.ENF,
+    Arkivtema.AAP,
+    Arkivtema.EYO,
+    Arkivtema.OPP,
+    Arkivtema.UFO,
+    Arkivtema.YRK,
+];
+
 export const utledArkivtema = (tema: Arkivtema | undefined) =>
     tema ? arkivtemaerTilTekst[tema] : 'Tema ikke satt';

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -1,3 +1,4 @@
 export enum Toggle {
     KAN_OPPRETTE_REVURDERING = 'sak.kan-opprette-revurdering',
+    FILTRERING_DOKUMENTOVERSIKT = `sak.frontend.filtrering-dokumentoversikt`,
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Saksbehandler ønsker å kunne se alle relevante dokumentposter. TSO og TSR skal være default. Ingen valgt henter foreløpig alle temaer, men det kan evt endres senere.

Har også fjernet oversikriften "Dokumentoversikt" etter ønske fra Marie.

<img width="1698" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/9bdf009b-b0f4-4d92-8c60-bb10b0cb24d6">
<img width="733" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/21220467/4fe813d7-474c-498a-a9fa-3279f5aa6bae">

