### PR TITLE
Admin opprett førstegangsbehandling

### DIFF
--- a/src/frontend/App.tsx
+++ b/src/frontend/App.tsx
@@ -101,9 +101,7 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
     innloggetSaksbehandler,
 }) => {
     const { loggUt } = useApp();
-    const kanOppretteBehandlingFraJournalpost = useFlag(
-        Toggle.KAN_OPPRETTE_BEHANDLING_FRA_JOURNALPOST
-    );
+    const adminKanOppretteBehandling = useFlag(Toggle.ADMIN_KAN_OPPRETTE_BEHANDLING);
     return (
         <>
             <Sticky $zIndex={100}>
@@ -129,7 +127,7 @@ const AppInnhold: React.FC<{ innloggetSaksbehandler: Saksbehandler }> = ({
                         />
                         <Dropdown.Menu>
                             <Dropdown.Menu.List>
-                                {kanOppretteBehandlingFraJournalpost && (
+                                {adminKanOppretteBehandling && (
                                     <Dropdown.Menu.GroupedList.Item
                                         as="a"
                                         href="/admin/opprett-behandling"

--- a/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
+++ b/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
@@ -91,7 +91,7 @@ const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
     return (
         <Container>
             <div>
-                <Heading size={'medium'}>[Admin] Opprett førstegangsbehandling</Heading>
+                <Heading size={'medium'}>[Admin] Opprett førstegangsbehandling Tilsyn barn</Heading>
                 <Detail>Opprett en førstegangsbehandling med fødelsnummer.</Detail>
                 <Detail>Man må velge hvilke barn som skal være med i behandlingen.</Detail>
             </div>

--- a/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
+++ b/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
@@ -4,11 +4,12 @@ import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
 import {
+    BodyShort,
     Button,
     Checkbox,
     CheckboxGroup,
-    Detail,
     Heading,
+    List,
     TextField,
     VStack,
 } from '@navikt/ds-react';
@@ -70,10 +71,6 @@ const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
     };
 
     const opprettBehandling = () => {
-        if (!valgteBarn.length) {
-            settOpprettBehandlingResponse(byggFeiletRessurs('Må velge minimum 1 barn.'));
-            return;
-        }
         settOpprettBehandlingResponse(byggHenterRessurs());
         request<Personinfo, OpprettFørstegansbehandlingRequest>(
             `/api/sak/behandling/admin/opprett-foerstegangsbehandling`,
@@ -92,8 +89,23 @@ const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
         <Container>
             <div>
                 <Heading size={'medium'}>[Admin] Opprett førstegangsbehandling Tilsyn barn</Heading>
-                <Detail>Opprett en førstegangsbehandling med fødelsnummer.</Detail>
-                <Detail>Man må velge hvilke barn som skal være med i behandlingen.</Detail>
+                <VStack gap={'2'}>
+                    <BodyShort>
+                        Enkelte ganger vil det være behov for å opprette en førstegangsbehandling
+                        manuelt. Du søker da først opp brukers fødselsnummer og velger deretter
+                        hvilke barn det er søkt stønad for slik at disse blir med i behandlingen.
+                    </BodyShort>
+                    <BodyShort size={'small'}>
+                        Det er primært for å opprette førstegangsbehandling for allerede
+                        journalførte søknader.
+                    </BodyShort>
+                    <List size={'small'}>
+                        <List.Item>Papirsøknad</List.Item>
+                        <List.Item>Søknad om barnetilsyn fra enslig forsørger</List.Item>
+                        <List.Item>Søknad som blitt sendt inn til Arena</List.Item>
+                    </List>
+                    <BodyShort>Hvis du er usikker, spør på teams.</BodyShort>
+                </VStack>
             </div>
             <VStack gap={'1'}>
                 <TextField
@@ -105,12 +117,7 @@ const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
                         settOpprettBehandlingResponse(byggTomRessurs());
                     }}
                 />
-                <Button
-                    variant={'primary'}
-                    size={'small'}
-                    disabled={!ident.trim()}
-                    onClick={hentPersoninfo}
-                >
+                <Button variant={'secondary'} size={'small'} onClick={hentPersoninfo}>
                     Hent barn til person
                 </Button>
             </VStack>
@@ -120,7 +127,7 @@ const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
                     <>
                         <Heading size={'small'}>Informasjon om søker</Heading>
                         <CheckboxGroup
-                            legend={'Barn til søker'}
+                            legend={'Velg barn fra søknad'}
                             onChange={(values) => settValgteBarn(values)}
                         >
                             {personinfo.barn.map(({ ident, navn }) => (
@@ -129,7 +136,7 @@ const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
                                 </Checkbox>
                             ))}
                         </CheckboxGroup>
-                        <Button variant={'secondary'} size={'small'} onClick={opprettBehandling}>
+                        <Button variant={'primary'} size={'small'} onClick={opprettBehandling}>
                             Opprett behandling fra søknad
                         </Button>
                     </>

--- a/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
+++ b/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
@@ -3,10 +3,19 @@ import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { BodyLong, Button, Detail, Heading, List, TextField } from '@navikt/ds-react';
+import {
+    Button,
+    Checkbox,
+    CheckboxGroup,
+    Detail,
+    Heading,
+    TextField,
+    VStack,
+} from '@navikt/ds-react';
 
 import { useApp } from '../../context/AppContext';
 import DataViewer from '../../komponenter/DataViewer';
+import { IdentRequest } from '../../typer/identrequest';
 import {
     byggFeiletRessurs,
     byggHenterRessurs,
@@ -14,53 +23,62 @@ import {
     Ressurs,
     RessursStatus,
 } from '../../typer/ressurs';
+import { erGyldigFnr } from '../../utils/utils';
 
 const Container = styled.div`
     margin: 2rem;
     width: 40rem;
     display: flex;
     flex-direction: column;
-    gap: 0.5rem;
+    gap: 1rem;
 `;
 
-interface JournalpostData {
+interface Personinfo {
+    barn: {
+        ident: string;
+        navn: string;
+    }[];
+}
+
+interface OpprettFørstegansbehandlingRequest {
     ident: string;
-    barnIdenterFraSøknad: string[];
-    fagsakId?: string;
+    valgteBarn: string[];
 }
 
 const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
     const { request } = useApp();
     const navigate = useNavigate();
-    const [journalpostId, settJournalpostId] = useState<string>('');
+    const [ident, settIdent] = useState<string>('');
+    const [valgteBarn, settValgteBarn] = useState<string[]>([]);
 
-    const [journalpostData, settJournalpostData] =
-        useState<Ressurs<JournalpostData>>(byggTomRessurs());
+    const [personinfo, settPersoninfo] = useState<Ressurs<Personinfo>>(byggTomRessurs());
 
     const [opprettBehandlingResponse, settOpprettBehandlingResponse] =
-        useState<Ressurs<JournalpostData>>(byggTomRessurs());
+        useState<Ressurs<null>>(byggTomRessurs());
 
-    const hentJournalpostStatus = () => {
-        if (!journalpostId.trim()) {
-            settJournalpostData(byggFeiletRessurs('Mangler journalpostId'));
+    const hentPersoninfo = () => {
+        settOpprettBehandlingResponse(byggTomRessurs());
+        settValgteBarn([]);
+        if (!erGyldigFnr(ident)) {
+            settPersoninfo(byggFeiletRessurs('Ikke gyldig ident.'));
             return;
         }
-        settJournalpostData(byggHenterRessurs());
-        request<JournalpostData, null>(`/api/sak/behandling/journalpost/${journalpostId}`).then(
-            settJournalpostData
-        );
+        settPersoninfo(byggHenterRessurs());
+        request<Personinfo, IdentRequest>(`/api/sak/behandling/admin/hent-person`, 'POST', {
+            ident,
+        }).then(settPersoninfo);
     };
 
     const opprettBehandling = () => {
-        if (!journalpostId.trim()) {
-            settOpprettBehandlingResponse(byggFeiletRessurs('Mangler journalpostId'));
+        if (!valgteBarn.length) {
+            settOpprettBehandlingResponse(byggFeiletRessurs('Må velge minimum 1 barn.'));
             return;
         }
-
-        request<JournalpostData, string>(
-            `/api/sak/behandling/journalpost/${journalpostId}`,
+        settOpprettBehandlingResponse(byggHenterRessurs());
+        request<Personinfo, OpprettFørstegansbehandlingRequest>(
+            `/api/sak/behandling/admin/opprett-foerstegangsbehandling`,
             'POST',
-            undefined
+            { ident, valgteBarn }
         ).then((res) => {
             if (res.status === RessursStatus.SUKSESS) {
                 navigate(`/behandling/${res.data}`);
@@ -72,41 +90,45 @@ const OpprettFørstegangsbehandlingAdmin: React.FC = () => {
 
     return (
         <Container>
-            <Heading size={'medium'}>
-                [Admin] Opprett førstegangsbehandling fra journalpostId
-            </Heading>
-            <Detail>
-                Opprett en førstegangsbehandling ut fra en journalpostId. JournalpostId til en
-                søknad finnes inne på gosys når man går inn på en journalpost. Når man har søkt
-                etter en journalpostId så vil barnen i søknaden listes opp før man oppretter selve
-                behandlingen. Behandle-sak-oppgaven vil bli tildelt deg.
-            </Detail>
-            <TextField
-                label={'JournalpostId'}
-                description={'Søk etter journalpostId'}
-                onChange={(e) => {
-                    settJournalpostId(e.target.value);
-                }}
-            />
-            <Button
-                variant={'primary'}
-                size={'small'}
-                disabled={!journalpostId.trim()}
-                onClick={hentJournalpostStatus}
-            >
-                Hent info om journalpost
-            </Button>
+            <div>
+                <Heading size={'medium'}>[Admin] Opprett førstegangsbehandling</Heading>
+                <Detail>Opprett en førstegangsbehandling med fødelsnummer.</Detail>
+                <Detail>Man må velge hvilke barn som skal være med i behandlingen.</Detail>
+            </div>
+            <VStack gap={'1'}>
+                <TextField
+                    label={'Søkers ident'}
+                    onChange={(e) => {
+                        settIdent(e.target.value);
+                        settValgteBarn([]);
+                        settPersoninfo(byggTomRessurs());
+                        settOpprettBehandlingResponse(byggTomRessurs());
+                    }}
+                />
+                <Button
+                    variant={'primary'}
+                    size={'small'}
+                    disabled={!ident.trim()}
+                    onClick={hentPersoninfo}
+                >
+                    Hent barn til person
+                </Button>
+            </VStack>
 
-            <DataViewer response={{ journalpostData }}>
-                {({ journalpostData }) => (
+            <DataViewer response={{ personinfo }}>
+                {({ personinfo }) => (
                     <>
-                        <Heading size={'small'}>Informasjon fra søknad</Heading>
-                        <BodyLong>Søker: {journalpostData.ident}</BodyLong>
-                        <List title={'Barn i søknad'}>
-                            {journalpostData.barnIdenterFraSøknad.map((ident, indeks) => (
-                                <List.Item key={indeks}>{ident}</List.Item>
+                        <Heading size={'small'}>Informasjon om søker</Heading>
+                        <CheckboxGroup
+                            legend={'Barn til søker'}
+                            onChange={(values) => settValgteBarn(values)}
+                        >
+                            {personinfo.barn.map(({ ident, navn }) => (
+                                <Checkbox key={ident} value={ident}>
+                                    {ident} - {navn}
+                                </Checkbox>
                             ))}
-                        </List>
+                        </CheckboxGroup>
                         <Button variant={'secondary'} size={'small'} onClick={opprettBehandling}>
                             Opprett behandling fra søknad
                         </Button>

--- a/src/frontend/typer/identrequest.ts
+++ b/src/frontend/typer/identrequest.ts
@@ -1,0 +1,3 @@
+export interface IdentRequest {
+    ident: string;
+}

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -3,6 +3,7 @@ export enum Toggle {
     KAN_OPPRETTE_KLAGE = 'sak.kan-opprette-klage',
     SKAL_VISE_OPPGAVER_PERSONOVERSIKT = 'sak.vis-oppgaver-personoversikt',
     VIS_SIMULERING = 'sak.simulering',
-    KAN_OPPRETTE_BEHANDLING_FRA_JOURNALPOST = 'sak.kan-opprette-behandling-fra-journalpost',
     KAN_OPPDATERE_GRUNNLAG_VILKÅRPERIODE = 'sak.kan-oppdatere-grunnlag-vilkarperiode',
+
+    ADMIN_KAN_OPPRETTE_BEHANDLING = 'sak.admin-kan-opprette-behandling',
 }

--- a/src/frontend/utils/utils.ts
+++ b/src/frontend/utils/utils.ts
@@ -5,6 +5,9 @@ export const harVerdi = (str: string | undefined | null): str is string =>
 
 export const fjernSpaces = (str: string) => str.replace(/ /g, '');
 
+const REGEX_FNR = /^\d{11}$/;
+export const erGyldigFnr = (ident: string | undefined): boolean => !!ident && REGEX_FNR.test(ident);
+
 export const åpneFilIEgenTab = (
     journalpostId: string,
     dokumentinfoId: string,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det var tidligere mulig å opprette førstegangsbehandling fra journalpostId via admin.

Vi har haft noen tilfeller der det finnes papirsøknad eller søknad fra EF der det også er ønskelig å opprette førstegangsbehandling. 
For å støtte dette kan man då opprette basert fra ident. Og då velge hvilke barn som skal være med på behandlingen.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21972

* https://github.com/navikt/tilleggsstonader-sak/pull/394

![image](https://github.com/user-attachments/assets/bb990721-6d37-48f8-98d2-5b17ae70493f)


