### PR TITLE
Revurdering velge barn

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
@@ -58,6 +58,7 @@ export const FagsakOversikt: React.FC<Props> = ({
             />
             <OpprettNyBehandlingModal
                 fagsakId={fagsakId}
+                stønadstype={stønadstype}
                 hentKlagebehandlinger={hentKlagebehandlinger}
                 hentBehandlinger={hentBehandlinger}
             />

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
@@ -51,7 +51,10 @@ const BarnTilRevurdering: React.FC<{
                 return (
                     <>
                         {eksisterendeBarn.length > 0 ? (
-                            <List title={'Barn som eksisterer fra før'} size={'small'}>
+                            <List
+                                title={'Barn det er søkt om tilleggsstønad for tilsyn barn for før'}
+                                size={'small'}
+                            >
                                 {eksisterendeBarn.map(({ ident, navn }) => (
                                     <List.Item key={ident}>
                                         {ident} - {navn}
@@ -64,7 +67,7 @@ const BarnTilRevurdering: React.FC<{
 
                         {valgbareBarn.length > 0 && (
                             <CheckboxGroup
-                                legend={'Velg eventuellt nye barn fra søknad'}
+                                legend={'Velg eventuelle nye barn det søkes stønad for'}
                                 onChange={settValgteBarn}
                             >
                                 {valgbareBarn.map(({ ident, navn }) => (

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
@@ -53,7 +53,7 @@ const BarnTilRevurdering: React.FC<{
                     <>
                         {eksisterendeBarn.length > 0 ? (
                             <List
-                                title={'Barn det er søkt om tilleggsstønad for tilsyn barn for før'}
+                                title={'Barn det er søkt om tilleggsstønad for tilsyn barn fra før'}
                                 size={'small'}
                             >
                                 {eksisterendeBarn.map(({ ident, navn }) => (

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
@@ -1,0 +1,84 @@
+import React, { useEffect } from 'react';
+
+import { BodyShort, Checkbox, CheckboxGroup, List } from '@navikt/ds-react';
+
+import { useApp } from '../../../../context/AppContext';
+import DataViewer from '../../../../komponenter/DataViewer';
+import { Ressurs } from '../../../../typer/ressurs';
+
+export interface BarnTilRevurderingResponse {
+    barn: BarnTilRevurdering[];
+}
+
+interface BarnTilRevurdering {
+    ident: string;
+    navn: string;
+    finnesPåForrigeBehandling: boolean;
+}
+
+const filterEksisterendeBarn = (barnTilRevurdering: BarnTilRevurderingResponse) =>
+    barnTilRevurdering.barn.filter((b) => b.finnesPåForrigeBehandling);
+
+const filterValgbareBarn = (barnTilRevurdering: BarnTilRevurderingResponse) =>
+    barnTilRevurdering.barn.filter((b) => !b.finnesPåForrigeBehandling);
+
+const BarnTilRevurdering: React.FC<{
+    fagsakId: string;
+    barnTilRevurdering: Ressurs<BarnTilRevurderingResponse>;
+    settBarnTilRevurdering: React.Dispatch<
+        React.SetStateAction<Ressurs<BarnTilRevurderingResponse>>
+    >;
+    settValgteBarn: (identer: string[]) => void;
+}> = ({ fagsakId, barnTilRevurdering, settBarnTilRevurdering, settValgteBarn }) => {
+    const { request } = useApp();
+
+    const hentBarnTilRevurdering = (fagsakId: string) => {
+        request<BarnTilRevurderingResponse, null>(
+            `/api/sak/behandling/barn-til-revurdering/${fagsakId}`
+        ).then(settBarnTilRevurdering);
+    };
+
+    useEffect(() => {
+        hentBarnTilRevurdering(fagsakId);
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, []);
+
+    return (
+        <DataViewer response={{ barnTilRevurdering }}>
+            {({ barnTilRevurdering }) => {
+                const eksisterendeBarn = filterEksisterendeBarn(barnTilRevurdering);
+                const valgbareBarn = filterValgbareBarn(barnTilRevurdering);
+                return (
+                    <>
+                        {eksisterendeBarn.length > 0 ? (
+                            <List title={'Barn som eksisterer fra før'} size={'small'}>
+                                {eksisterendeBarn.map(({ ident, navn }) => (
+                                    <List.Item key={ident}>
+                                        {ident} - {navn}
+                                    </List.Item>
+                                ))}
+                            </List>
+                        ) : (
+                            <BodyShort>Finnes ingen barn på forrige behandling</BodyShort>
+                        )}
+
+                        {valgbareBarn.length > 0 && (
+                            <CheckboxGroup
+                                legend={'Velg eventuellt nye barn fra søknad'}
+                                onChange={settValgteBarn}
+                            >
+                                {valgbareBarn.map(({ ident, navn }) => (
+                                    <Checkbox key={ident} value={ident}>
+                                        {ident} - {navn}
+                                    </Checkbox>
+                                ))}
+                            </CheckboxGroup>
+                        )}
+                    </>
+                );
+            }}
+        </DataViewer>
+    );
+};
+
+export default BarnTilRevurdering;

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
@@ -4,7 +4,7 @@ import { BodyShort, Checkbox, CheckboxGroup, List } from '@navikt/ds-react';
 
 import { useApp } from '../../../../context/AppContext';
 import DataViewer from '../../../../komponenter/DataViewer';
-import { Ressurs } from '../../../../typer/ressurs';
+import { byggHenterRessurs, Ressurs } from '../../../../typer/ressurs';
 
 export interface BarnTilRevurderingResponse {
     barn: BarnTilRevurdering[];
@@ -33,6 +33,7 @@ const BarnTilRevurdering: React.FC<{
     const { request } = useApp();
 
     const hentBarnTilRevurdering = (fagsakId: string) => {
+        settBarnTilRevurdering(byggHenterRessurs());
         request<BarnTilRevurderingResponse, null>(
             `/api/sak/behandling/barn-til-revurdering/${fagsakId}`
         ).then(settBarnTilRevurdering);
@@ -41,7 +42,7 @@ const BarnTilRevurdering: React.FC<{
     useEffect(() => {
         hentBarnTilRevurdering(fagsakId);
         // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+    }, [fagsakId]);
 
     return (
         <DataViewer response={{ barnTilRevurdering }}>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -8,6 +8,7 @@ import OpprettKlageBehandling from './OpprettKlageBehandling';
 import OpprettRevurderingBehandling from './OpprettRevurderingBehandling';
 import { useApp } from '../../../../context/AppContext';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import {
     BehandlingType,
     behandlingTypeTilTekst,
@@ -16,12 +17,14 @@ import { Toggle } from '../../../../utils/toggles';
 
 interface Props {
     fagsakId: string;
+    stønadstype: Stønadstype;
     hentKlagebehandlinger: () => void;
     hentBehandlinger: () => void;
 }
 
 const OpprettNyBehandlingModal: FC<Props> = ({
     fagsakId,
+    stønadstype,
     hentKlagebehandlinger,
     hentBehandlinger,
 }) => {
@@ -78,6 +81,7 @@ const OpprettNyBehandlingModal: FC<Props> = ({
                     {behandlingtype === BehandlingType.REVURDERING && (
                         <OpprettRevurderingBehandling
                             fagsakId={fagsakId}
+                            stønadstype={stønadstype}
                             lukkModal={lukkModal}
                             hentBehandlinger={hentBehandlinger}
                         />

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
@@ -1,12 +1,14 @@
 import React, { useState } from 'react';
 
-import { Button, HStack, VStack } from '@navikt/ds-react';
+import { Button, HStack, Select, VStack } from '@navikt/ds-react';
 
+import BarnTilRevurdering, { BarnTilRevurderingResponse } from './BarnTilRevurdering';
 import { useApp } from '../../../../context/AppContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { BehandlingÅrsak } from '../../../../typer/behandling/behandlingÅrsak';
-import { RessursStatus } from '../../../../typer/ressurs';
+import { byggTomRessurs, Ressurs, RessursStatus } from '../../../../typer/ressurs';
+import { harVerdi } from '../../../../utils/utils';
 
 interface Props {
     fagsakId: string;
@@ -18,21 +20,38 @@ interface Props {
 interface OpprettBehandlingRequest {
     fagsakId: string;
     årsak: BehandlingÅrsak;
+    valgteBarn: string[];
 }
+
+const utledSkalViseBarnTilRevurdering = (
+    stønadstype: Stønadstype,
+    årsak: BehandlingÅrsak | undefined
+) => stønadstype === Stønadstype.BARNETILSYN && årsak === BehandlingÅrsak.SØKNAD;
 
 const OpprettRevurderingBehandling: React.FC<Props> = ({
     fagsakId,
+    stønadstype,
     lukkModal,
     hentBehandlinger,
 }) => {
     const { request } = useApp();
 
+    const [årsak, settÅrsak] = useState<BehandlingÅrsak>();
+    const [barnTilRevurdering, setBarnTilRevurdering] =
+        useState<Ressurs<BarnTilRevurderingResponse>>(byggTomRessurs());
+    const [valgteBarn, settValgteBarn] = useState<string[]>([]);
+
     const [feilmelding, settFeilmelding] = useState<string>();
 
     const opprett = () => {
+        if (!årsak) {
+            settFeilmelding('Mangler årsak');
+            return;
+        }
         request<string, OpprettBehandlingRequest>(`/api/sak/behandling`, 'POST', {
             fagsakId: fagsakId,
-            årsak: BehandlingÅrsak.NYE_OPPLYSNINGER,
+            årsak: årsak,
+            valgteBarn: valgteBarn,
         }).then((response) => {
             if (response.status === RessursStatus.SUKSESS) {
                 hentBehandlinger();
@@ -43,13 +62,45 @@ const OpprettRevurderingBehandling: React.FC<Props> = ({
         });
     };
 
+    const endreÅrsak = (event: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = event.target.value;
+        if (harVerdi(value)) {
+            settÅrsak(value as BehandlingÅrsak);
+        } else {
+            settÅrsak(undefined);
+        }
+    };
+
+    const skalViseBarnTilRevurdering = utledSkalViseBarnTilRevurdering(stønadstype, årsak);
+    const skalVentePåOkHentingAvBarn =
+        skalViseBarnTilRevurdering && barnTilRevurdering.status !== RessursStatus.SUKSESS;
     return (
         <VStack gap="4">
+            <Select label={'Årsak'} onChange={endreÅrsak}>
+                <option value="">- Velg årsak -</option>
+                <option value={BehandlingÅrsak.NYE_OPPLYSNINGER}>Nye opplysninger</option>
+                <option value={BehandlingÅrsak.SØKNAD}>Søknad</option>
+            </Select>
+
+            {skalViseBarnTilRevurdering && (
+                <BarnTilRevurdering
+                    fagsakId={fagsakId}
+                    barnTilRevurdering={barnTilRevurdering}
+                    settBarnTilRevurdering={setBarnTilRevurdering}
+                    settValgteBarn={settValgteBarn}
+                />
+            )}
+
             <HStack gap="4" justify={'end'}>
                 <Button variant="tertiary" onClick={lukkModal} size="small">
                     Avbryt
                 </Button>
-                <Button variant="primary" onClick={opprett} size="small">
+                <Button
+                    variant="primary"
+                    onClick={opprett}
+                    size="small"
+                    disabled={skalVentePåOkHentingAvBarn}
+                >
                     Lagre
                 </Button>
             </HStack>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
@@ -4,11 +4,13 @@ import { Button, HStack, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../../context/AppContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { BehandlingÅrsak } from '../../../../typer/behandling/behandlingÅrsak';
 import { RessursStatus } from '../../../../typer/ressurs';
 
 interface Props {
     fagsakId: string;
+    stønadstype: Stønadstype;
     lukkModal: () => void;
     hentBehandlinger: () => void;
 }

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettRevurderingBehandling.tsx
@@ -26,7 +26,9 @@ interface OpprettBehandlingRequest {
 const utledSkalViseBarnTilRevurdering = (
     stønadstype: Stønadstype,
     årsak: BehandlingÅrsak | undefined
-) => stønadstype === Stønadstype.BARNETILSYN && årsak === BehandlingÅrsak.SØKNAD;
+) =>
+    stønadstype === Stønadstype.BARNETILSYN &&
+    (årsak === BehandlingÅrsak.SØKNAD || årsak === BehandlingÅrsak.PAPIRSØKNAD);
 
 const OpprettRevurderingBehandling: React.FC<Props> = ({
     fagsakId,
@@ -80,6 +82,7 @@ const OpprettRevurderingBehandling: React.FC<Props> = ({
                 <option value="">- Velg årsak -</option>
                 <option value={BehandlingÅrsak.NYE_OPPLYSNINGER}>Nye opplysninger</option>
                 <option value={BehandlingÅrsak.SØKNAD}>Søknad</option>
+                <option value={BehandlingÅrsak.PAPIRSØKNAD}>Papirsøknad</option>
             </Select>
 
             {skalViseBarnTilRevurdering && (

--- a/src/frontend/typer/behandling/behandlingÅrsak.ts
+++ b/src/frontend/typer/behandling/behandlingÅrsak.ts
@@ -1,5 +1,6 @@
 export enum BehandlingÅrsak {
     SØKNAD = 'SØKNAD',
+    PAPIRSØKNAD = 'PAPIRSØKNAD',
     NYE_OPPLYSNINGER = 'NYE_OPPLYSNINGER',
 }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det er ønskelig å kunne velge barn når man oppretter en revurdering.
Vi gjenbruker data fra forrige behandling. I tilfelle det i en første behandling er behandlet 1 barn, og i en ny søknad kommer et nytt barn, så må man kunne legge til denne til den nye behandlingen

Vi har noen ulike situasjoner:
* Mottatt papirsøknad
* En digital søknad for revurdering har blitt journalført men ikke fått opprettet behandling
* Søknad til barnetilsyn fra enslig forsørger

I tillegg så har vi mulighet for å kunne opprette førstegangsbehandling med barn fra admin-funksjonalitet. Det er mulig det blir flyttet hit en gang. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21972

* https://github.com/navikt/tilleggsstonader-sak/pull/398

Hvis man ønsker å teste de nå lokalt så kan man sjekke ut branchen `revurdering-velge-barn-test` i backend
* https://github.com/navikt/tilleggsstonader-sak/compare/revurdering-velge-barn...revurdering-velge-barn-test


<img width="507" alt="image" src="https://github.com/user-attachments/assets/9941eb38-bb22-469c-a5c2-f497322dba9e">
