### PR TITLE
Omruting til behandling og saksoversikt basert på eksterne ID-er

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -20,6 +20,7 @@ import ScrollToTop from './komponenter/ScrollToTop/ScrollToTop';
 import Toast from './komponenter/Toast';
 import { Sticky } from './komponenter/Visningskomponenter/Sticky';
 import BehandlingContainer from './Sider/Behandling/BehandlingContainer';
+import { EksternOmruting } from './Sider/EksternOmruting/EksternOmruting';
 import { Journalføring } from './Sider/Journalføring/Standard/Journalføring';
 import { App as KlageApp } from './Sider/Klage/App';
 import Oppgavebenk from './Sider/Oppgavebenk/Oppgavebenk';
@@ -44,6 +45,7 @@ const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
                     <Route path={'/person/:fagsakPersonId/*'} element={<Personoversikt />} />
                     <Route path={'/journalfor'} element={<Journalføring />} />
                     <Route path={'/behandling/:behandlingId/*'} element={<BehandlingContainer />} />
+                    <Route path={'/ekstern/*'} element={<EksternOmruting />} />
                     <Route path={'/klagebehandling/*'} element={<KlageApp />} />
                 </Route>
             ) : (

--- a/src/frontend/Sider/EksternOmruting/EksternOmruting.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmruting.tsx
@@ -1,0 +1,18 @@
+import React from 'react';
+
+import { Route, Routes } from 'react-router-dom';
+
+import { EksternOmrutingBehandling } from './EksternOmrutingBehandling';
+import { EksternOmrutingSaksoversikt } from './EksternOmrutingSaksoversikt';
+
+export function EksternOmruting() {
+    return (
+        <Routes>
+            <Route path={'/person/:eksternFagsakId'} element={<EksternOmrutingSaksoversikt />} />
+            <Route
+                path={'/behandling/:eksternBehandlingId'}
+                element={<EksternOmrutingBehandling />}
+            />
+        </Routes>
+    );
+}

--- a/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { useApp } from '../../context/AppContext';
+import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
+import { Behandling } from '../../typer/behandling/behandling';
+import { RessursStatus } from '../../typer/ressurs';
+
+/*
+/* Brukes dersom du har en ekstern behandling-ID og vil rutes til behandlingen
+*/
+export const EksternOmrutingBehandling = () => {
+    const navigate = useNavigate();
+    const { request } = useApp();
+    const { eksternBehandlingId } = useParams<{ eksternBehandlingId: string }>();
+
+    const [feilmelding, settFeilmelding] = useState<string>();
+
+    useEffect(() => {
+        request<Behandling, null>(`/api/sak/behandling/ekstern/${eksternBehandlingId}`).then(
+            (resultat) => {
+                if (resultat.status === RessursStatus.SUKSESS) {
+                    navigate(`/behandling/${resultat.data.id}`);
+                } else {
+                    settFeilmelding(resultat.frontendFeilmelding);
+                }
+            }
+        );
+    }, [eksternBehandlingId, navigate, request]);
+
+    return <Feilmelding variant="alert">{feilmelding}</Feilmelding>;
+};

--- a/src/frontend/Sider/EksternOmruting/EksternOmrutingSaksoversikt.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmrutingSaksoversikt.tsx
@@ -1,0 +1,33 @@
+import React, { useEffect, useState } from 'react';
+
+import { useNavigate, useParams } from 'react-router-dom';
+
+import { useApp } from '../../context/AppContext';
+import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
+import { Søkeresultat } from '../../komponenter/PersonSøk';
+import { RessursStatus } from '../../typer/ressurs';
+
+/*
+/* Brukes dersom du har en ekstern fagsak-ID og vil rutes til relatert personoversikt/saksoversikt
+*/
+export const EksternOmrutingSaksoversikt = () => {
+    const navigate = useNavigate();
+    const { request } = useApp();
+    const { eksternFagsakId } = useParams<{ eksternFagsakId: string }>();
+
+    const [feilmelding, settFeilmelding] = useState<string>();
+
+    useEffect(() => {
+        request<Søkeresultat, null>(`/api/sak/sok/person/fagsak-ekstern/${eksternFagsakId}`).then(
+            (resultat) => {
+                if (resultat.status === RessursStatus.SUKSESS) {
+                    navigate(`/person/${resultat.data.fagsakPersonId}`);
+                } else {
+                    settFeilmelding(resultat.frontendFeilmelding);
+                }
+            }
+        );
+    }, [eksternFagsakId, navigate, request]);
+
+    return <Feilmelding variant="alert">{feilmelding}</Feilmelding>;
+};

--- a/src/frontend/Sider/Klage/Felles/Visittkort/Status/StatusElementer.tsx
+++ b/src/frontend/Sider/Klage/Felles/Visittkort/Status/StatusElementer.tsx
@@ -8,7 +8,6 @@ import { stønadstypeTilTekst } from '../../../App/typer/stønadstype';
 import { ATextDefault, ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 import { utledTekstForBehandlingsresultat } from '../../../Komponenter/Behandling/Resultat/utils';
 import { formaterIsoDatoTid } from '../../../../../utils/dato';
-import { useHentPersonopplysninger } from '../../../App/hooks/useHentPersonopplysninger';
 
 interface StatusMenyInnholdProps {
     åpen: boolean;
@@ -100,9 +99,8 @@ export const Status = styled.div<StatusProps>`
     }
 `;
 
-export const StatusMeny: FC<{ behandling: Behandling; fagsakPersonId: string }> = ({
+export const StatusMeny: FC<{ behandling: Behandling }> = ({
     behandling,
-    fagsakPersonId,
 }) => {
     const [åpenStatusMeny, settÅpenStatusMeny] = useState<boolean>(false);
 
@@ -168,7 +166,10 @@ export const StatusMeny: FC<{ behandling: Behandling; fagsakPersonId: string }> 
                     )}
                     <li>
                         <Status>
-                            <Link href={`/ekstern/person/${fagsakPersonId}`} target="_blank">
+                            <Link
+                                href={`/ekstern/person/${behandling.eksternFagsystemFagsakId}`}
+                                target="_blank"
+                            >
                                 Gå til saksoversikt
                                 <ExternalLinkIcon
                                     aria-label="Gå til saksoversikt"
@@ -183,9 +184,8 @@ export const StatusMeny: FC<{ behandling: Behandling; fagsakPersonId: string }> 
     );
 };
 
-export const AlleStatuser: FC<{ behandling: Behandling; fagsakPersonId: string }> = ({
+export const AlleStatuser: FC<{ behandling: Behandling }> = ({
     behandling,
-    fagsakPersonId,
 }) => {
     return (
         <Statuser>
@@ -208,7 +208,7 @@ export const AlleStatuser: FC<{ behandling: Behandling; fagsakPersonId: string }
             {behandling.påklagetVedtak.eksternFagsystemBehandlingId && (
                 <Status>
                     <Link
-                        href={`/behandling/${behandling.påklagetVedtak.eksternFagsystemBehandlingId}`}
+                        href={`/ekstern/behandling/${behandling.påklagetVedtak.eksternFagsystemBehandlingId}`}
                         target="_blank"
                     >
                         Gå til behandling
@@ -217,7 +217,10 @@ export const AlleStatuser: FC<{ behandling: Behandling; fagsakPersonId: string }
                 </Status>
             )}
             <Status>
-                <Link href={`/ekstern/person/${fagsakPersonId}`} target="_blank">
+                <Link
+                    href={`/ekstern/person/${behandling.eksternFagsystemFagsakId}`}
+                    target="_blank"
+                >
                     Gå til saksoversikt
                     <ExternalLinkIcon aria-label="Gå til saksoversikt" fontSize="1.5rem" />
                 </Link>

--- a/src/frontend/Sider/Klage/Felles/Visittkort/Visittkort.tsx
+++ b/src/frontend/Sider/Klage/Felles/Visittkort/Visittkort.tsx
@@ -61,7 +61,6 @@ const VisittkortComponent: FC<{
 }) => {
     const {
         personIdent,
-        fagsakPersonId,
         kjønn,
         navn,
         folkeregisterpersonstatus,
@@ -120,9 +119,9 @@ const VisittkortComponent: FC<{
 
             {behandling && (
                 <>
-                    <AlleStatuser behandling={behandling} fagsakPersonId={fagsakPersonId}/>
+                    <AlleStatuser behandling={behandling}/>
                     <StatuserLitenSkjerm>
-                        <StatusMeny behandling={behandling} fagsakPersonId={fagsakPersonId} />
+                        <StatusMeny behandling={behandling}/>
                     </StatuserLitenSkjerm>
                 </>
             )}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I klage-appen er det lenker tilbake til personoversikten og behandlingen, men i kontekst av klage har vi ikke de interne UUID-ene som brukes i URL-en. 

Derfor har jeg nå laget en route under `/ekstern/*` som lar oss rute til saksbehandlingen basertt påekstern fagsak-ID, og påklaget vedtak (hvis et er valgt) basert på ekstern behandling-ID. 

![image](https://github.com/navikt/tilleggsstonader-sak-frontend/assets/17157469/9265eee7-7a65-4725-8f8e-565d2a951452)
