### PR TITLE
Skal vise kommentar for sett på vent om behandling er redigerbar

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Historikk/Metadata.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Historikk/Metadata.tsx
@@ -4,14 +4,26 @@ import { Detail, VStack } from '@navikt/ds-react';
 
 import { HendelseMetadata } from './typer';
 import { erSettPåVentMetadata, erTattAvVentMetadata, erVedtakUnderkjentMetadata } from './utils';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import { årsakTilTekst } from '../../SettPåVent/typer';
 import { årsakUnderkjentTilTekst } from '../../Totrinnskontroll/typer';
 
 const Metadata: React.FC<{ metadata: HendelseMetadata }> = ({ metadata }) => {
+    const { behandlingErRedigerbar } = useBehandling();
+
     if (erSettPåVentMetadata(metadata)) {
         const venterPå = metadata.årsaker.map((årsak) => årsakTilTekst[årsak]).join(', ');
 
-        return <Detail>{venterPå}</Detail>;
+        return (
+            <>
+                <Detail>{venterPå}</Detail>
+                {behandlingErRedigerbar && (
+                    <Detail>
+                        <i>{metadata.kommentarSettPåVent}</i>
+                    </Detail>
+                )}
+            </>
+        );
     }
 
     if (erVedtakUnderkjentMetadata(metadata)) {

--- a/src/frontend/Sider/Behandling/Venstremeny/Historikk/typer.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Historikk/typer.tsx
@@ -13,6 +13,7 @@ export type HendelseMetadata = SattPåVentMetadata | VedtakUnderkjentMetadata | 
 
 export interface SattPåVentMetadata {
     årsaker: ÅrsakSettPåVent[];
+    kommentarSettPåVent?: string;
 }
 
 export interface VedtakUnderkjentMetadata {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønskelig å se kommentaren for satt på vent i historikken slik at man har den tilgjengelig når man tar behandlingen av vent. 
Fra diskusjon på [slack](https://nav-it.slack.com/archives/C05TU86SU8Y/p1721635186981229)