### PR TITLE
🚧 Oppgavebenk splitte filter og oppgaver

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -9,6 +9,7 @@ import Oppgavetabell from './Oppgavetabell';
 import { OpprettDummyBehandling } from './OpprettDummyBehandling';
 import { useApp } from '../../context/AppContext';
 import { OppgaveProvider, useOppgave } from '../../context/OppgaveContext';
+import { OppgaveFilterProvider, useOppgaveFilter } from '../../context/OppgaveFilterContext';
 import DataViewer from '../../komponenter/DataViewer';
 import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
 import SystemetLaster from '../../komponenter/SystemetLaster/SystemetLaster';
@@ -24,7 +25,8 @@ const AlertContainer = styled.div`
 `;
 
 const OppgavebenkContainer = () => {
-    const { feilmelding, oppgaveRessurs, lasterOppgaveRequestFraLocaleStorage } = useOppgave();
+    const { feilmelding, oppgaveRessurs } = useOppgave();
+    const { lasterOppgaveRequestFraLocaleStorage } = useOppgaveFilter();
 
     if (lasterOppgaveRequestFraLocaleStorage) {
         return <SystemetLaster />;
@@ -63,7 +65,9 @@ const Oppgavebenk: React.FC = () => {
         <div>
             {!erProd() && <OpprettDummyBehandling />}
             <OppgaveProvider>
-                <OppgavebenkContainer />
+                <OppgaveFilterProvider>
+                    <OppgavebenkContainer />
+                </OppgaveFilterProvider>
             </OppgaveProvider>
         </div>
     );

--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -26,7 +26,8 @@ const AlertContainer = styled.div`
 
 const OppgavebenkContainer = () => {
     const { feilmelding, oppgaveRessurs } = useOppgave();
-    const { lasterOppgaveRequestFraLocaleStorage } = useOppgaveFilter();
+    const { lasterOppgaveRequestFraLocaleStorage, oppgaveRequest, settOppgaveRequest } =
+        useOppgaveFilter();
 
     if (lasterOppgaveRequestFraLocaleStorage) {
         return <SystemetLaster />;
@@ -36,7 +37,13 @@ const OppgavebenkContainer = () => {
         <Container>
             <Oppgavefiltrering />
             <DataViewer response={{ oppgaver: oppgaveRessurs }}>
-                {({ oppgaver }) => <Oppgavetabell oppgaverResponse={oppgaver} />}
+                {({ oppgaver }) => (
+                    <Oppgavetabell
+                        oppgaverResponse={oppgaver}
+                        oppgaveRequest={oppgaveRequest}
+                        settOppgaveRequest={settOppgaveRequest}
+                    />
+                )}
             </DataViewer>
             <Feilmelding>{feilmelding}</Feilmelding>
         </Container>

--- a/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
@@ -20,6 +20,7 @@ import {
     OppgaverResponse,
 } from './typer/oppgave';
 import { useOppgave } from '../../context/OppgaveContext';
+import { useOppgaveFilter } from '../../context/OppgaveFilterContext';
 import { PartialRecord } from '../../typer/common';
 
 const Tabell = styled(Table)`
@@ -61,7 +62,8 @@ const utledTabellSort = (oppgaveRequest: OppgaveRequest): SortState => ({
 });
 
 const Oppgavetabell: React.FC<Props> = ({ oppgaverResponse }) => {
-    const { oppgaveRequest, settOppgaveRequest, hentOppgaver } = useOppgave();
+    const { hentOppgaver } = useOppgave();
+    const { oppgaveRequest, settOppgaveRequest } = useOppgaveFilter();
     const side = utledSide(oppgaveRequest);
     const antallSider = utledAntallSider(oppgaverResponse);
 

--- a/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
@@ -20,7 +20,6 @@ import {
     OppgaverResponse,
 } from './typer/oppgave';
 import { useOppgave } from '../../context/OppgaveContext';
-import { useOppgaveFilter } from '../../context/OppgaveFilterContext';
 import { PartialRecord } from '../../typer/common';
 
 const Tabell = styled(Table)`
@@ -28,6 +27,8 @@ const Tabell = styled(Table)`
 `;
 interface Props {
     oppgaverResponse: OppgaverResponse;
+    oppgaveRequest: OppgaveRequest;
+    settOppgaveRequest: (oppgaveRequest: OppgaveRequest) => void;
 }
 
 const tabellHeaders: PartialRecord<keyof Oppgave, { tittel: string; orderBy?: OppgaveOrderBy }> = {
@@ -61,9 +62,12 @@ const utledTabellSort = (oppgaveRequest: OppgaveRequest): SortState => ({
     direction: oppgaveRequest.order === 'ASC' ? 'ascending' : 'descending',
 });
 
-const Oppgavetabell: React.FC<Props> = ({ oppgaverResponse }) => {
+const Oppgavetabell: React.FC<Props> = ({
+    oppgaverResponse,
+    oppgaveRequest,
+    settOppgaveRequest,
+}) => {
     const { hentOppgaver } = useOppgave();
-    const { oppgaveRequest, settOppgaveRequest } = useOppgaveFilter();
     const side = utledSide(oppgaveRequest);
     const antallSider = utledAntallSider(oppgaverResponse);
 

--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -9,6 +9,7 @@ import { lagreTilLocalStorage, oppgaveRequestKey } from './oppgavefilterStorage'
 import SaksbehandlerVelger from './SaksbehandlerVelger';
 import { useApp } from '../../../context/AppContext';
 import { useOppgave } from '../../../context/OppgaveContext';
+import { useOppgaveFilter } from '../../../context/OppgaveFilterContext';
 import { harEgenAnsattRolle, harStrengtFortroligRolle } from '../../../utils/roller';
 import {
     defaultOppgaveRequest,
@@ -43,7 +44,8 @@ const AlignetCheckbox = styled(Checkbox)`
 
 export const Oppgavefiltrering = () => {
     const { saksbehandler, appEnv } = useApp();
-    const { oppgaveRequest, settOppgaveRequest, hentOppgaver } = useOppgave();
+    const { hentOppgaver } = useOppgave();
+    const { oppgaveRequest, settOppgaveRequest } = useOppgaveFilter();
 
     const harSaksbehandlerStrengtFortroligRolle = harStrengtFortroligRolle(appEnv, saksbehandler);
     const harSaksbehandlerEgenAnsattRolle = harEgenAnsattRolle(appEnv, saksbehandler);

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
@@ -1,0 +1,86 @@
+import React, { useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { Alert } from '@navikt/ds-react';
+
+import { useApp } from '../../../context/AppContext';
+import { OppgaveProvider, useOppgave } from '../../../context/OppgaveContext';
+import { usePersonopplysninger } from '../../../context/PersonopplysningerContext';
+import DataViewer from '../../../komponenter/DataViewer';
+import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
+import { harStrengtFortroligRolle } from '../../../utils/roller';
+import {
+    defaultOppgaveRequest,
+    oppgaveRequestMedDefaultEnhet,
+} from '../../Oppgavebenk/oppgaverequestUtil';
+import Oppgavetabell from '../../Oppgavebenk/Oppgavetabell';
+import { OppgaveRequest } from '../../Oppgavebenk/typer/oppgave';
+
+const AlertContainer = styled.div`
+    margin: 2rem;
+    width: fit-content;
+`;
+
+/**
+ * TODO håndter at det kan gjelde egne ansatt
+ * TODO håndter at backend skal håndtere oppgaver: Alle/satt på vent/ikke satt på vent
+ */
+const Personoppgaver: React.FC = () => {
+    const { saksbehandler, appEnv } = useApp();
+    const {
+        personopplysninger: { personIdent },
+    } = usePersonopplysninger();
+    const { feilmelding, oppgaveRessurs, hentOppgaver } = useOppgave();
+
+    const harSaksbehandlerStrengtFortroligRolle = harStrengtFortroligRolle(appEnv, saksbehandler);
+    const [oppgaveRequest, settOppgaveRequest] = useState<OppgaveRequest>({
+        ...oppgaveRequestMedDefaultEnhet(
+            defaultOppgaveRequest,
+            harSaksbehandlerStrengtFortroligRolle
+        ),
+        ident: personIdent,
+    });
+
+    useEffect(() => {
+        hentOppgaver(oppgaveRequest);
+    }, []);
+
+    return (
+        <>
+            <DataViewer response={{ oppgaver: oppgaveRessurs }}>
+                {({ oppgaver }) => (
+                    <Oppgavetabell
+                        oppgaverResponse={oppgaver}
+                        oppgaveRequest={oppgaveRequest}
+                        settOppgaveRequest={settOppgaveRequest}
+                    />
+                )}
+            </DataViewer>
+            <Feilmelding>{feilmelding}</Feilmelding>
+        </>
+    );
+};
+
+const Oppgaveoversikt: React.FC = () => {
+    const { erSaksbehandler } = useApp();
+
+    if (!erSaksbehandler) {
+        return (
+            <AlertContainer>
+                <Alert variant={'info'}>
+                    Oppgavebenken er ikke tilgjengelig for veiledere. Benytt fødselsnummer i
+                    søkefelt for å finne informasjon om en person
+                </Alert>
+            </AlertContainer>
+        );
+    }
+
+    return (
+        <OppgaveProvider>
+            <Personoppgaver />
+        </OppgaveProvider>
+    );
+};
+
+export default Oppgaveoversikt;

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -9,6 +9,7 @@ import Aktivitetsoversikt from './Aktivitetsoversikt/Aktivitetsoversikt';
 import Behandlingsoversikt from './Behandlingsoversikt/BehandlingOversikt';
 import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import FrittståendeBrevFane from './FrittståendeBrev/FrittståendeBrevFane';
+import Oppgaveoversikt from './Oppgaveoversikt/Oppgaveoversikt';
 import Ytelseoversikt from './Ytelseoversikt/Ytelseoversikt';
 
 type TabWithRouter = {
@@ -22,6 +23,11 @@ const tabs: TabWithRouter[] = [
         label: 'Behandlinger',
         path: 'behandlinger',
         komponent: (fagsakPersonId) => <Behandlingsoversikt fagsakPersonId={fagsakPersonId} />,
+    },
+    {
+        label: 'Oppgaver',
+        path: 'oppgaver',
+        komponent: () => <Oppgaveoversikt />,
     },
     {
         label: 'Aktiviteter',

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -11,6 +11,8 @@ import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import FrittståendeBrevFane from './FrittståendeBrev/FrittståendeBrevFane';
 import Oppgaveoversikt from './Oppgaveoversikt/Oppgaveoversikt';
 import Ytelseoversikt from './Ytelseoversikt/Ytelseoversikt';
+import { useFlag } from '@unleash/proxy-client-react';
+import { Toggle } from '../../utils/toggles';
 
 type TabWithRouter = {
     label: string;
@@ -23,11 +25,6 @@ const tabs: TabWithRouter[] = [
         label: 'Behandlinger',
         path: 'behandlinger',
         komponent: (fagsakPersonId) => <Behandlingsoversikt fagsakPersonId={fagsakPersonId} />,
-    },
-    {
-        label: 'Oppgaver',
-        path: 'oppgaver',
-        komponent: () => <Oppgaveoversikt />,
     },
     {
         label: 'Aktiviteter',
@@ -51,6 +48,12 @@ const tabs: TabWithRouter[] = [
     },
 ];
 
+const oppgaveTab = {
+    label: 'Oppgaver',
+    path: 'oppgaver',
+    komponent: () => <Oppgaveoversikt />,
+};
+
 const InnholdWrapper = styled.div`
     padding: 2rem;
     display: flex;
@@ -64,6 +67,10 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
     const paths = useLocation().pathname.split('/').slice(-1);
     const path = paths.length ? paths[paths.length - 1] : '';
 
+    const skalViseOppgavebenk = useFlag(Toggle.SKAL_VISE_OPPGAVER_PERSONOVERSIKT);
+
+    const tabsSomSkalVises = [...tabs, ...(skalViseOppgavebenk ? [oppgaveTab] : [])];
+
     return (
         <>
             <Tabs
@@ -73,14 +80,14 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
                 }}
             >
                 <Tabs.List>
-                    {tabs.map((tab) => {
+                    {tabsSomSkalVises.map((tab) => {
                         return <Tabs.Tab key={tab.path} value={tab.path} label={tab.label} />;
                     })}
                 </Tabs.List>
             </Tabs>
             <InnholdWrapper>
                 <Routes>
-                    {tabs.map((tab) => (
+                    {tabsSomSkalVises.map((tab) => (
                         <Route
                             key={tab.path}
                             path={`/${tab.path}`}

--- a/src/frontend/context/OppgaveContext.ts
+++ b/src/frontend/context/OppgaveContext.ts
@@ -1,10 +1,8 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import constate from 'constate';
 
 import { useApp } from './AppContext';
-import { hentLagretOppgaveRequest } from '../Sider/Oppgavebenk/filter/oppgavefilterStorage';
-import { defaultOppgaveRequest } from '../Sider/Oppgavebenk/oppgaverequestUtil';
 import { Oppgave, OppgaveRequest, OppgaverResponse } from '../Sider/Oppgavebenk/typer/oppgave';
 import {
     byggHenterRessurs,
@@ -14,20 +12,13 @@ import {
     RessursStatus,
     RessursSuksess,
 } from '../typer/ressurs';
-import { harStrengtFortroligRolle } from '../utils/roller';
 
 export const [OppgaveProvider, useOppgave] = constate(() => {
-    const { request, saksbehandler, appEnv } = useApp();
+    const { request } = useApp();
     const [oppgaveRessurs, settOppgaveRessurs] =
         useState<Ressurs<OppgaverResponse>>(byggTomRessurs());
     const [laster, settLaster] = useState<boolean>(false);
-    const [lasterOppgaveRequestFraLocaleStorage, settLasterOppgaveRequestFraLocaleStorage] =
-        useState<boolean>(true);
     const [feilmelding, settFeilmelding] = useState<string>();
-
-    const [oppgaveRequest, settOppgaveRequest] = useState<OppgaveRequest>(defaultOppgaveRequest);
-
-    const harSaksbehandlerStrengtFortroligRolle = harStrengtFortroligRolle(appEnv, saksbehandler);
 
     const hentOppgaver = useCallback(
         (data: OppgaveRequest) => {
@@ -38,16 +29,6 @@ export const [OppgaveProvider, useOppgave] = constate(() => {
         },
         [request]
     );
-
-    useEffect(() => {
-        const lagretFiltrering = hentLagretOppgaveRequest(
-            saksbehandler,
-            harSaksbehandlerStrengtFortroligRolle
-        );
-        settOppgaveRequest(lagretFiltrering);
-        settLasterOppgaveRequestFraLocaleStorage(false);
-        hentOppgaver(lagretFiltrering);
-    }, [hentOppgaver, harSaksbehandlerStrengtFortroligRolle, saksbehandler]);
 
     const oppdaterOppgaveEtterTilbakestilling = (oppdatertOppgave: Oppgave) => {
         settOppgaveRessurs((prevState) => {
@@ -121,8 +102,5 @@ export const [OppgaveProvider, useOppgave] = constate(() => {
         tilbakestillFordeling,
         settOppgaveTilSaksbehandler,
         oppdaterOppgaveEtterTilbakestilling,
-        lasterOppgaveRequestFraLocaleStorage,
-        oppgaveRequest,
-        settOppgaveRequest,
     };
 });

--- a/src/frontend/context/OppgaveFilterContext.ts
+++ b/src/frontend/context/OppgaveFilterContext.ts
@@ -1,0 +1,36 @@
+import { useEffect, useState } from 'react';
+
+import constate from 'constate';
+
+import { useApp } from './AppContext';
+import { useOppgave } from './OppgaveContext';
+import { hentLagretOppgaveRequest } from '../Sider/Oppgavebenk/filter/oppgavefilterStorage';
+import { defaultOppgaveRequest } from '../Sider/Oppgavebenk/oppgaverequestUtil';
+import { OppgaveRequest } from '../Sider/Oppgavebenk/typer/oppgave';
+import { harStrengtFortroligRolle } from '../utils/roller';
+
+export const [OppgaveFilterProvider, useOppgaveFilter] = constate(() => {
+    const { saksbehandler, appEnv } = useApp();
+    const { hentOppgaver } = useOppgave();
+    const [lasterOppgaveRequestFraLocaleStorage, settLasterOppgaveRequestFraLocaleStorage] =
+        useState<boolean>(true);
+    const [oppgaveRequest, settOppgaveRequest] = useState<OppgaveRequest>(defaultOppgaveRequest);
+
+    const harSaksbehandlerStrengtFortroligRolle = harStrengtFortroligRolle(appEnv, saksbehandler);
+
+    useEffect(() => {
+        const lagretFiltrering = hentLagretOppgaveRequest(
+            saksbehandler,
+            harSaksbehandlerStrengtFortroligRolle
+        );
+        settOppgaveRequest(lagretFiltrering);
+        settLasterOppgaveRequestFraLocaleStorage(false);
+        hentOppgaver(lagretFiltrering);
+    }, [hentOppgaver, harSaksbehandlerStrengtFortroligRolle, saksbehandler]);
+
+    return {
+        lasterOppgaveRequestFraLocaleStorage,
+        oppgaveRequest,
+        settOppgaveRequest,
+    };
+});

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -1,4 +1,5 @@
 export enum Toggle {
     KAN_OPPRETTE_REVURDERING = 'sak.kan-opprette-revurdering',
     KAN_OPPRETTE_KLAGE = 'sak.kan-opprette-klage',
+    SKAL_VISE_OPPGAVER_PERSONOVERSIKT = 'sak.vis-oppgaver-personoversikt',
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Arbeid påbegynt av Johan tidligere som fungerer som en start på å vise oppgaver i personoversikten. 

Hva er gjort: 
- Trekk filtrering ut av oppgavetabellen i egen context slik at tabellen kan brukes uten filtrering.
- Send request inn til oppgavebenken slik at default kan defineres ulikt på de to ulike stedene

Det er litt som må fikses før denne kan legges ut i prod, men det er en start på å kunne gjenbruke samme komponent begge steder. Må feks håndtere å hente alle oppgaver (både på vent og ikke på vent osv). 