### PR TITLE
✨ Dokumentoversikt i behandling

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/DokumentKomponenter.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/DokumentKomponenter.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { PaperclipIcon } from '@navikt/aksel-icons';
+import { BodyShort, HStack, Tag, VStack } from '@navikt/ds-react';
+
+import { Lenke } from '../../../../komponenter/Lenke';
+import { DokumentInfo } from '../../../../typer/dokument';
+import { Journalposttype } from '../../../../typer/journalpost';
+import { formaterDato } from '../../../../utils/dato';
+
+export const Hoveddokument: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
+    return (
+        <VStack>
+            <LenkeTilDokument dokument={dokument} />
+            <BodyShort size="small">{formaterDato(dokument.dato)}</BodyShort>
+        </VStack>
+    );
+};
+
+export const Vedlegg: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
+    return (
+        <HStack gap="2" wrap={false}>
+            <PaperclipIcon />
+            <LenkeTilDokument dokument={dokument} />
+        </HStack>
+    );
+};
+
+const LenkeTilDokument: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
+    return (
+        <Lenke
+            target="_blank"
+            href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentInfoId}`}
+        >
+            <BodyShort size="small">{dokument.tittel}</BodyShort>
+        </Lenke>
+    );
+};
+
+const StyledTag = styled(Tag).attrs({ size: 'small' })`
+    width: 22px;
+    height: 22px;
+`;
+
+export const DokumentTypeTag: React.FC<{ journalposttype: Journalposttype }> = ({
+    journalposttype,
+}) => {
+    switch (journalposttype) {
+        case 'I':
+            return <StyledTag variant="info">I</StyledTag>;
+        case 'N':
+            return <StyledTag variant="alt1">N</StyledTag>;
+        case 'U':
+            return <StyledTag variant="neutral">U</StyledTag>;
+    }
+};

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { PaperclipIcon } from '@navikt/aksel-icons';
+import { BodyShort, HStack, Tag, VStack } from '@navikt/ds-react';
+
+import { Lenke } from '../../../../komponenter/Lenke';
+import { DokumentInfo } from '../../../../typer/dokument';
+import { Journalposttype } from '../../../../typer/journalpost';
+import {
+    grupperDokumenterPåJournalpost,
+    sorterJournalpostPåTid,
+} from '../../../Personoversikt/Dokumentoversikt/utils';
+
+const Dokumentoversikt: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
+    const dokumenterGrupperPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
+    const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGrupperPåJournalpost);
+
+    return (
+        <VStack gap="6">
+            {journalposterSortertPåTid.map((journalpost) => {
+                const dokumenter = dokumenterGrupperPåJournalpost[journalpost];
+
+                return (
+                    <HStack gap="4" key={journalpost} wrap={false}>
+                        <DokumentTypeTag journalposttype={dokumenter[0].journalposttype} />
+                        <VStack gap="2">
+                            {dokumenter.map((dokument, indeks) => (
+                                <HStack wrap={false} key={dokument.dokumentInfoId} gap="2">
+                                    {indeks !== 0 && <PaperclipIcon />}
+                                    <Lenke
+                                        target="_blank"
+                                        href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentInfoId}`}
+                                    >
+                                        <BodyShort size="small">{dokument.tittel}</BodyShort>
+                                    </Lenke>
+                                </HStack>
+                            ))}
+                        </VStack>
+                    </HStack>
+                );
+            })}
+        </VStack>
+    );
+};
+
+export default Dokumentoversikt;
+
+const StyledTag = styled(Tag).attrs({ size: 'small' })`
+    width: 22px;
+    height: 22px;
+`;
+
+const DokumentTypeTag: React.FC<{ journalposttype: Journalposttype }> = ({ journalposttype }) => {
+    switch (journalposttype) {
+        case 'I':
+            return <StyledTag variant="info">I</StyledTag>;
+        case 'N':
+            return <StyledTag variant="alt1">N</StyledTag>;
+        case 'U':
+            return <StyledTag variant="neutral">U</StyledTag>;
+    }
+};

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
@@ -1,8 +1,10 @@
 import React from 'react';
 
