### PR TITLE
Fjerner påklaget vedtakstype UTESTENGELSE fra klage-løsningen

### DIFF
--- a/src/frontend/Sider/Klage/App/typer/fagsak.ts
+++ b/src/frontend/Sider/Klage/App/typer/fagsak.ts
@@ -71,14 +71,12 @@ export enum PåklagetVedtakstype {
     VEDTAK = 'VEDTAK',
     UTEN_VEDTAK = 'UTEN_VEDTAK',
     IKKE_VALGT = 'IKKE_VALGT',
-    UTESTENGELSE = 'UTESTENGELSE',
 }
 
 export const påklagetVedtakstypeTilTekst: Record<PåklagetVedtakstype, string> = {
     IKKE_VALGT: 'Ikke valgt',
     UTEN_VEDTAK: 'Har ikke klaget på et vedtak',
     VEDTAK: 'Vedtak',
-    UTESTENGELSE: 'Utestengelse',
 };
 
 export enum BehandlingResultat {

--- a/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/VedtakSelect.tsx
+++ b/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/VedtakSelect.tsx
@@ -6,7 +6,6 @@ import { FamilieSelect } from '@navikt/familie-form-elements';
 import {
     erVedtakFraFagsystemet,
     fagsystemVedtakTilVisningstekst,
-    harManuellVedtaksdato,
     sorterVedtakstidspunktDesc,
 } from './utils';
 import { FagsystemVedtak } from '../../../App/typer/fagsystemVedtak';
@@ -73,38 +72,10 @@ export const VedtakSelect: React.FC<IProps> = ({
                         {fagsystemVedtakTilVisningstekst(valg)}
                     </option>
                 ))}
-                <option value={PåklagetVedtakstype.UTESTENGELSE}>
-                    {påklagetVedtakstypeTilTekst[PåklagetVedtakstype.UTESTENGELSE]}
-                </option>
                 <option value={PåklagetVedtakstype.UTEN_VEDTAK}>
                     {påklagetVedtakstypeTilTekst[PåklagetVedtakstype.UTEN_VEDTAK]}
                 </option>
             </FamilieSelect>
-            {harManuellVedtaksdato(vurderinger.påklagetVedtak.påklagetVedtakstype) && (
-                <DatoWrapper>
-                    <Label htmlFor={'vedtaksdato'}>Vedtaksdato</Label>
-                    <Datovelger
-                        label={''}
-                        id={'vedtaksdato'}
-                        verdi={manuellVedtaksdato}
-                        settVerdi={(dato) => {
-                            settOppdaterteVurderinger((prevState) => ({
-                                ...prevState,
-                                påklagetVedtak: {
-                                    ...prevState.påklagetVedtak,
-                                    manuellVedtaksdato: dato as string,
-                                },
-                            }));
-                        }}
-                        feil={
-                            manuellVedtaksdato && !erGyldigDato(manuellVedtaksdato)
-                                ? 'Ugyldig dato'
-                                : undefined
-                        }
-                        maksDato={new Date()}
-                    />
-                </DatoWrapper>
-            )}
         </SelectWrapper>
     );
 };

