### PR TITLE
Fjern muligheten for å filtrere på personident, dette gjøres nå på pe…

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
-import { Button, Checkbox, Select, TextField, VStack } from '@navikt/ds-react';
+import { Button, Checkbox, Select, VStack } from '@navikt/ds-react';
 
 import { oppdaterFilter } from './filterutils';
 import { lagreTilLocalStorage, oppgaveRequestKey } from './oppgavefilterStorage';
@@ -127,19 +127,6 @@ export const Oppgavefiltrering = () => {
                 <SaksbehandlerVelger
                     oppgaveRequest={oppgaveRequest}
                     settOppgaveRequest={settOppgaveRequest}
-                />
-                <TextField
-                    value={oppgaveRequest.ident || ''}
-                    label="Personident"
-                    inputMode="numeric"
-                    onChange={oppdaterOppgaveTargetValue('ident')}
-                    onKeyDown={(e) => {
-                        if (e.key === 'Enter') {
-                            sjekkFeilOgHentOppgaver();
-                        }
-                    }}
-                    autoComplete="off"
-                    size="small"
                 />
                 <AlignetCheckbox
                     checked={oppgaveRequest['oppgaverPåVent'] || false}


### PR DESCRIPTION
…rsonoversikt

### Hvorfor er denne endringen nødvendig? ✨
Pga. forvirring mellom forskjellen på resultatet ved filtrering på personident i oppgavebenk og søk på person (personoversikt) fjernes feltet. 

Alle oppgaver på en person kan ses i personoversikten til en person. 

<img width="1332" alt="image" src="https://github.com/user-attachments/assets/fda445f7-2e4f-4d01-ba45-58f246ca51b3">
