### PR TITLE
Oppgaver på personoversikt

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
@@ -4,11 +4,12 @@ import { CopyButton, HStack, Popover, Table } from '@navikt/ds-react';
 
 import Oppgaveknapp from './Oppgaveknapp';
 import { utledetFolkeregisterIdent } from './Oppgavetabell';
-import { behandlingstemaTilTekst, Oppgave, oppgaveBehandlingstypeTilTekst } from './typer/oppgave';
+import { Oppgave } from './typer/oppgave';
 import { oppgaveTypeTilVisningstekstSomTarHensynTilKlage } from './typer/oppgavetema';
 import { useApp } from '../../context/AppContext';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../utils/dato';
 import { Saksbehandler } from '../../utils/saksbehandler';
+import { utledTypeBehandling } from './oppgaveutils';
 
 const utledTildeltRessurs = (oppgave: Oppgave, saksbehandler: Saksbehandler) => {
     if (!oppgave.tilordnetRessurs) {
@@ -27,17 +28,6 @@ const Oppgaverad: React.FC<{ oppgave: Oppgave }> = ({ oppgave }) => {
     const togglePopover = (element: React.MouseEvent<HTMLElement>) => {
         settAnker(anker ? null : element.currentTarget);
     };
-    const behandlingstema =
-        oppgave.behandlingstema && behandlingstemaTilTekst[oppgave.behandlingstema];
-
-    const behandlingstype =
-        oppgave.behandlingstype && oppgaveBehandlingstypeTilTekst[oppgave.behandlingstype];
-
-    const typeBehandling = behandlingstype
-        ? behandlingstema
-            ? behandlingstype + ' - ' + behandlingstema
-            : behandlingstype
-        : behandlingstema;
 
     const folkeregistrertIdent = utledetFolkeregisterIdent(oppgave);
 
@@ -51,7 +41,9 @@ const Oppgaverad: React.FC<{ oppgave: Oppgave }> = ({ oppgave }) => {
                       )
                     : 'Mangler oppgavetype'}
             </Table.DataCell>
-            <Table.DataCell>{typeBehandling}</Table.DataCell>
+            <Table.DataCell>
+                {utledTypeBehandling(oppgave.behandlingstype, oppgave.behandlingstema)}
+            </Table.DataCell>
             <Table.DataCell onMouseEnter={togglePopover} onMouseLeave={togglePopover}>
                 {formaterNullableIsoDato(oppgave.opprettetTidspunkt)}
                 <Popover

--- a/src/frontend/Sider/Oppgavebenk/oppgaveutils.ts
+++ b/src/frontend/Sider/Oppgavebenk/oppgaveutils.ts
@@ -1,4 +1,10 @@
-import { Oppgave } from './typer/oppgave';
+import {
+    Behandlingstema,
+    Oppgave,
+    OppgaveBehandlingstype,
+    behandlingstemaTilTekst,
+    oppgaveBehandlingstypeTilTekst,
+} from './typer/oppgave';
 import { Oppgavetype } from './typer/oppgavetema';
 import { Saksbehandler } from '../../utils/saksbehandler';
 
@@ -31,4 +37,18 @@ export const oppgaveErJournalføringKlage = (oppgave: Oppgave) =>
 
 export const lagJournalføringUrl = (journalpostId: string, oppgaveId: string | number): string => {
     return `/journalfor?${JOURNALPOST_QUERY_STRING}=${journalpostId}&${OPPGAVEID_QUERY_STRING}=${oppgaveId}`;
+};
+
+export const utledTypeBehandling = (
+    behandlingstype?: OppgaveBehandlingstype,
+    behandlingstema?: Behandlingstema
+) => {
+    const behandlingstypeTekst = behandlingstype && oppgaveBehandlingstypeTilTekst[behandlingstype];
+    const behandlingstemaTekst = behandlingstema && behandlingstemaTilTekst[behandlingstema];
+
+    return behandlingstype
+        ? behandlingstema
+            ? behandlingstypeTekst + ' - ' + behandlingstemaTekst
+            : behandlingstypeTekst
+        : behandlingstemaTekst;
 };

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -117,3 +117,10 @@ export const oppgaveBehandlingstypeTilTekst: Record<OppgaveBehandlingstype, stri
     [OppgaveBehandlingstype.TidligereHjemsendtsak]: 'Tidligere hjemsendt sak',
     [OppgaveBehandlingstype.HjemsendtTilNyBehandling]: 'Hjemsendt til ny behandling',
 };
+
+export interface Mappe {
+    id: number;
+    navn: string;
+    enhetsnr: string;
+    tema: string;
+}

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Oppgave } from '../../Oppgavebenk/typer/oppgave';
 import { Table } from '@navikt/ds-react';