-import { HStack, VStack } from '@navikt/ds-react';
+import { ExternalLinkIcon } from '@navikt/aksel-icons';
+import { Alert, HStack, Link, VStack } from '@navikt/ds-react';
 
 import { DokumentTypeTag, Hoveddokument, Vedlegg } from './DokumentKomponenter';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import { DokumentInfo } from '../../../../typer/dokument';
 import {
     grupperDokumenterPåJournalpost,
@@ -10,11 +12,13 @@ import {
 } from '../../../Personoversikt/Dokumentoversikt/utils';
 
 const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
+    const { behandling } = useBehandling();
+
     const dokumenterGruppertPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
     const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGruppertPåJournalpost);
 
     return (
-        <VStack gap="6">
+        <VStack gap="6" align="start">
             {journalposterSortertPåTid.map((journalpost) => {
                 const dokumenter = dokumenterGruppertPåJournalpost[journalpost];
 
@@ -35,6 +39,26 @@ const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter })
                     </HStack>
                 );
             })}
+            {/* <Button
+                variant="tertiary"
+                icon={<ExternalLinkIcon />}
+                size="small"
+                onClick={() => navigate(`/person/${behandling.fagsakPersonId}/dokumentoversikt`)}
+            >
+                Se flere dokumenter
+            </Button> */}
+            <Alert variant="info" inline size="small">
+                Vi viser bare TSO og TSR dokumenter her. Se{' '}
+                <Link
+                    variant="neutral"
+                    target="_blank"
+                    href={`/person/${behandling.fagsakPersonId}/dokumentoversikt`}
+                    inlineText
+                >
+                    dokumenter på flere temaer i personoversikten
+                    <ExternalLinkIcon />
+                </Link>
+            </Alert>
         </VStack>
     );
 };

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
@@ -10,13 +10,13 @@ import {
 } from '../../../Personoversikt/Dokumentoversikt/utils';
 
 const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
