### PR TITLE
Oppgaver fra Arena i personoversikten

### DIFF
--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgavelisteArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgavelisteArena.tsx
@@ -5,10 +5,9 @@ import styled from 'styled-components';
 import { Table } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
-import { målgruppeArenaTilTekst, OppgaveArena } from './typer';
+import { OppgaveArena } from './typer';
 import { FlexColumn } from '../../../../komponenter/Visningskomponenter/Flex';
 import { formaterNullableIsoDato } from '../../../../utils/dato';
-import { tekstEllerKode } from '../../../../utils/tekstformatering';
 
 const Tabell = styled(Table)`
     max-width: 900px;
@@ -26,11 +25,9 @@ const OppgavelisteArena: React.FC<{
             <Tabell size="small">
                 <Table.Header>
                     <Table.Row>
-                        <Table.ColumnHeader>Oppgavetype</Table.ColumnHeader>
-                        <Table.ColumnHeader>Stønad</Table.ColumnHeader>
+                        <Table.ColumnHeader>Tittel</Table.ColumnHeader>
                         <Table.ColumnHeader>Opprettet</Table.ColumnHeader>
-                        <Table.ColumnHeader>Mappe</Table.ColumnHeader>
-                        <Table.ColumnHeader>Frist</Table.ColumnHeader>
+                        <Table.ColumnHeader>Benk</Table.ColumnHeader>
                         <Table.ColumnHeader>Tildelt</Table.ColumnHeader>
                         <Table.ColumnHeader />
                     </Table.Row>
@@ -40,15 +37,9 @@ const OppgavelisteArena: React.FC<{
                         <Table.Row key={oppgave.id}>
                             <Table.DataCell>{oppgave.tittel}</Table.DataCell>
                             <Table.DataCell>
-                                {tekstEllerKode(målgruppeArenaTilTekst, oppgave.målgruppe)}
-                            </Table.DataCell>
-                            <Table.DataCell>
                                 {formaterNullableIsoDato(oppgave.opprettetTidspunkt)}
                             </Table.DataCell>
                             <Table.DataCell>{oppgave.benk}</Table.DataCell>
-                            <Table.DataCell>
-                                {formaterNullableIsoDato(oppgave.fristFerdigstillelse)}
-                            </Table.DataCell>
                             <Table.DataCell>{oppgave.tildelt}</Table.DataCell>
                         </Table.Row>
                     ))}

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgavelisteArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgavelisteArena.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Table } from '@navikt/ds-react';
+import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
+
+import { målgruppeArenaTilTekst, OppgaveArena } from './typer';
+import { FlexColumn } from '../../../../komponenter/Visningskomponenter/Flex';
+import { formaterNullableIsoDato } from '../../../../utils/dato';
+import { tekstEllerKode } from '../../../../utils/tekstformatering';
+
+const Tabell = styled(Table)`
+    max-width: 900px;
+    border: 1px solid ${ABorderDivider};
+    --ac-table-row-border: ${ABorderDivider};
+    --ac-table-row-hover: none;
+    --ac-table-cell-hover-border: ${ABorderDivider};
+`;
+
+const OppgavelisteArena: React.FC<{
+    oppgaver: OppgaveArena[];
+}> = ({ oppgaver }) => {
+    return (
+        <FlexColumn>
+            <Tabell size="small">
+                <Table.Header>
+                    <Table.Row>
+                        <Table.ColumnHeader>Oppgavetype</Table.ColumnHeader>
+                        <Table.ColumnHeader>Stønad</Table.ColumnHeader>
+                        <Table.ColumnHeader>Opprettet</Table.ColumnHeader>
+                        <Table.ColumnHeader>Mappe</Table.ColumnHeader>
+                        <Table.ColumnHeader>Frist</Table.ColumnHeader>
+                        <Table.ColumnHeader>Tildelt</Table.ColumnHeader>
+                        <Table.ColumnHeader />
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {oppgaver.map((oppgave) => (
+                        <Table.Row key={oppgave.id}>
+                            <Table.DataCell>{oppgave.tittel}</Table.DataCell>
+                            <Table.DataCell>
+                                {tekstEllerKode(målgruppeArenaTilTekst, oppgave.målgruppe)}
+                            </Table.DataCell>
+                            <Table.DataCell>
+                                {formaterNullableIsoDato(oppgave.opprettetTidspunkt)}
+                            </Table.DataCell>
+                            <Table.DataCell>{oppgave.benk}</Table.DataCell>
+                            <Table.DataCell>
+                                {formaterNullableIsoDato(oppgave.fristFerdigstillelse)}
+                            </Table.DataCell>
+                            <Table.DataCell>{oppgave.tildelt}</Table.DataCell>
+                        </Table.Row>
+                    ))}
+                </Table.Body>
+            </Tabell>
+        </FlexColumn>
+    );
+};
+
+export default OppgavelisteArena;

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Button } from '@navikt/ds-react';
+import { Button, Heading, VStack } from '@navikt/ds-react';
 
 import OppgavelisteArena from './OppgavelisteArena';
 import { OppgaveArena } from './typer';
@@ -26,21 +26,24 @@ const OppgaverArena: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId })
     }, []);
 
     return (
-        <DataViewer response={{ oppgaveResponse }}>
-            {({ oppgaveResponse }) => (
-                <>
-                    <OppgavelisteArena oppgaver={oppgaveResponse} />
-                    <Button
-                        onClick={() => hentOppgaver()}
-                        size="small"
-                        variant="secondary"
-                        style={{ maxWidth: 'fit-content' }}
-                    >
-                        Hent oppgaver på nytt
-                    </Button>
-                </>
-            )}
-        </DataViewer>
+        <VStack gap={'2'}>
+            <Heading size={'xsmall'}>Arena</Heading>
+            <DataViewer response={{ oppgaveResponse }}>
+                {({ oppgaveResponse }) => (
+                    <>
+                        <OppgavelisteArena oppgaver={oppgaveResponse} />
+                        <Button
+                            onClick={() => hentOppgaver()}
+                            size="small"
+                            variant="secondary"
+                            style={{ maxWidth: 'fit-content' }}
+                        >
+                            Hent oppgaver på nytt
+                        </Button>
+                    </>
+                )}
+            </DataViewer>
+        </VStack>
     );
 };
 

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
@@ -1,0 +1,47 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import { Button } from '@navikt/ds-react';
+
+import OppgavelisteArena from './OppgavelisteArena';
+import { OppgaveArena } from './typer';
+import { useApp } from '../../../../context/AppContext';
+import DataViewer from '../../../../komponenter/DataViewer';
+import { Ressurs, byggTomRessurs } from '../../../../typer/ressurs';
+
+const OppgaverArena: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
+    const { request } = useApp();
+
+    const [oppgaveResponse, settOppgaveResponse] =
+        useState<Ressurs<OppgaveArena[]>>(byggTomRessurs());
+
+    const hentOppgaver = useCallback(() => {
+        request<OppgaveArena[], null>(`/api/sak/oppgave/arena/${fagsakPersonId}`).then(
+            settOppgaveResponse
+        );
+    }, [request, fagsakPersonId]);
+
+    useEffect(() => {
+        hentOppgaver();
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <DataViewer response={{ oppgaveResponse }}>
+            {({ oppgaveResponse }) => (
+                <>
+                    <OppgavelisteArena oppgaver={oppgaveResponse} />
+                    <Button
+                        onClick={() => hentOppgaver()}
+                        size="small"
+                        variant="secondary"
+                        style={{ maxWidth: 'fit-content' }}
+                    >
+                        Hent oppgaver på nytt
+                    </Button>
+                </>
+            )}
+        </DataViewer>
+    );
+};
+
+export default OppgaverArena;

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/typer.ts
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/typer.ts
@@ -1,0 +1,34 @@
+export interface OppgaveArena {
+    id: number;
+    tittel: string;
+    kommentar: string;
+    fristFerdigstillelse: string;
+    benk?: string;
+    tildelt?: string;
+    opprettetTidspunkt: string;
+    målgruppe?: MålgruppeArena;
+}
+
+enum MålgruppeArena {
+    ARBEIDSSØKER = 'ARBEIDSSØKER',
+    ENSLIG_FORSØRGER_SØKER_ARBEID = 'ENSLIG_FORSØRGER_SØKER_ARBEID',
+    ENSLIG_FORSØRGER_UTDANNING = 'ENSLIG_FORSØRGER_UTDANNING',
+    GJENLEVENDE_SØKER_ARBEID = 'GJENLEVENDE_SØKER_ARBEID',
+    GJENLEVENDE_UTDANNING = 'GJENLEVENDE_UTDANNING',
+    DAGPENGER = 'DAGPENGER',
+    TILTAKSPENGER = 'TILTAKSPENGER',
+    NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
+    TIDLIGERE_FAMILIEPLEIER_UTDANNING = 'TIDLIGERE_FAMILIEPLEIER_UTDANNING',
+}
+
+export const målgruppeArenaTilTekst: Record<MålgruppeArena, string> = {
+    ARBEIDSSØKER: 'Arbeidssøker',
+    ENSLIG_FORSØRGER_SØKER_ARBEID: 'Enslig forsørger - arbeidssøker',
+    ENSLIG_FORSØRGER_UTDANNING: 'Enslig forsørger - under utdanning',
+    GJENLEVENDE_SØKER_ARBEID: 'Gjenlevende - arbeidssøker',
+    GJENLEVENDE_UTDANNING: 'Gjenlevende - under utdanning',
+    DAGPENGER: 'Dagpenger',
+    TILTAKSPENGER: 'Tiltakspenger',
+    NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
+    TIDLIGERE_FAMILIEPLEIER_UTDANNING: 'Tidligere familiepleier',
+};

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/typer.ts
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/typer.ts
@@ -2,33 +2,7 @@ export interface OppgaveArena {
     id: number;
     tittel: string;
     kommentar: string;
-    fristFerdigstillelse: string;
     benk?: string;
     tildelt?: string;
     opprettetTidspunkt: string;
-    målgruppe?: MålgruppeArena;
 }
-
-enum MålgruppeArena {
-    ARBEIDSSØKER = 'ARBEIDSSØKER',
-    ENSLIG_FORSØRGER_SØKER_ARBEID = 'ENSLIG_FORSØRGER_SØKER_ARBEID',
-    ENSLIG_FORSØRGER_UTDANNING = 'ENSLIG_FORSØRGER_UTDANNING',
-    GJENLEVENDE_SØKER_ARBEID = 'GJENLEVENDE_SØKER_ARBEID',
-    GJENLEVENDE_UTDANNING = 'GJENLEVENDE_UTDANNING',
-    DAGPENGER = 'DAGPENGER',
-    TILTAKSPENGER = 'TILTAKSPENGER',
-    NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
-    TIDLIGERE_FAMILIEPLEIER_UTDANNING = 'TIDLIGERE_FAMILIEPLEIER_UTDANNING',
-}
-
-export const målgruppeArenaTilTekst: Record<MålgruppeArena, string> = {
-    ARBEIDSSØKER: 'Arbeidssøker',
-    ENSLIG_FORSØRGER_SØKER_ARBEID: 'Enslig forsørger - arbeidssøker',
-    ENSLIG_FORSØRGER_UTDANNING: 'Enslig forsørger - under utdanning',
-    GJENLEVENDE_SØKER_ARBEID: 'Gjenlevende - arbeidssøker',
-    GJENLEVENDE_UTDANNING: 'Gjenlevende - under utdanning',
-    DAGPENGER: 'Dagpenger',
-    TILTAKSPENGER: 'Tiltakspenger',
-    NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
-    TIDLIGERE_FAMILIEPLEIER_UTDANNING: 'Tidligere familiepleier',
-};

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { useFlag } from '@unleash/proxy-client-react';
 
+import { VStack } from '@navikt/ds-react';
+
 import OppgaverArena from './Arena/OppgaverArena';
 import Oppgaver from './Oppgaver';
 import { Toggle } from '../../../utils/toggles';
@@ -10,10 +12,10 @@ const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId 
     const skalHenteArenaOppgaver = useFlag(Toggle.ARENA_OPPGAVER);
 
     return (
-        <>
+        <VStack gap={'8'}>
             <Oppgaver fagsakPersonId={fagsakPersonId} />
             {skalHenteArenaOppgaver && <OppgaverArena fagsakPersonId={fagsakPersonId} />}
-        </>
+        </VStack>
     );
 };
 

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveoversikt.tsx
@@ -1,11 +1,18 @@
 import React from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
+
+import OppgaverArena from './Arena/OppgaverArena';
 import Oppgaver from './Oppgaver';
+import { Toggle } from '../../../utils/toggles';
 
 const Oppgaveoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
+    const skalHenteArenaOppgaver = useFlag(Toggle.ARENA_OPPGAVER);
+
     return (
         <>
             <Oppgaver fagsakPersonId={fagsakPersonId} />
+            {skalHenteArenaOppgaver && <OppgaverArena fagsakPersonId={fagsakPersonId} />}
         </>
     );
 };

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Button } from '@navikt/ds-react';
+import { Button, Heading, VStack } from '@navikt/ds-react';
 
 import Oppgaveliste from './Oppgaveliste';
 import { mapperTilIdRecord } from './utils';
@@ -38,25 +38,28 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     };
 
     return (
-        <DataViewer response={{ oppgaveResponse, mapper }}>
-            {({ oppgaveResponse, mapper }) => (
-                <>
-                    <Oppgaveliste
-                        oppgaver={oppgaveResponse.oppgaver}
-                        mapper={mapperTilIdRecord(mapper)}
-                        oppdaterOppgaveEtterOppdatering={oppdaterOppgaveEtterOppdatering}
-                    />
-                    <Button
-                        onClick={() => hentOppgaverOgMapper()}
-                        size="small"
-                        variant="secondary"
-                        style={{ maxWidth: 'fit-content' }}
-                    >
-                        Hent oppgaver på nytt
-                    </Button>
-                </>
-            )}
-        </DataViewer>
+        <VStack gap={'2'}>
+            <Heading size={'xsmall'}>TS-sak og GOSYS</Heading>
+            <DataViewer response={{ oppgaveResponse, mapper }}>
+                {({ oppgaveResponse, mapper }) => (
+                    <>
+                        <Oppgaveliste
+                            oppgaver={oppgaveResponse.oppgaver}
+                            mapper={mapperTilIdRecord(mapper)}
+                            oppdaterOppgaveEtterOppdatering={oppdaterOppgaveEtterOppdatering}
+                        />
+                        <Button
+                            onClick={() => hentOppgaverOgMapper()}
+                            size="small"
+                            variant="secondary"
+                            style={{ maxWidth: 'fit-content' }}
+                        >
+                            Hent oppgaver på nytt
+                        </Button>
+                    </>
+                )}
+            </DataViewer>
+        </VStack>
     );
 };
 

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -5,4 +5,5 @@ export enum Toggle {
     VIS_SIMULERING = 'sak.simulering',
     KAN_OPPRETTE_BEHANDLING_FRA_JOURNALPOST = 'sak.kan-opprette-behandling-fra-journalpost',
     KAN_OPPDATERE_GRUNNLAG_VILKÅRPERIODE = 'sak.kan-oppdatere-grunnlag-vilkarperiode',
+    ARENA_OPPGAVER = 'sak.frontend.arena-oppgaver',
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å kunne vise oppgaver i Arena i personoversikten for å kunne vite om personen har åpne oppgaver i Arena

* https://github.com/navikt/tilleggsstonader-arena/pull/35
* https://github.com/navikt/tilleggsstonader-sak/pull/393

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21779

<img width="965" alt="image" src="https://github.com/user-attachments/assets/10665f81-46a9-4490-8df9-bb08a1dea74f">
