### PR TITLE
✨ Skal slette vilkårperiode permanent dersom den ble laget i denne behandlingen

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
@@ -10,14 +10,19 @@ import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../typer/ressurs';
 import { formaterIsoDato } from '../../../../utils/dato';
 import { Aktivitet } from '../typer/aktivitet';
-import { Målgruppe, MålgruppeType } from '../typer/målgruppe';
+import { Målgruppe } from '../typer/målgruppe';
 import {
+    KildeVilkårsperiode,
     LagreVilkårperiodeResponse,
     SlettVilkårperiode,
     StønadsperiodeStatus,
 } from '../typer/vilkårperiode';
+import { harIkkeVerdi } from '../../../../utils/utils';
+import { erMålgruppe } from '../Målgruppe/utils';
 
 type Response = LagreVilkårperiodeResponse<Aktivitet | Målgruppe>;
+type SlettPermanentResponse = LagreVilkårperiodeResponse<null>;
+
 const SlettVilkårperiodeModal: React.FC<{
     visModal: boolean;
     settVisModal: React.Dispatch<SetStateAction<boolean>>;
@@ -26,7 +31,12 @@ const SlettVilkårperiodeModal: React.FC<{
 }> = ({ vilkårperiode, visModal, settVisModal, avbrytRedigering }) => {
     const { request } = useApp();
     const { behandling } = useBehandling();
-    const { oppdaterAktivitet, oppdaterMålgruppe, settStønadsperiodeFeil } = useInngangsvilkår();
+    const { oppdaterAktivitet, oppdaterMålgruppe, settStønadsperiodeFeil, slettVilkårperiode } =
+        useInngangsvilkår();
+
+    const kanSlettePeriodePermanent =
+        vilkårperiode.kilde !== KildeVilkårsperiode.SYSTEM &&
+        harIkkeVerdi(vilkårperiode.forrigeVilkårperiodeId);
 
     const [feil, settFeil] = useState('');
     const [laster, settLaster] = useState(false);
@@ -34,37 +44,64 @@ const SlettVilkårperiodeModal: React.FC<{
 
     const slettVilkårsperiode = () => {
         if (laster) return;
-        if (!slettBegrunnelse) {
+
+        if (!kanSlettePeriodePermanent && !slettBegrunnelse) {
             settFeil('Begrunnelse for sletting er påkrevd');
             return;
         }
         settLaster(true);
         settFeil('');
 
+        const response = kanSlettePeriodePermanent
+            ? slettNyVilkårperiode()
+            : slettVilkårperiodeFraTidligereBehandling();
+
+        response.finally(() => settLaster(false));
+    };
+
+    const slettVilkårperiodeFraTidligereBehandling = () =>
         request<Response, SlettVilkårperiode>(
             `/api/sak/vilkarperiode/${vilkårperiode.id}`,
             'DELETE',
             { behandlingId: behandling.id, kommentar: slettBegrunnelse }
-        )
-            .then((res: RessursSuksess<Response> | RessursFeilet) => {
-                if (res.status === RessursStatus.SUKSESS) {
-                    if (res.data.stønadsperiodeStatus === StønadsperiodeStatus.Ok) {
-                        settStønadsperiodeFeil(undefined);
-                    } else {
-                        settStønadsperiodeFeil(res.data.stønadsperiodeFeil);
-                    }
-                    if (vilkårperiode.type in MålgruppeType) {
-                        oppdaterMålgruppe(res.data.periode as Målgruppe);
-                    } else {
-                        oppdaterAktivitet(res.data.periode as Aktivitet);
-                    }
-                    settVisModal(false);
-                    avbrytRedigering();
+        ).then((res: RessursSuksess<Response> | RessursFeilet) => {
+            if (res.status === RessursStatus.SUKSESS) {
+                oppdaterStønadsperiodeFeil(res.data);
+
+                if (erMålgruppe(res.data.periode)) {
+                    oppdaterMålgruppe(res.data.periode);
                 } else {
-                    settFeil(`Feil ved sletting av vilkårperiode: ${res.frontendFeilmelding}`);
+                    oppdaterAktivitet(res.data.periode);
                 }
-            })
-            .finally(() => settLaster(false));
+                settVisModal(false);
+                avbrytRedigering();
+            } else {
+                settFeil(`Feil ved sletting av vilkårperiode: ${res.frontendFeilmelding}`);
+            }
+        });
+
+    const slettNyVilkårperiode = () =>
+        request<SlettPermanentResponse, null>(
+            `/api/sak/vilkarperiode/${vilkårperiode.id}/permanent`,
+            'DELETE'
+        ).then((res: RessursSuksess<SlettPermanentResponse> | RessursFeilet) => {
+            if (res.status === RessursStatus.SUKSESS) {
+                oppdaterStønadsperiodeFeil(res.data);
+                slettVilkårperiode(vilkårperiode.type, vilkårperiode.id);
+
+                settVisModal(false);
+                avbrytRedigering();
+            } else {
+                settFeil(`Feil ved sletting av vilkårperiode: ${res.frontendFeilmelding}`);
+            }
+        });
+
+    const oppdaterStønadsperiodeFeil = (response: Response | SlettPermanentResponse) => {
+        if (response.stønadsperiodeStatus === StønadsperiodeStatus.Ok) {
+            settStønadsperiodeFeil(undefined);
+        } else {
+            settStønadsperiodeFeil(response.stønadsperiodeFeil);
+        }
     };
 
     const lukkModal = () => {
@@ -78,7 +115,11 @@ const SlettVilkårperiodeModal: React.FC<{
         <ModalWrapper
             visModal={visModal}
             onClose={lukkModal}
-            tittel={'Slett periode'}
+            tittel={
+                kanSlettePeriodePermanent
+                    ? 'Er du sikker på at du vil slette perioden?'
+                    : 'Slett periode'
+            }
             aksjonsknapper={{
                 hovedKnapp: {
                     onClick: slettVilkårsperiode,
@@ -90,37 +131,43 @@ const SlettVilkårperiodeModal: React.FC<{
                 },
             }}
         >
-            <VStack gap="4">
-                <Table>
-                    <Table.Header>
-                        <Table.Row shadeOnHover={false}>
-                            <Table.HeaderCell style={{ width: '20px' }} />
-                            <Table.HeaderCell>Ytelse/situasjon</Table.HeaderCell>
-                            <Table.HeaderCell>Fra</Table.HeaderCell>
-                            <Table.HeaderCell>Til</Table.HeaderCell>
-                            <Table.HeaderCell>Kilde</Table.HeaderCell>
-                            <Table.HeaderCell />
-                        </Table.Row>
-                    </Table.Header>
-                    <Table.Body>
-                        <Table.Row shadeOnHover={false}>
-                            <Table.DataCell width="max-content">
-                                <VilkårsresultatIkon vilkårsresultat={vilkårperiode.resultat} />
-                            </Table.DataCell>
-                            <Table.DataCell>{vilkårperiode.type}</Table.DataCell>
-                            <Table.DataCell>{formaterIsoDato(vilkårperiode.fom)}</Table.DataCell>
-                            <Table.DataCell>{formaterIsoDato(vilkårperiode.tom)}</Table.DataCell>
-                            <Table.DataCell>{vilkårperiode.kilde}</Table.DataCell>
-                        </Table.Row>
-                    </Table.Body>
-                </Table>
-                <Textarea
-                    label={'Begrunnelse for sletting (obligatorisk)'}
-                    value={slettBegrunnelse}
-                    onChange={(e) => settSlettBegrunnelse(e.target.value)}
-                    error={feil}
-                />
-            </VStack>
+            {!kanSlettePeriodePermanent && (
+                <VStack gap="4">
+                    <Table>
+                        <Table.Header>
+                            <Table.Row shadeOnHover={false}>
+                                <Table.HeaderCell style={{ width: '20px' }} />
+                                <Table.HeaderCell>Ytelse/situasjon</Table.HeaderCell>
+                                <Table.HeaderCell>Fra</Table.HeaderCell>
+                                <Table.HeaderCell>Til</Table.HeaderCell>
+                                <Table.HeaderCell>Kilde</Table.HeaderCell>
+                                <Table.HeaderCell />
+                            </Table.Row>
+                        </Table.Header>
+                        <Table.Body>
+                            <Table.Row shadeOnHover={false}>
+                                <Table.DataCell width="max-content">
+                                    <VilkårsresultatIkon vilkårsresultat={vilkårperiode.resultat} />
+                                </Table.DataCell>
+                                <Table.DataCell>{vilkårperiode.type}</Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterIsoDato(vilkårperiode.fom)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterIsoDato(vilkårperiode.tom)}
+                                </Table.DataCell>
+                                <Table.DataCell>{vilkårperiode.kilde}</Table.DataCell>
+                            </Table.Row>
+                        </Table.Body>
+                    </Table>
+                    <Textarea
+                        label={'Begrunnelse for sletting (obligatorisk)'}
+                        value={slettBegrunnelse}
+                        onChange={(e) => settSlettBegrunnelse(e.target.value)}
+                        error={feil}
+                    />
+                </VStack>
+            )}
         </ModalWrapper>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
@@ -123,7 +123,7 @@ const SlettVilkårperiodeModal: React.FC<{
             aksjonsknapper={{
                 hovedKnapp: {
                     onClick: slettVilkårsperiode,
-                    tekst: 'Slett og lagre begrunnelse',
+                    tekst: kanSlettePeriodePermanent ? 'Slett' : 'Slett og lagre begrunnelse',
                 },
                 lukkKnapp: {
                     onClick: lukkModal,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode.ts
@@ -39,7 +39,7 @@ interface HentetInformasjon {
     tom: string;
 }
 
-export interface LagreVilkårperiodeResponse<T extends Aktivitet | Målgruppe> {
+export interface LagreVilkårperiodeResponse<T extends Aktivitet | Målgruppe | null> {
     periode: T;
     stønadsperiodeStatus: StønadsperiodeStatus;
     stønadsperiodeFeil?: string;
@@ -57,6 +57,7 @@ export interface VilkårPeriode extends Periode {
     kilde: KildeVilkårsperiode;
     slettetKommentar?: string;
     sistEndret: string;
+    forrigeVilkårperiodeId?: string;
 }
 
 export enum VilkårPeriodeResultat {

--- a/src/frontend/context/InngangsvilkårContext.ts
+++ b/src/frontend/context/InngangsvilkårContext.ts
@@ -2,8 +2,8 @@ import { useEffect, useState } from 'react';
 
 import constate from 'constate';
 
-import { Aktivitet } from '../Sider/Behandling/Inngangsvilkår/typer/aktivitet';
-import { Målgruppe } from '../Sider/Behandling/Inngangsvilkår/typer/målgruppe';
+import { Aktivitet, AktivitetType } from '../Sider/Behandling/Inngangsvilkår/typer/aktivitet';
+import { Målgruppe, MålgruppeType } from '../Sider/Behandling/Inngangsvilkår/typer/målgruppe';
 import { Stønadsperiode } from '../Sider/Behandling/Inngangsvilkår/typer/stønadsperiode';
 import { Vilkårperioder } from '../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode';
 
@@ -14,6 +14,7 @@ interface UseInngangsvilkår {
     aktiviteter: Aktivitet[];
     leggTilAktivitet: (nyPeriode: Aktivitet) => void;
     oppdaterAktivitet: (oppdatertPeriode: Aktivitet) => void;
+    slettVilkårperiode: (type: MålgruppeType | AktivitetType, id: string) => void;
     stønadsperioder: Stønadsperiode[];
     stønadsperiodeFeil: string | undefined;
     settStønadsperiodeFeil: (feilmelding: string | undefined) => void;
@@ -49,6 +50,16 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             );
         };
 
+        const slettVilkårperiode = (type: MålgruppeType | AktivitetType, id: string) => {
+            if (type in MålgruppeType) {
+                settMålgrupper((prevState) => prevState.filter((målgruppe) => målgruppe.id !== id));
+            } else {
+                settAktiviteter((prevState) =>
+                    prevState.filter((aktivitet) => aktivitet.id !== id)
+                );
+            }
+        };
+
         const leggTilAktivitet = (nyPeriode: Aktivitet) => {
             settAktiviteter((prevState) => [...prevState, nyPeriode]);
         };
@@ -65,6 +76,7 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             målgrupper,
             leggTilMålgruppe,
             oppdaterMålgruppe,
+            slettVilkårperiode,
             aktiviteter,
             leggTilAktivitet,
             oppdaterAktivitet,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Til nå har vi kun markert slettede vilkårperioder, men nå ønsker vi at de skal bli borte. 
Tilpasset for å ta i bruk endepunktet for permanent sletting i [PR 366 i backend](https://github.com/navikt/tilleggsstonader-sak/pull/366).

Landet på at det er best å starte med å fortsatt ha modal etter [diskusjon på slack](https://nav-it.slack.com/archives/C05TU86SU8Y/p1719828817727129). 

### Bilder 🎨 
**Sletting av periode lagt til i denne behandlingen:** 
Før (nederste lagt til nå): 
<img width="1281" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/590e8e77-11f9-4bad-8ca7-c8f6c9ba8da4">

Under sletting: 
<img width="497" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/e8ea6352-4b08-4eb8-9c0a-31f615110d7c">

Etter sletting vises ikke perioden at all: 
<img width="1284" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/0ca0d08f-0d01-40ae-8c42-4d28e0c33cbb">


**Sletting av gjenbrukt periode:** 
<img width="534" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/2e1ef469-6f28-427c-910e-efa0c5e55220">

<img width="1055" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/392cc54e-adec-4ad7-84f8-1bf247285483">

