### PR TITLE
Lagt til eslint plugin react og validering av jsx-key

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -14,7 +14,7 @@
         "ecmaVersion": 2020,
         "sourceType": "module"
     },
-    "plugins": ["@typescript-eslint", "prettier", "react-hooks", "import", "unused-imports"],
+    "plugins": ["@typescript-eslint", "prettier", "react-hooks", "react","import", "unused-imports"],
     "rules": {
         "import/extensions": [
             "off",
@@ -38,6 +38,10 @@
         "jsx-a11y/click-events-have-key-events": "off",
         "react-hooks/rules-of-hooks": "error",
         "react-hooks/exhaustive-deps": "warn",
+        "react/jsx-key": ["error", {
+            "checkFragmentShorthand": true,
+            "checkKeyMustBeforeSpread": true
+        }],
         "no-console": "warn",
         "import/export": "warn",
         "import/order": [

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "build:dev": "cd src/backend && yarn build",
     "start:dev": "cd src/backend && yarn start:dev",
     "start:dev-preprod": "cd src/backend && yarn start:dev-preprod",
-    "prepare": "husky"
+    "prepare": "husky",
+    "lint-all": "eslint \"src/frontend/**/*.{js,jsx,ts,tsx,json,css}\" --ignore-pattern src/frontend/Sider/Klage/"
   },
   "lint-staged": {
     "src/**/*.{js,jsx,ts,tsx,json,css} !(src/frontend/Sider/Klage/**/*)": [

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarn.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarn.tsx
@@ -27,13 +27,13 @@ const PassBarn: React.FC<Props> = ({ vilkårsregler, vilkårsvurdering }) => {
 
     return vilkårsett.map((vilkår) => {
         if (!vilkår.barnId) {
-            return <div>Vilkår er ikke knyttet til et barn</div>;
+            return <div key={vilkår.id}>Vilkår er ikke knyttet til et barn</div>;
         }
 
         const grunnlagBarn = finnBarnIGrunnlag(vilkår.barnId);
 
         if (!grunnlagBarn) {
-            return <div>Fant ikke grunnlag for barn</div>;
+            return <div key={vilkår.id}>Fant ikke grunnlag for barn</div>;
         }
 
         const barnetsNavn = grunnlagBarn.registergrunnlag.navn;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VarselBarnUnder2år.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VarselBarnUnder2år.tsx
@@ -19,8 +19,8 @@ export const VarselBarnUnder2År = (props: { vilkårsvurderteBarn: BarnOppsummer
             <Heading size={'xsmall'} level="3">
                 Mulig kontantstøtte. Søker har barn under 2 år.
             </Heading>
-            Sjekk om det utbetales kontantstøtte for barnet. Meld fra til utviklingsteamet hvis det er
-            tilfelle.
+            Sjekk om det utbetales kontantstøtte for barnet. Meld fra til utviklingsteamet hvis det
+            er tilfelle.
         </Alert>
     );
 };

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgavetema.ts
@@ -50,7 +50,7 @@ export const oppgaveTypeTilVisningstekstSomTarHensynTilKlage = (
     oppgaveBehandlingstype?: OppgaveBehandlingstype
 ): string => {
     if (oppgavetype === 'BEH_SAK' && oppgaveBehandlingstype === OppgaveBehandlingstype.Klage) {
-          return 'Behandle sak (klage)';
+        return 'Behandle sak (klage)';
     }
     return oppgaveTypeTilTekst[oppgavetype];
 };

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
@@ -20,9 +20,9 @@ import {
     KlagebehandlingStatus,
     KlageÅrsak,
 } from '../../../typer/klage';
+import { sorterBehandlinger } from '../../../utils/behandlingutil';
 import { formaterIsoDatoTid, formaterNullableIsoDatoTid } from '../../../utils/dato';
 import { formaterEnumVerdi } from '../../../utils/tekstformatering';
-import { sorterBehandlinger } from '../../../utils/behandlingutil';
 
 const TabellData: PartialRecord<keyof Behandling | 'vedtaksdato', string> = {
     opprettet: 'Behandling opprettetdato',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Føler det skjer relativt ofte at vi får feil i loggene om en en eller annen `list.map(item => <div )` som mangler key.

Så tenker det hadde vært fint å unngå den med eslint. 
Kjørte også lint på alle filer som fikset noe tomme tegn. 