-    const dokumenterGrupertPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
-    const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGrupertPåJournalpost);
+    const dokumenterGruppertPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
+    const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGruppertPåJournalpost);
 
     return (
         <VStack gap="6">
             {journalposterSortertPåTid.map((journalpost) => {
-                const dokumenter = dokumenterGrupertPåJournalpost[journalpost];
+                const dokumenter = dokumenterGruppertPåJournalpost[journalpost];
 
                 return (
                     <HStack gap="4" key={journalpost} wrap={false}>

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
@@ -10,13 +10,13 @@ import {
 } from '../../../Personoversikt/Dokumentoversikt/utils';
 
 const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
-    const dokumenterGrupperPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
-    const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGrupperPåJournalpost);
+    const dokumenterGrupertPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
+    const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGrupertPåJournalpost);
 
     return (
         <VStack gap="6">
             {journalposterSortertPåTid.map((journalpost) => {
-                const dokumenter = dokumenterGrupperPåJournalpost[journalpost];
+                const dokumenter = dokumenterGrupertPåJournalpost[journalpost];
 
                 return (
                     <HStack gap="4" key={journalpost} wrap={false}>

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
@@ -13,7 +13,7 @@ import {
     sorterJournalpostPåTid,
 } from '../../../Personoversikt/Dokumentoversikt/utils';
 
-const Dokumentoversikt: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
+const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
     const dokumenterGrupperPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
     const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGrupperPåJournalpost);
 
@@ -45,7 +45,7 @@ const Dokumentoversikt: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter
     );
 };
 
-export default Dokumentoversikt;
+export default Dokumentliste;
 
 const StyledTag = styled(Tag).attrs({ size: 'small' })`
     width: 22px;

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { ExternalLinkIcon } from '@navikt/aksel-icons';
 import { Alert, HStack, Link, VStack } from '@navikt/ds-react';
 
 import { DokumentTypeTag, Hoveddokument, Vedlegg } from './DokumentKomponenter';
@@ -18,7 +17,19 @@ const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter })
     const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGruppertPåJournalpost);
 
     return (
-        <VStack gap="6" align="start">
+        <VStack gap="6">
+            <Alert variant="info" inline size="small">
+                Vi viser bare tema TSO og TSR her. Se flere dokumenter{' '}
+                <Link
+                    variant="neutral"
+                    target="_blank"
+                    href={`/person/${behandling.fagsakPersonId}/dokumentoversikt`}
+                    inlineText
+                >
+                    i personoversikten
+                </Link>
+                .
+            </Alert>
             {journalposterSortertPåTid.map((journalpost) => {
                 const dokumenter = dokumenterGruppertPåJournalpost[journalpost];
 
@@ -39,26 +50,6 @@ const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter })
                     </HStack>
                 );
             })}
-            {/* <Button
-                variant="tertiary"
-                icon={<ExternalLinkIcon />}
-                size="small"
-                onClick={() => navigate(`/person/${behandling.fagsakPersonId}/dokumentoversikt`)}
-            >
-                Se flere dokumenter
-            </Button> */}
-            <Alert variant="info" inline size="small">
-                Vi viser bare TSO og TSR dokumenter her. Se{' '}
-                <Link
-                    variant="neutral"
-                    target="_blank"
-                    href={`/person/${behandling.fagsakPersonId}/dokumentoversikt`}
-                    inlineText
-                >
-                    dokumenter på flere temaer i personoversikten
-                    <ExternalLinkIcon />
-                </Link>
-            </Alert>
         </VStack>
     );
 };

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentliste.tsx
@@ -1,13 +1,9 @@
 import React from 'react';
 
-import styled from 'styled-components';
+import { HStack, VStack } from '@navikt/ds-react';
 
-import { PaperclipIcon } from '@navikt/aksel-icons';
-import { BodyShort, HStack, Tag, VStack } from '@navikt/ds-react';
-
-import { Lenke } from '../../../../komponenter/Lenke';
+import { DokumentTypeTag, Hoveddokument, Vedlegg } from './DokumentKomponenter';
 import { DokumentInfo } from '../../../../typer/dokument';
-import { Journalposttype } from '../../../../typer/journalpost';
 import {
     grupperDokumenterPåJournalpost,
     sorterJournalpostPåTid,
@@ -28,13 +24,11 @@ const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter })
                         <VStack gap="2">
                             {dokumenter.map((dokument, indeks) => (
                                 <HStack wrap={false} key={dokument.dokumentInfoId} gap="2">
-                                    {indeks !== 0 && <PaperclipIcon />}
-                                    <Lenke
-                                        target="_blank"
-                                        href={`/dokument/journalpost/${dokument.journalpostId}/dokument-pdf/${dokument.dokumentInfoId}`}
-                                    >
-                                        <BodyShort size="small">{dokument.tittel}</BodyShort>
-                                    </Lenke>
+                                    {indeks === 0 ? (
+                                        <Hoveddokument dokument={dokument} />
+                                    ) : (
+                                        <Vedlegg dokument={dokument} />
+                                    )}
                                 </HStack>
                             ))}
                         </VStack>
@@ -46,19 +40,3 @@ const Dokumentliste: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter })
 };
 
 export default Dokumentliste;
-
-const StyledTag = styled(Tag).attrs({ size: 'small' })`
-    width: 22px;
-    height: 22px;
-`;
-
-const DokumentTypeTag: React.FC<{ journalposttype: Journalposttype }> = ({ journalposttype }) => {
-    switch (journalposttype) {
-        case 'I':
-            return <StyledTag variant="info">I</StyledTag>;
-        case 'N':
-            return <StyledTag variant="alt1">N</StyledTag>;
-        case 'U':
-            return <StyledTag variant="neutral">U</StyledTag>;
-    }
-};

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
@@ -4,7 +4,7 @@ import Dokumentliste from './Dokumentliste';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import DataViewer from '../../../../komponenter/DataViewer';
-import { relevanteArkivtemaer } from '../../../../typer/arkivtema';
+import { relevanteArkivtemaerIBehandling } from '../../../../typer/arkivtema';
 import { DokumentInfo, VedleggRequest } from '../../../../typer/dokument';
 import { Ressurs, byggTomRessurs } from '../../../../typer/ressurs';
 
@@ -19,7 +19,7 @@ const Dokumentoversikt: React.FC = () => {
             `/api/sak/vedlegg/fagsak-person/${behandling.fagsakPersonId}`,
             'POST',
             {
-                tema: relevanteArkivtemaer,
+                tema: relevanteArkivtemaerIBehandling,
             }
         ).then(settDokumenter);
     }, [request, behandling]);

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import Dokumentliste from './Dokumentliste';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import DataViewer from '../../../../komponenter/DataViewer';
@@ -25,13 +26,7 @@ const Dokumentoversikt: React.FC = () => {
 
     return (
         <DataViewer response={{ dokumenter }}>
-            {({ dokumenter }) => (
-                <ul>
-                    {dokumenter.map((dokument, index) => (
-                        <li key={dokument.journalpostId + index}>{dokument.tittel}</li>
-                    ))}
-                </ul>
-            )}
+            {({ dokumenter }) => <Dokumentliste dokumenter={dokumenter} />}
         </DataViewer>
     );
 };

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+
+import { useApp } from '../../../../context/AppContext';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import DataViewer from '../../../../komponenter/DataViewer';
+import { relevanteArkivtemaer } from '../../../../typer/arkivtema';
+import { DokumentInfo, VedleggRequest } from '../../../../typer/dokument';
+import { Ressurs, byggTomRessurs } from '../../../../typer/ressurs';
+
+const Dokumentoversikt: React.FC = () => {
+    const { request } = useApp();
+    const { behandling } = useBehandling();
+
+    const [dokumenter, settDokumenter] = useState<Ressurs<DokumentInfo[]>>(byggTomRessurs());
+
+    useEffect(() => {
+        request<DokumentInfo[], VedleggRequest>(
+            `/api/sak/vedlegg/fagsak-person/${behandling.fagsakPersonId}`,
+            'POST',
+            {
+                tema: relevanteArkivtemaer,
+            }
+        ).then(settDokumenter);
+    }, [request, behandling]);
+
+    return (
+        <DataViewer response={{ dokumenter }}>
+            {({ dokumenter }) => (
+                <ul>
+                    {dokumenter.map((dokument, index) => (
+                        <li key={dokument.journalpostId + index}>{dokument.tittel}</li>
+                    ))}
+                </ul>
+            )}
+        </DataViewer>
+    );
+};
+
+export default Dokumentoversikt;

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -21,16 +21,26 @@ const StickyTablistContainer = styled(Sticky)`
     border-right: 1px solid ${ABorderDefault};
 `;
 
+const Tab = styled(Tabs.Tab)`
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
+`;
+
 const tabs = [
     {
         value: 'søknaden',
-        label: 'Søknaden',
+        label: 'Søknad',
         komponent: <OppsummeringSøknad />,
     },
     {
         value: 'historikk',
         label: 'Historikk',
         komponent: <Historikk />,
+    },
+    {
+        value: 'dokumenter',
+        label: 'Dokumenter',
+        komponent: <div>Dokumenter</div>,
     },
 ];
 
@@ -42,7 +52,7 @@ const VenstreMeny: React.FC = () => {
                 <StickyTablistContainer>
                     <Tabs.List>
                         {tabs.map((tab) => (
-                            <Tabs.Tab label={tab.label} value={tab.value} key={tab.value} />
+                            <Tab label={tab.label} value={tab.value} key={tab.value} />
                         ))}
                     </Tabs.List>
                 </StickyTablistContainer>

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Box, Tabs } from '@navikt/ds-react';
 import { ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
 
+import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import Historikk from './Historikk/Historikk';
 import OppsummeringSøknad from './Oppsummering/OppsummeringSøknad';
 import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
@@ -40,7 +41,7 @@ const tabs = [
     {
         value: 'dokumenter',
         label: 'Dokumenter',
-        komponent: <div>Dokumenter</div>,
+        komponent: <Dokumentoversikt />,
     },
 ];
 

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentTabell.tsx
@@ -4,27 +4,13 @@ import { Table } from '@navikt/ds-react';
 
 import DokumentRad from './DokumentRad';
 import { Underrad } from './Underrad';
+import { grupperDokumenterPåJournalpost, sorterJournalpostPåTid } from './utils';
 import { DokumentInfo } from '../../../typer/dokument';
-import { groupBy } from '../../../utils/utils';
 
 export const DokumentTabell: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokumenter }) => {
-    const dokumentterGrupperPåJournalpost = groupBy(
-        dokumenter,
-        (dokument) => dokument.journalpostId
-    );
+    const dokumenterGrupperPåJournalpost = grupperDokumenterPåJournalpost(dokumenter);
+    const journalposterSortertPåTid = sorterJournalpostPåTid(dokumenterGrupperPåJournalpost);
 
-    const journalposterSortertPåTid = Object.keys(dokumentterGrupperPåJournalpost).sort(
-        function (a, b) {
-            const datoA = dokumentterGrupperPåJournalpost[a][0].dato;
-            const datoB = dokumentterGrupperPåJournalpost[b][0].dato;
-            if (!datoA) {
-                return -1;
-            } else if (!datoB) {
-                return 1;
-            }
-            return datoA > datoB ? -1 : 1;
-        }
-    );
     return (
         <Table size="small">
             <Table.Header>
@@ -39,7 +25,7 @@ export const DokumentTabell: React.FC<{ dokumenter: DokumentInfo[] }> = ({ dokum
             </Table.Header>
             <Table.Body>
                 {journalposterSortertPåTid.map((journalpost) =>
-                    dokumentterGrupperPåJournalpost[journalpost].map((dokument, indeks) =>
+                    dokumenterGrupperPåJournalpost[journalpost].map((dokument, indeks) =>
                         indeks === 0 ? (
                             <DokumentRad key={dokument.dokumentInfoId} dokument={dokument} />
                         ) : (

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -8,14 +8,8 @@ import { DokumentTabell } from './DokumentTabell';
 import { useApp } from '../../../context/AppContext';
 import DataViewer from '../../../komponenter/DataViewer';
 import { Arkivtema, arkivtemaerTilTekst, relevanteArkivtemaer } from '../../../typer/arkivtema';
-import { DokumentInfo } from '../../../typer/dokument';
+import { DokumentInfo, VedleggRequest } from '../../../typer/dokument';
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
-
-type VedleggRequest = {
-    tema: Arkivtema[];
-    journalposttype?: string;
-    journalstatus?: string;
-};
 
 const ComboBox = styled(UNSAFE_Combobox)`
     width: 35rem;

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/utils.ts
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/utils.ts
@@ -1,0 +1,19 @@
+import { DokumentInfo } from '../../../typer/dokument';
+import { groupBy } from '../../../utils/utils';
+
+export const grupperDokumenterPåJournalpost = (dokumenter: DokumentInfo[]) =>
+    groupBy(dokumenter, (dokument) => dokument.journalpostId);
+
+export const sorterJournalpostPåTid = (
+    dokumentterGrupperPåJournalpost: Record<string, DokumentInfo[]>
+) =>
+    Object.keys(dokumentterGrupperPåJournalpost).sort(function (a, b) {
+        const datoA = dokumentterGrupperPåJournalpost[a][0].dato;
+        const datoB = dokumentterGrupperPåJournalpost[b][0].dato;
+        if (!datoA) {
+            return -1;
+        } else if (!datoB) {
+            return 1;
+        }
+        return datoA > datoB ? -1 : 1;
+    });

--- a/src/frontend/typer/arkivtema.ts
+++ b/src/frontend/typer/arkivtema.ts
@@ -137,6 +137,7 @@ export const relevanteArkivtemaer: Arkivtema[] = [
     Arkivtema.OPP,
     Arkivtema.UFO,
     Arkivtema.YRK,
+    Arkivtema.KON,
 ];
 
 export const utledArkivtema = (tema: Arkivtema | undefined) =>

--- a/src/frontend/typer/arkivtema.ts
+++ b/src/frontend/typer/arkivtema.ts
@@ -140,5 +140,7 @@ export const relevanteArkivtemaer: Arkivtema[] = [
     Arkivtema.KON,
 ];
 
+export const relevanteArkivtemaerIBehandling: Arkivtema[] = [Arkivtema.TSO, Arkivtema.TSR];
+
 export const utledArkivtema = (tema: Arkivtema | undefined) =>
     tema ? arkivtemaerTilTekst[tema] : 'Tema ikke satt';

--- a/src/frontend/typer/dokument.ts
+++ b/src/frontend/typer/dokument.ts
@@ -47,3 +47,9 @@ type VarselSendt = {
     type: 'SMS' | 'EPOST';
     varslingstidspunkt?: string;
 };
+
+export type VedleggRequest = {
+    tema: Arkivtema[];
+    journalposttype?: string;
+    journalstatus?: string;
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Enkel tilgang til alle dokumenter og vedlegg fra en behandling. 

Har flyttet noen av funksjonene som er brukt i dokumentoversikten på personoversikten ut til utils for å kunne bruke begge steder. 

Henter alle "relevante" dokumenter (samme som dokumentoversikten)
<img width="339" alt="image" src="https://github.com/user-attachments/assets/6ad9a435-5e7c-4535-937e-e7cecb9b72c5">
