### PR TITLE
Veiledere skal ikke kunne utføre endringer på en behandling

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -71,7 +71,11 @@ const BehandlingTabsInnhold = () => {
     const behandlingFaner = hentBehandlingfaner(behandling, visSimulering);
 
     return (
-        <StegProvider fane={aktivFane} behandling={behandling}>
+        <StegProvider
+            fane={aktivFane}
+            behandling={behandling}
+            behandlingErRedigerbar={behandlingErRedigerbar}
+        >
             <Tabs value={aktivFane} onChange={(e) => håndterFaneBytte(e as FanePath)}>
                 <StickyTablistContainer>
                     <TabsList>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
@@ -5,6 +5,7 @@ import { Link } from 'react-router-dom';
 import { Button, Table } from '@navikt/ds-react';
 
 import HenleggModal from './HenleggModal';
+import { useApp } from '../../../context/AppContext';
 import { Behandling } from '../../../typer/behandling/behandling';
 import { BehandlingResultat } from '../../../typer/behandling/behandlingResultat';
 import {
@@ -43,7 +44,9 @@ interface Props {
 }
 
 const BehandlingTabell: React.FC<Props> = ({ tabellbehandlinger, hentBehandlinger }) => {
+    const { erSaksbehandler } = useApp();
     const skalViseHenleggKnapp = (behandling: TabellBehandling) =>
+        erSaksbehandler &&
         behandling.type !== BehandlingType.KLAGE &&
         erBehandlingRedigerbar(behandling.status as BehandlingStatus);
 

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
@@ -1,6 +1,5 @@
 import React from 'react';
 
-import { useFlag } from '@unleash/proxy-client-react';
 import { styled } from 'styled-components';
 
 import { BodyShort, Heading, Tag } from '@navikt/ds-react';
@@ -8,7 +7,6 @@ import { BodyShort, Heading, Tag } from '@navikt/ds-react';
 import BehandlingTabell, { TabellBehandling } from './BehandlingTabell';
 import OpprettNyBehandlingModal from './OpprettNyBehandling/OpprettNyBehandlingModal';
 import { Stønadstype, stønadstypeTilTekst } from '../../../typer/behandling/behandlingTema';
-import { Toggle } from '../../../utils/toggles';
 
 const Container = styled.div`
     display: flex;
@@ -41,8 +39,6 @@ export const FagsakOversikt: React.FC<Props> = ({
     hentBehandlinger,
     hentKlagebehandlinger,
 }) => {
-    const kanOppretteKlage = useFlag(Toggle.KAN_OPPRETTE_KLAGE);
-
     return (
         <Container>
             <TittelLinje>
@@ -60,13 +56,11 @@ export const FagsakOversikt: React.FC<Props> = ({
                 tabellbehandlinger={tabellbehandlinger}
                 hentBehandlinger={hentBehandlinger}
             />
-            {kanOppretteKlage && (
-                <OpprettNyBehandlingModal
-                    fagsakId={fagsakId}
-                    hentKlagebehandlinger={hentKlagebehandlinger}
-                    hentBehandlinger={hentBehandlinger}
-                />
-            )}
+            <OpprettNyBehandlingModal
+                fagsakId={fagsakId}
+                hentKlagebehandlinger={hentKlagebehandlinger}
+                hentBehandlinger={hentBehandlinger}
+            />
         </Container>
     );
 };

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -6,6 +6,7 @@ import { Button, Select, VStack } from '@navikt/ds-react';
 
 import OpprettKlageBehandling from './OpprettKlageBehandling';
 import OpprettRevurderingBehandling from './OpprettRevurderingBehandling';
+import { useApp } from '../../../../context/AppContext';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import {
     BehandlingType,
@@ -24,6 +25,7 @@ const OpprettNyBehandlingModal: FC<Props> = ({
     hentKlagebehandlinger,
     hentBehandlinger,
 }) => {
+    const { erSaksbehandler } = useApp();
     const [visModal, settVisModal] = useState(false);
     const [behandlingtype, settBehandlingtype] = useState<BehandlingType>();
 
@@ -33,6 +35,10 @@ const OpprettNyBehandlingModal: FC<Props> = ({
         settVisModal(false);
         settBehandlingtype(undefined);
     };
+
+    if (!erSaksbehandler) {
+        return null;
+    }
 
     return (
         <div className="py-16">

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -30,6 +30,7 @@ const OpprettNyBehandlingModal: FC<Props> = ({
     const [behandlingtype, settBehandlingtype] = useState<BehandlingType>();
 
     const kanOppretteRevurdering = useFlag(Toggle.KAN_OPPRETTE_REVURDERING);
+    const kanOppretteKlage = useFlag(Toggle.KAN_OPPRETTE_KLAGE);
 
     const lukkModal = () => {
         settVisModal(false);
@@ -37,6 +38,9 @@ const OpprettNyBehandlingModal: FC<Props> = ({
     };
 
     if (!erSaksbehandler) {
+        return null;
+    }
+    if (!kanOppretteKlage && !kanOppretteRevurdering) {
         return null;
     }
 
@@ -57,7 +61,7 @@ const OpprettNyBehandlingModal: FC<Props> = ({
                         <option value={''}>Velg</option>
                         {[
                             ...(kanOppretteRevurdering ? [BehandlingType.REVURDERING] : []),
-                            BehandlingType.KLAGE,
+                            ...(kanOppretteKlage ? [BehandlingType.KLAGE] : []),
                         ].map((type) => (
                             <option key={type} value={type}>
                                 {behandlingTypeTilTekst[type]}

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -12,6 +12,7 @@ import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import FrittståendeBrevFane from './FrittståendeBrev/FrittståendeBrevFane';
 import Oppgaveoversikt from './Oppgaveoversikt/Oppgaveoversikt';
 import Ytelseoversikt from './Ytelseoversikt/Ytelseoversikt';
+import { useApp } from '../../context/AppContext';
 import { Toggle } from '../../utils/toggles';
 
 type TabWithRouter = {
@@ -62,12 +63,14 @@ const InnholdWrapper = styled.div`
 `;
 
 const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
+    const { erSaksbehandler } = useApp();
     const navigate = useNavigate();
 
     const paths = useLocation().pathname.split('/').slice(-1);
     const path = paths.length ? paths[paths.length - 1] : '';
 
-    const skalViseOppgaveTab = useFlag(Toggle.SKAL_VISE_OPPGAVER_PERSONOVERSIKT);
+    const toggleSkalViseOppgaveTab = useFlag(Toggle.SKAL_VISE_OPPGAVER_PERSONOVERSIKT);
+    const skalViseOppgaveTab = erSaksbehandler && toggleSkalViseOppgaveTab;
 
     const tabsSomSkalVises = [...(skalViseOppgaveTab ? [oppgaveTab] : []), ...tabs];
 

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -1,5 +1,6 @@
 import constate from 'constate';
 
+import { useApp } from './AppContext';
 import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
 import { Behandling } from '../typer/behandling/behandling';
 import { BehandlingFakta } from '../typer/behandling/behandlingFakta/behandlingFakta';
@@ -13,8 +14,9 @@ interface Props {
 
 export const [BehandlingProvider, useBehandling] = constate(
     ({ behandling, hentBehandling, behandlingFakta }: Props) => {
-        const behandlingErRedigerbar = erBehandlingRedigerbar(behandling.status);
+        const { erSaksbehandler } = useApp();
 
+        const behandlingErRedigerbar = erBehandlingRedigerbar(behandling.status) && erSaksbehandler;
         return {
             behandling,
             behandlingErRedigerbar,

--- a/src/frontend/context/StegContext.ts
+++ b/src/frontend/context/StegContext.ts
@@ -2,18 +2,20 @@ import constate from 'constate';
 
 import { FanePath, faneTilSteg } from '../Sider/Behandling/faner';
 import { Behandling } from '../typer/behandling/behandling';
-import { erBehandlingRedigerbar } from '../typer/behandling/behandlingStatus';
 
 interface Props {
     fane: FanePath | undefined;
     behandling: Behandling;
+    behandlingErRedigerbar: boolean;
 }
 
-export const [StegProvider, useSteg] = constate(({ fane, behandling }: Props) => {
-    const erISteg = fane && behandling.steg === faneTilSteg[fane];
-    const erStegRedigerbart = erISteg && erBehandlingRedigerbar(behandling.status);
+export const [StegProvider, useSteg] = constate(
+    ({ fane, behandling, behandlingErRedigerbar }: Props) => {
+        const erISteg = fane && behandling.steg === faneTilSteg[fane];
+        const erStegRedigerbart = erISteg && behandlingErRedigerbar;
 
-    return {
-        erStegRedigerbart,
-    };
-});
+        return {
+            erStegRedigerbart,
+        };
+    }
+);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Nå vises endringsknapper inne på en behandling for de som kun er veileder, som ikke er ønskelig. 

Usikker på om vi må skjule oppgaver for veiledere, men ettersom ikke oppgavebenken vises for veiledere fjerner jeg den fra personoversikten og. 