### PR TITLE
Opprett førstegangsbehandling fra journalpostid

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
-import FlagProvider, { IConfig } from '@unleash/proxy-client-react';
+import FlagProvider, { IConfig, useFlag } from '@unleash/proxy-client-react';
 import {
     createBrowserRouter,
     createRoutesFromElements,
@@ -19,6 +19,7 @@ import PersonSøk from './komponenter/PersonSøk';
 import ScrollToTop from './komponenter/ScrollToTop/ScrollToTop';
 import Toast from './komponenter/Toast';
 import { Sticky } from './komponenter/Visningskomponenter/Sticky';
+import OpprettBehandlingFraJournalpost from './Sider/Admin/OpprettBehandlingFraJournalpost';
 import BehandlingContainer from './Sider/Behandling/BehandlingContainer';
 import { EksternOmruting } from './Sider/EksternOmruting/EksternOmruting';
 import { Journalføring } from './Sider/Journalføring/Standard/Journalføring';
@@ -27,6 +28,7 @@ import Oppgavebenk from './Sider/Oppgavebenk/Oppgavebenk';
 import Personoversikt from './Sider/Personoversikt/Personoversikt';
 import { AppEnv, hentEnv } from './utils/env';
 import { hentInnloggetSaksbehandler, Saksbehandler } from './utils/saksbehandler';
+import { Toggle } from './utils/toggles';
 import { mockFlags } from './utils/unleashMock';
 
 const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
@@ -47,6 +49,10 @@ const AppRoutes: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
                     <Route path={'/behandling/:behandlingId/*'} element={<BehandlingContainer />} />
                     <Route path={'/ekstern/*'} element={<EksternOmruting />} />
                     <Route path={'/klagebehandling/*'} element={<KlageApp />} />
+                    <Route
+                        path={'/admin/opprett-behandling-fra-journalpost'}
+                        element={<OpprettBehandlingFraJournalpost />}
+                    />
                 </Route>
             ) : (
                 <Route
@@ -95,6 +101,9 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
     innloggetSaksbehandler,
 }) => {
     const { loggUt } = useApp();
+    const kanOppretteBehandlingFraJournalpost = useFlag(
+        Toggle.KAN_OPPRETTE_BEHANDLING_FRA_JOURNALPOST
+    );
     return (
         <>
             <Sticky $zIndex={100}>
@@ -120,6 +129,15 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
                         />
                         <Dropdown.Menu>
                             <Dropdown.Menu.List>
+                                {kanOppretteBehandlingFraJournalpost && (
+                                    <Dropdown.Menu.GroupedList.Item
+                                        as="a"
+                                        href="/admin/opprett-behandling-fra-journalpost"
+                                    >
+                                        [Admin] Opprett behandling fra journalpost
+                                    </Dropdown.Menu.GroupedList.Item>
+                                )}
+                                <Dropdown.Menu.Divider />
                                 <Dropdown.Menu.List.Item onClick={loggUt}>
                                     Logg ut <Spacer /> <LeaveIcon aria-hidden fontSize="1.5rem" />
                                 </Dropdown.Menu.List.Item>

--- a/src/frontend/Sider/Admin/OpprettBehandlingFraJournalpost.tsx
+++ b/src/frontend/Sider/Admin/OpprettBehandlingFraJournalpost.tsx
@@ -1,0 +1,121 @@
+import React, { useState } from 'react';
+
+import { useNavigate } from 'react-router-dom';
+import styled from 'styled-components';
+
+import { BodyLong, Button, Detail, Heading, List, TextField } from '@navikt/ds-react';
+
+import { useApp } from '../../context/AppContext';
+import DataViewer from '../../komponenter/DataViewer';
+import {
+    byggFeiletRessurs,
+    byggHenterRessurs,
+    byggTomRessurs,
+    Ressurs,
+    RessursStatus,
+} from '../../typer/ressurs';
+
+const Container = styled.div`
+    margin: 2rem;
+    width: 40rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.5rem;
+`;
+
+interface JournalpostStatus {
+    ident: string;
+    barnIdenterFraSøknad: string[];
+    fagsakId?: string;
+}
+
+const OpprettBehandlingFraJournalpost: React.FC = () => {
+    const { request } = useApp();
+    const navigate = useNavigate();
+    const [journalpostId, settJournalpostId] = useState<string>('');
+
+    const [journalpostStatus, settJournalpostStatus] =
+        useState<Ressurs<JournalpostStatus>>(byggTomRessurs());
+
+    const [opprettBehandlingResponse, settOpprettBehandlingResponse] =
+        useState<Ressurs<JournalpostStatus>>(byggTomRessurs());
+
+    const hentJournalpostStatus = () => {
+        if (!journalpostId.trim()) {
+            settJournalpostStatus(byggFeiletRessurs('Mangler journalpostId'));
+            return;
+        }
+        settJournalpostStatus(byggHenterRessurs());
+        request<JournalpostStatus, null>(`/api/sak/behandling/journalpost/${journalpostId}`).then(
+            settJournalpostStatus
+        );
+    };
+
+    const opprettBehandling = () => {
+        if (!journalpostId.trim()) {
+            settOpprettBehandlingResponse(byggFeiletRessurs('Mangler journalpostId'));
+            return;
+        }
+
+        request<JournalpostStatus, string>(
+            `/api/sak/behandling/journalpost/${journalpostId}`,
+            'POST',
+            undefined
+        ).then((res) => {
+            if (res.status === RessursStatus.SUKSESS) {
+                navigate(`/behandling/${res.data}`);
+            } else {
+                settOpprettBehandlingResponse(res);
+            }
+        });
+    };
+
+    return (
+        <Container>
+            <Heading size={'medium'}>
+                [Admin] Opprett førstegangsbehandling fra journalpostId
+            </Heading>
+            <Detail>
+                Opprett en førstegangsbehandling ut fra en journalpostId. JournalpostId til en
+                søknad finnes inne på gosys når man går inn på en journalpost. Når man har søkt
+                etter en journalpostId så vil barnen i søknaden listes opp før man oppretter selve
+                behandlingen. Behandle-sak-oppgaven vil bli tildelt deg.
+            </Detail>
+            <TextField
+                label={'JournalpostId'}
+                description={'Søk etter journalpostId'}
+                onChange={(e) => {
+                    settJournalpostId(e.target.value);
+                }}
+            />
+            <Button
+                variant={'primary'}
+                size={'small'}
+                disabled={!journalpostId.trim()}
+                onClick={hentJournalpostStatus}
+            >
+                Hent info om journalpost
+            </Button>
+
+            <DataViewer response={{ journalpostStatus }}>
+                {({ journalpostStatus }) => (
+                    <>
+                        <Heading size={'small'}>Informasjon fra søknad</Heading>
+                        <BodyLong>Søker: {journalpostStatus.ident}</BodyLong>
+                        <List title={'Barn i søknad'}>
+                            {journalpostStatus.barnIdenterFraSøknad.map((ident, indeks) => (
+                                <List.Item key={indeks}>{ident}</List.Item>
+                            ))}
+                        </List>
+                        <Button variant={'secondary'} size={'small'} onClick={opprettBehandling}>
+                            Opprett behandling fra søknad
+                        </Button>
+                    </>
+                )}
+            </DataViewer>
+            <DataViewer response={{ opprettBehandlingResponse }}>{() => <>Ok</>}</DataViewer>
+        </Container>
+    );
+};
+
+export default OpprettBehandlingFraJournalpost;

--- a/src/frontend/Sider/Admin/OpprettBehandlingFraJournalpost.tsx
+++ b/src/frontend/Sider/Admin/OpprettBehandlingFraJournalpost.tsx
@@ -23,7 +23,7 @@ const Container = styled.div`
     gap: 0.5rem;
 `;
 
-interface JournalpostStatus {
+interface JournalpostData {
     ident: string;
     barnIdenterFraSøknad: string[];
     fagsakId?: string;
@@ -34,20 +34,20 @@ const OpprettBehandlingFraJournalpost: React.FC = () => {
     const navigate = useNavigate();
     const [journalpostId, settJournalpostId] = useState<string>('');
 
-    const [journalpostStatus, settJournalpostStatus] =
-        useState<Ressurs<JournalpostStatus>>(byggTomRessurs());
+    const [journalpostData, settJournalpostData] =
+        useState<Ressurs<JournalpostData>>(byggTomRessurs());
 
     const [opprettBehandlingResponse, settOpprettBehandlingResponse] =
-        useState<Ressurs<JournalpostStatus>>(byggTomRessurs());
+        useState<Ressurs<JournalpostData>>(byggTomRessurs());
 
     const hentJournalpostStatus = () => {
         if (!journalpostId.trim()) {
-            settJournalpostStatus(byggFeiletRessurs('Mangler journalpostId'));
+            settJournalpostData(byggFeiletRessurs('Mangler journalpostId'));
             return;
         }
-        settJournalpostStatus(byggHenterRessurs());
-        request<JournalpostStatus, null>(`/api/sak/behandling/journalpost/${journalpostId}`).then(
-            settJournalpostStatus
+        settJournalpostData(byggHenterRessurs());
+        request<JournalpostData, null>(`/api/sak/behandling/journalpost/${journalpostId}`).then(
+            settJournalpostData
         );
     };
 
@@ -57,7 +57,7 @@ const OpprettBehandlingFraJournalpost: React.FC = () => {
             return;
         }
 
-        request<JournalpostStatus, string>(
+        request<JournalpostData, string>(
             `/api/sak/behandling/journalpost/${journalpostId}`,
             'POST',
             undefined
@@ -97,13 +97,13 @@ const OpprettBehandlingFraJournalpost: React.FC = () => {
                 Hent info om journalpost
             </Button>
 
-            <DataViewer response={{ journalpostStatus }}>
-                {({ journalpostStatus }) => (
+            <DataViewer response={{ journalpostData }}>
+                {({ journalpostData }) => (
                     <>
                         <Heading size={'small'}>Informasjon fra søknad</Heading>
-                        <BodyLong>Søker: {journalpostStatus.ident}</BodyLong>
+                        <BodyLong>Søker: {journalpostData.ident}</BodyLong>
                         <List title={'Barn i søknad'}>
-                            {journalpostStatus.barnIdenterFraSøknad.map((ident, indeks) => (
+                            {journalpostData.barnIdenterFraSøknad.map((ident, indeks) => (
                                 <List.Item key={indeks}>{ident}</List.Item>
                             ))}
                         </List>

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { Table } from '@navikt/ds-react';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 
+import { Lenke } from '../../../komponenter/Lenke';
 import { arkivtemaerTilTekst } from '../../../typer/arkivtema';
 import { DokumentInfo } from '../../../typer/dokument';
 import { journalstatuserTilTekst } from '../../../typer/journalpost';
 import { formaterNullableIsoDatoTid } from '../../../utils/dato';
-import { Lenke } from '../../../komponenter/Lenke';
 
 const DokumentRad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
     return (

--- a/src/frontend/typer/ressurs.ts
+++ b/src/frontend/typer/ressurs.ts
@@ -53,6 +53,15 @@ export const byggRessursSuksess = <T>(data: T): RessursSuksess<T> => {
     };
 };
 
+export const byggFeiletRessurs = <T>(melding: string, error?: Error): Ressurs<T> => {
+    return {
+        errorMelding: error ? error.message : undefined,
+        melding,
+        frontendFeilmelding: melding,
+        status: RessursStatus.FEILET,
+    };
+};
+
 export const pakkUtHvisSuksess = <T>(ressurs: Ressurs<T>) =>
     ressurs.status === RessursStatus.SUKSESS ? ressurs.data : undefined;
 

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -3,4 +3,5 @@ export enum Toggle {
     KAN_OPPRETTE_KLAGE = 'sak.kan-opprette-klage',
     SKAL_VISE_OPPGAVER_PERSONOVERSIKT = 'sak.vis-oppgaver-personoversikt',
     VIS_SIMULERING = 'sak.simulering',
+    KAN_OPPRETTE_BEHANDLING_FRA_JOURNALPOST = 'sak.kan-opprette-behandling-fra-journalpost',
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det finnes mange søknader som har kommit inn via fyll ut/send inn, som har fått opprettet en sak med vedtak som ikke har noe status ennå i Arena.
Disse skal behandles i ny løsning

For å kunne gjøre det er det ønskelig med en knapp som kan opprette en behandling fra journalpostId som henter barnen fra søknaden og oppretter en behandling med disse.
Skal ikke håndtere papirsøknad nå. Då barnen manuellt må legges inn. 


https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21648

https://github.com/navikt/tilleggsstonader-sak/blob/main/src/main/kotlin/no/nav/tilleggsstonader/sak/behandling/manuell/OpprettBehandlingFraJournalpostService.kt

### 1.
![image](https://github.com/user-attachments/assets/d729aff5-5078-4eff-8881-937c1277ba6b)

### 2.
![image](https://github.com/user-attachments/assets/42cba75e-9ad6-411c-bb2b-6d19f6c1df31)

### 3
![image](https://github.com/user-attachments/assets/8b3ffffb-dc1a-4050-9d71-195cf37c295d)
