### PR TITLE
AAP-perioder info om aktivitetsfase ferdig avklart 

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { Alert, Detail, HStack, HelpText, VStack } from '@navikt/ds-react';
+import { Alert, Detail, HelpText, HStack, Link, VStack } from '@navikt/ds-react';
 
 import RegisterYtelserTabell from './RegisterYtelserTabell';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import ExpansionCard from '../../../../komponenter/ExpansionCard';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../../utils/dato';
 import { VilkårperioderGrunnlag, YtelseGrunnlagPeriode } from '../typer/vilkårperiode';
@@ -11,6 +12,7 @@ const RegisterYtelser: React.FC<{
     grunnlag: VilkårperioderGrunnlag | undefined;
     lagRadForPeriode: (valgPeriode: YtelseGrunnlagPeriode) => void;
 }> = ({ grunnlag, lagRadForPeriode }) => {
+    const { behandling } = useBehandling();
     if (!grunnlag) {
         return (
             <Alert variant={'info'} inline size="small">
@@ -43,15 +45,27 @@ const RegisterYtelser: React.FC<{
                         perioderMedYtelse={perioderMedYtelse}
                         lagRadForPeriode={lagRadForPeriode}
                     />
-                    <HStack gap="2" align="center">
+                    <VStack>
+                        <HStack gap="2" align="center">
+                            <Detail>
+                                <strong>{opplysningerHentetTekst}</strong>
+                            </Detail>
+                            <HelpText>
+                                Vi henter kun perioder med arbeidsavklaringspenger, rett til
+                                overgangsstønad og omstillingsstønad.
+                            </HelpText>
+                        </HStack>
                         <Detail>
-                            <strong>{opplysningerHentetTekst}</strong>
+                            <Link
+                                href={`/person/${behandling.fagsakPersonId}/ytelser`}
+                                target="_blank"
+                                variant={'neutral'}
+                            >
+                                Se flere ytelser bruker mottar
+                            </Link>{' '}
+                            i personoversikten.
                         </Detail>
-                        <HelpText>
-                            Vi henter kun perioder med arbeidsavklaringspenger, rett til
-                            overgangsstønad og omstillingsstønad.
-                        </HelpText>
-                    </HStack>
+                    </VStack>
                 </VStack>
             </ExpansionCard>
         </VStack>

--- a/src/frontend/Sider/Personoversikt/Ytelseoversikt/YtelserTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Ytelseoversikt/YtelserTabell.tsx
@@ -25,7 +25,10 @@ const YtelserTabell: React.FC<{ perioder: PeriodeYtelseRegister[] }> = ({ period
                 {perioder.map((periode, indeks) => {
                     return (
                         <Table.Row key={indeks}>
-                            <Table.DataCell>{registerYtelseTilTekst[periode.type]}</Table.DataCell>
+                            <Table.DataCell>
+                                {registerYtelseTilTekst[periode.type]}
+                                {periode.aapErFerdigAvklart && ` (Ferdig avklart)`}
+                            </Table.DataCell>
                             <Table.DataCell>{formaterIsoDato(periode.fom)}</Table.DataCell>
                             <Table.DataCell>
                                 {formaterNullableIsoDato(periode.tom) ?? 'Mangler tom'}

--- a/src/frontend/typer/registerytelser.ts
+++ b/src/frontend/typer/registerytelser.ts
@@ -10,6 +10,7 @@ export interface PeriodeYtelseRegister {
     type: TypeRegisterYtelse;
     fom: string;
     tom?: string;
+    aapErFerdigAvklart?: boolean;
 }
 
 export interface HentetInformasjon {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi henter perioder fra AAP som gir rett på våre stønader
Dersom en periode har aktivitetsfase "ferdig avklart" gir den ikke rett på tilsyn barn.

Dersom man henter periodene til personoversikten er det fortsatt ønskelig å vise informasjonen.
Dersom man henter de som grunnlag til behandlingen så er det ikke ønskelig å vise de.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21588

* https://github.com/navikt/tilleggsstonader-integrasjoner/pull/109
* https://github.com/navikt/tilleggsstonader-sak/pull/388

<img width="721" alt="image" src="https://github.com/user-attachments/assets/b0c2b812-c514-4f72-aebd-072a69fe4381">
