### PR TITLE
LocalStorage av OppgaveRequest skal nullstilles ved ny dag

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
+++ b/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
@@ -13,7 +13,7 @@ export const oppgaveRequestKey = (innloggetIdent: string): string => {
     return oppgaveRequestKeyPrefix + innloggetIdent;
 };
 
-export const lagreTilLocalStorage = (key: string, request: OppgaveRequest): void => {
+export const lagreTilLocalStorage = (key: string, request: Partial<OppgaveRequest>): void => {
     try {
         localStorage.setItem(key, JSON.stringify({ ...request, _datoLagret: dagensDato() }));
     } catch {
@@ -23,7 +23,7 @@ export const lagreTilLocalStorage = (key: string, request: OppgaveRequest): void
 
 export const hentFraLocalStorage = (
     key: string,
-    fallbackVerdi: OppgaveRequest
+    fallbackVerdi: Partial<OppgaveRequest>
 ): Partial<OppgaveRequest> => {
     try {
         const request = localStorage.getItem(key);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig at filter er nullstilte ved ny dag sån at det ikke henger igjen fra forrige dag.
Det er egentlige ønskelig at de nullstilles ved innlogging, jeg er usikker på om det virkelig er ønskelig og tror dette vil løste det største behovet. Er også usikker på hvordan det skulle blitt løst.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21261

Har også endret signaturen på metodene til å kun være koblet til OppgaveRequest nå når det finnes et felt for timestamp som kanskje ikke gjelder andre metoder som skal lagre til localStorage. Samtidig er også denne utilen nede blant oppgave-filene. 

Kan testes med å endre dato på feltet `_datoLagret` i local storage. 