--- a/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/VisFormkravVurderinger.tsx
+++ b/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/VisFormkravVurderinger.tsx
@@ -16,7 +16,6 @@ import { useNavigate } from 'react-router-dom';
 import { formaterIsoDatoTid, formaterNullableIsoDato } from '../../../App/utils/formatter';
 import { Ressurs, RessursFeilet, RessursStatus, RessursSuksess } from '../../../App/typer/ressurs';
 import {
-    harManuellVedtaksdato,
     skalViseKlagefristUnntak,
     utledFagsystemVedtakFraPåklagetVedtak,
     utledRadioKnapper,
@@ -119,11 +118,7 @@ export const VisFormkravVurderinger: React.FC<IProps> = ({
     settRedigeringsmodus,
     vurderinger,
 }) => {
-    const {
-        behandlingErRedigerbar,
-        hentBehandling,
-        hentBehandlingshistorikk
-    } = useBehandling();
+    const { behandlingErRedigerbar, hentBehandling, hentBehandlingshistorikk } = useBehandling();
     const { påklagetVedtakstype, manuellVedtaksdato } = vurderinger.påklagetVedtak;
     const navigate = useNavigate();
     const [nullstillerVurderinger, settNullstillerVurderinger] = useState<boolean>(false);
@@ -248,11 +243,6 @@ export const VisFormkravVurderinger: React.FC<IProps> = ({
                         ) : (
                             <div>
                                 <div>{påklagetVedtakstypeTilTekst[påklagetVedtakstype]}</div>
-                                <div>
-                                    {harManuellVedtaksdato(påklagetVedtakstype)
-                                        ? formaterNullableIsoDato(manuellVedtaksdato)
-                                        : ''}
-                                </div>
                             </div>
                         )}
                     </Svar>

--- a/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/utils.ts
+++ b/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/utils.ts
@@ -72,8 +72,7 @@ export const vedtakstidspunktTilVisningstekst = (vedtak: FagsystemVedtak) =>
 export const erVedtakFraFagsystemet = (valgtElement: string) => {
     return !(
         valgtElement === PåklagetVedtakstype.UTEN_VEDTAK ||
-        valgtElement === PåklagetVedtakstype.IKKE_VALGT ||
-        valgtElement === PåklagetVedtakstype.UTESTENGELSE
+        valgtElement === PåklagetVedtakstype.IKKE_VALGT
     );
 };
 
@@ -116,13 +115,8 @@ export const evaluerOmFelterSkalTilbakestilles = (vurderinger: IFormkravVilkår)
 
     return vurderinger.klagefristOverholdt === VilkårStatus.OPPFYLT
         ? {
-            ...tilbakestillFritekstfelter,
-            klagefristOverholdtUnntak: FormkravFristUnntak.IKKE_SATT,
-        }
+              ...tilbakestillFritekstfelter,
+              klagefristOverholdtUnntak: FormkravFristUnntak.IKKE_SATT,
+          }
         : tilbakestillFritekstfelter;
 };
-
-export const harManuellVedtaksdato = (påklagetVedtakstype: PåklagetVedtakstype): boolean =>
-    [
-        PåklagetVedtakstype.UTESTENGELSE,
-    ].includes(påklagetVedtakstype);

--- a/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/validerFormkravUtils.ts
+++ b/src/frontend/Sider/Klage/Komponenter/Behandling/Formkrav/validerFormkravUtils.ts
@@ -1,7 +1,7 @@
 import { FormkravFristUnntak, IFormkravVilkår, Redigeringsmodus, VilkårStatus } from './typer';
 import { PåklagetVedtakstype } from '../../../App/typer/fagsak';
 import { harVerdi } from '../../../App/utils/utils';
-import { harManuellVedtaksdato, utledRadioKnapper } from './utils';
+import { utledRadioKnapper } from './utils';
 import { erGyldigDato } from '../../../App/utils/dato';
 
 export const alleVurderingerErStatus = (
@@ -19,10 +19,6 @@ export const alleVurderingerErStatus = (
 
 export const påKlagetVedtakValgt = (vurderinger: IFormkravVilkår) => {
     const valgtVedtakstype = vurderinger.påklagetVedtak.påklagetVedtakstype;
-    if (harManuellVedtaksdato(valgtVedtakstype)) {
-        const manuellVedtaksdato = vurderinger.påklagetVedtak.manuellVedtaksdato;
-        return manuellVedtaksdato !== undefined && erGyldigDato(manuellVedtaksdato);
-    }
     return valgtVedtakstype !== PåklagetVedtakstype.IKKE_VALGT;
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Fjerner uaktuell vedtakstype UTESTENGELSE fra klage-løsningen.

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21768


### FØR:

![Skjermbilde 2024-07-03 kl  12 10 25](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/28704275/b433524d-e006-47b6-8ba6-b44047e2c44a)


### ETTER:

![Skjermbilde 2024-07-03 kl  12 10 37](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/28704275/b1175de3-9553-4cf7-a0d6-271340d59b87)