+import { oppgaveTypeTilVisningstekstSomTarHensynTilKlage } from '../../Oppgavebenk/typer/oppgavetema';
 import { utledTypeBehandling } from '../../Oppgavebenk/oppgaveutils';
 import { formaterNullableIsoDato } from '../../../utils/dato';
 import styled from 'styled-components';
@@ -29,7 +30,12 @@ const Oppgaveliste: React.FC<{ oppgaver: Oppgave[] }> = ({ oppgaver }) => {
             <Table.Body>
                 {oppgaver.map((oppgave) => (
                     <Table.Row key={oppgave.id}>
-                        <Table.DataCell>{oppgave.oppgavetype}</Table.DataCell>
+                        <Table.DataCell>
+                            {oppgave.oppgavetype &&
+                                oppgaveTypeTilVisningstekstSomTarHensynTilKlage(
+                                    oppgave.oppgavetype
+                                )}
+                        </Table.DataCell>
                         <Table.DataCell>
                             {utledTypeBehandling(oppgave.behandlingstype, oppgave.behandlingstema)}
                         </Table.DataCell>

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { Oppgave } from '../../Oppgavebenk/typer/oppgave';
+import { Table } from '@navikt/ds-react';
+import { utledTypeBehandling } from '../../Oppgavebenk/oppgaveutils';
+import { formaterNullableIsoDato } from '../../../utils/dato';
+import styled from 'styled-components';
+import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
+
+const Tabell = styled(Table)`
+    max-width: 900px;
+    border: 1px solid ${ABorderDivider};
+    --ac-table-row-border: ${ABorderDivider};
+    --ac-table-row-hover: none;
+    --ac-table-cell-hover-border: ${ABorderDivider};
+`;
+
+const Oppgaveliste: React.FC<{ oppgaver: Oppgave[] }> = ({ oppgaver }) => {
+    return (
+        <Tabell size="small">
+            <Table.Header>
+                <Table.Row>
+                    <Table.ColumnHeader>Oppgavetype</Table.ColumnHeader>
+                    <Table.ColumnHeader>Stønad</Table.ColumnHeader>
+                    <Table.ColumnHeader>Opprettet</Table.ColumnHeader>
+                    <Table.ColumnHeader>Frist</Table.ColumnHeader>
+                    <Table.ColumnHeader>Tildelt</Table.ColumnHeader>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {oppgaver.map((oppgave) => (
+                    <Table.Row key={oppgave.id}>
+                        <Table.DataCell>{oppgave.oppgavetype}</Table.DataCell>
+                        <Table.DataCell>
+                            {utledTypeBehandling(oppgave.behandlingstype, oppgave.behandlingstema)}
+                        </Table.DataCell>
+                        <Table.DataCell>
+                            {formaterNullableIsoDato(oppgave.opprettetTidspunkt)}
+                        </Table.DataCell>
+                        <Table.DataCell>
+                            {formaterNullableIsoDato(oppgave.fristFerdigstillelse)}
+                        </Table.DataCell>
+                        <Table.DataCell>{oppgave.tilordnetRessurs}</Table.DataCell>
+                    </Table.Row>
+                ))}
+            </Table.Body>
+        </Tabell>
+    );
+};
+
+export default Oppgaveliste;

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import { Oppgave } from '../../Oppgavebenk/typer/oppgave';
+import { Mappe, Oppgave } from '../../Oppgavebenk/typer/oppgave';
 import { Table } from '@navikt/ds-react';
 import { oppgaveTypeTilVisningstekstSomTarHensynTilKlage } from '../../Oppgavebenk/typer/oppgavetema';
 import { utledTypeBehandling } from '../../Oppgavebenk/oppgaveutils';
 import { formaterNullableIsoDato } from '../../../utils/dato';
 import styled from 'styled-components';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
+import { mappeIdTilMappenavn } from './utils';
 
 const Tabell = styled(Table)`
     max-width: 900px;
@@ -15,7 +16,10 @@ const Tabell = styled(Table)`
     --ac-table-cell-hover-border: ${ABorderDivider};
 `;
 
-const Oppgaveliste: React.FC<{ oppgaver: Oppgave[] }> = ({ oppgaver }) => {
+const Oppgaveliste: React.FC<{ oppgaver: Oppgave[]; mapper: Record<number, Mappe> }> = ({
+    oppgaver,
+    mapper,
+}) => {
     return (
         <Tabell size="small">
             <Table.Header>
@@ -23,6 +27,7 @@ const Oppgaveliste: React.FC<{ oppgaver: Oppgave[] }> = ({ oppgaver }) => {
                     <Table.ColumnHeader>Oppgavetype</Table.ColumnHeader>
                     <Table.ColumnHeader>Stønad</Table.ColumnHeader>
                     <Table.ColumnHeader>Opprettet</Table.ColumnHeader>
+                    <Table.ColumnHeader>Mappe</Table.ColumnHeader>
                     <Table.ColumnHeader>Frist</Table.ColumnHeader>
                     <Table.ColumnHeader>Tildelt</Table.ColumnHeader>
                 </Table.Row>
@@ -41,6 +46,9 @@ const Oppgaveliste: React.FC<{ oppgaver: Oppgave[] }> = ({ oppgaver }) => {
                         </Table.DataCell>
                         <Table.DataCell>
                             {formaterNullableIsoDato(oppgave.opprettetTidspunkt)}
+                        </Table.DataCell>
+                        <Table.DataCell>
+                            {mappeIdTilMappenavn(oppgave.mappeId, mapper)}
                         </Table.DataCell>
                         <Table.DataCell>
                             {formaterNullableIsoDato(oppgave.fristFerdigstillelse)}

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
@@ -16,10 +16,9 @@ const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId 
 
     useEffect(() => {
         const hentOppgaver = () =>
-            request<OppgaverResponse, null>(
-                `/api/sak/oppgave/soek/person/${fagsakPersonId}`,
-                'POST'
-            ).then(settOppgaveResponse);
+            request<OppgaverResponse, null>(`/api/sak/oppgave/soek/person/${fagsakPersonId}`).then(
+                settOppgaveResponse
+            );
 
         const hentMapper = () =>
             request<Mappe[], null>(`/api/sak/oppgave/mapper`, 'GET').then(settMapper);

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
@@ -1,0 +1,32 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import { OppgaverResponse } from '../../Oppgavebenk/typer/oppgave';
+import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
+import { useApp } from '../../../context/AppContext';
+import Oppgaveliste from './Oppgaveliste';
+import DataViewer from '../../../komponenter/DataViewer';
+
+const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
+    const { request } = useApp();
+
+    const [oppgaveResponse, settOppgaveResponse] =
+        useState<Ressurs<OppgaverResponse>>(byggTomRessurs());
+
+    const hentOppgaver = useCallback(() => {
+        request<OppgaverResponse, null>(
+            `/api/sak/oppgave/soek/person/${fagsakPersonId}`,
+            'POST'
+        ).then(settOppgaveResponse);
+    }, [request]);
+
+    useEffect(() => {
+        hentOppgaver();
+    }, []);
+
+    return (
+        <DataViewer response={{ oppgaveResponse }}>
+            {({ oppgaveResponse }) => <Oppgaveliste oppgaver={oppgaveResponse.oppgaver} />}
+        </DataViewer>
+    );
+};
+
+export default Oppgaveoversikt;

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
@@ -1,10 +1,11 @@
-import React, { useCallback, useEffect, useState } from 'react';
-import { Mappe, OppgaverResponse } from '../../Oppgavebenk/typer/oppgave';
-import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
-import { useApp } from '../../../context/AppContext';
+import React, { useEffect, useState } from 'react';
+
 import Oppgaveliste from './Oppgaveliste';
-import DataViewer from '../../../komponenter/DataViewer';
 import { mapperTilIdRecord } from './utils';
+import { useApp } from '../../../context/AppContext';
+import DataViewer from '../../../komponenter/DataViewer';
+import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
+import { Mappe, OppgaverResponse } from '../../Oppgavebenk/typer/oppgave';
 
 const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     const { request } = useApp();
@@ -13,21 +14,19 @@ const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId 
         useState<Ressurs<OppgaverResponse>>(byggTomRessurs());
     const [mapper, settMapper] = useState<Ressurs<Mappe[]>>(byggTomRessurs());
 
-    const hentOppgaver = useCallback(() => {
-        request<OppgaverResponse, null>(
-            `/api/sak/oppgave/soek/person/${fagsakPersonId}`,
-            'POST'
-        ).then(settOppgaveResponse);
-    }, [request]);
-
-    const hentMapper = useCallback(() => {
-        request<Mappe[], null>(`/api/sak/oppgave/mapper`, 'GET').then(settMapper);
-    }, [request]);
-
     useEffect(() => {
+        const hentOppgaver = () =>
+            request<OppgaverResponse, null>(
+                `/api/sak/oppgave/soek/person/${fagsakPersonId}`,
+                'POST'
+            ).then(settOppgaveResponse);
+
+        const hentMapper = () =>
+            request<Mappe[], null>(`/api/sak/oppgave/mapper`, 'GET').then(settMapper);
+
         hentOppgaver();
         hentMapper();
-    }, []);
+    }, [fagsakPersonId, request]);
 
     return (
         <DataViewer response={{ oppgaveResponse, mapper }}>

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
@@ -1,15 +1,17 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { OppgaverResponse } from '../../Oppgavebenk/typer/oppgave';
+import { Mappe, OppgaverResponse } from '../../Oppgavebenk/typer/oppgave';
 import { Ressurs, byggTomRessurs } from '../../../typer/ressurs';
 import { useApp } from '../../../context/AppContext';
 import Oppgaveliste from './Oppgaveliste';
 import DataViewer from '../../../komponenter/DataViewer';
+import { mapperTilIdRecord } from './utils';
 
 const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     const { request } = useApp();
 
     const [oppgaveResponse, settOppgaveResponse] =
         useState<Ressurs<OppgaverResponse>>(byggTomRessurs());
+    const [mapper, settMapper] = useState<Ressurs<Mappe[]>>(byggTomRessurs());
 
     const hentOppgaver = useCallback(() => {
         request<OppgaverResponse, null>(
@@ -18,13 +20,23 @@ const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId 
         ).then(settOppgaveResponse);
     }, [request]);
 
+    const hentMapper = useCallback(() => {
+        request<Mappe[], null>(`/api/sak/oppgave/mapper`, 'GET').then(settMapper);
+    }, [request]);
+
     useEffect(() => {
         hentOppgaver();
+        hentMapper();
     }, []);
 
     return (
-        <DataViewer response={{ oppgaveResponse }}>
-            {({ oppgaveResponse }) => <Oppgaveliste oppgaver={oppgaveResponse.oppgaver} />}
+        <DataViewer response={{ oppgaveResponse, mapper }}>
+            {({ oppgaveResponse, mapper }) => (
+                <Oppgaveliste
+                    oppgaver={oppgaveResponse.oppgaver}
+                    mapper={mapperTilIdRecord(mapper)}
+                />
+            )}
         </DataViewer>
     );
 };

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/utils.ts
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/utils.ts
@@ -1,0 +1,20 @@
+import { Mappe } from '../../Oppgavebenk/typer/oppgave';
+
+export const mapperTilIdRecord = (mapper: Mappe[]): Record<number, Mappe> =>
+    mapper.reduce(
+        (acc, item) => {
+            acc[item.id] = item;
+            return acc;
+        },
+        {} as Record<number, Mappe>
+    );
+
+export const mappeIdTilMappenavn = (
+    mappeId: number | 0 | undefined,
+    mapper: Record<number, Mappe>
+) => {
+    if (mappeId === 0 || mappeId === undefined) {
+        return;
+    }
+    return mapper[mappeId].navn ?? 'Ukjent mappe';
+};

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -10,6 +10,9 @@ import Behandlingsoversikt from './Behandlingsoversikt/BehandlingOversikt';
 import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import FrittståendeBrevFane from './FrittståendeBrev/FrittståendeBrevFane';
 import Ytelseoversikt from './Ytelseoversikt/Ytelseoversikt';
+import Oppgaveoversikt from './Oppgaveoversikt/Oppgaveoversikt';
+import { useFlag } from '@unleash/proxy-client-react';
+import { Toggle } from '../../utils/toggles';
 
 type TabWithRouter = {
     label: string;
@@ -45,6 +48,12 @@ const tabs: TabWithRouter[] = [
     },
 ];
 
+const oppgaveTab = {
+    label: 'Oppgaver',
+    path: 'oppgaver',
+    komponent: (fagsakPersonId: string) => <Oppgaveoversikt fagsakPersonId={fagsakPersonId} />,
+};
+
 const InnholdWrapper = styled.div`
     padding: 2rem;
     display: flex;
@@ -58,6 +67,10 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
     const paths = useLocation().pathname.split('/').slice(-1);
     const path = paths.length ? paths[paths.length - 1] : '';
 
+    const skalViseOppgaveTab = useFlag(Toggle.SKAL_VISE_OPPGAVER_PERSONOVERSIKT);
+
+    const tabsSomSkalVises = [...(skalViseOppgaveTab ? [oppgaveTab] : []), ...tabs];
+
     return (
         <>
             <Tabs
@@ -67,14 +80,14 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
                 }}
             >
                 <Tabs.List>
-                    {tabs.map((tab) => {
+                    {tabsSomSkalVises.map((tab) => {
                         return <Tabs.Tab key={tab.path} value={tab.path} label={tab.label} />;
                     })}
                 </Tabs.List>
             </Tabs>
             <InnholdWrapper>
                 <Routes>
-                    {tabs.map((tab) => (
+                    {tabsSomSkalVises.map((tab) => (
                         <Route
                             key={tab.path}
                             path={`/${tab.path}`}

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -94,7 +94,10 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
                             element={tab.komponent(fagsakPersonId)}
                         />
                     ))}
-                    <Route path="*" element={<Navigate to="behandlinger" replace={true} />} />
+                    <Route
+                        path="*"
+                        element={<Navigate to={tabsSomSkalVises[0].path} replace={true} />}
+                    />
                 </Routes>
             </InnholdWrapper>
         </>

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -1,4 +1,5 @@
 export enum Toggle {
     KAN_OPPRETTE_REVURDERING = 'sak.kan-opprette-revurdering',
     KAN_OPPRETTE_KLAGE = 'sak.kan-opprette-klage',
+    SKAL_VISE_OPPGAVER_PERSONOVERSIKT = 'sak.vis-oppgaver-personoversikt',
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Har lagt til en enkel tabell som ramser opp alle oppgaver som finnes på bruker på TSO. 
Den henter mapper selv for å få vist mappenavn. Lånt fra EF fordi det ikke var rett frem å sammenligne mappene i backend.

<img width="1487" alt="image" src="https://github.com/navikt/tilleggsstonader-sak-frontend/assets/46678893/612e7894-a4cd-4992-9903-97159c1ce106">
