### PR TITLE
Det er ønskelig med select for å velge klar eller på-vent benk

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -2,7 +2,7 @@ import React, { ChangeEvent } from 'react';
 
 import styled from 'styled-components';
 
-import { Button, Checkbox, Select, VStack } from '@navikt/ds-react';
+import { Button, Select, VStack } from '@navikt/ds-react';
 
 import { oppdaterFilter } from './filterutils';
 import { lagreTilLocalStorage, oppgaveRequestKey } from './oppgavefilterStorage';
@@ -34,11 +34,6 @@ const KnappWrapper = styled.div`
     display: flex;
     flex-direction: row;
     gap: 1rem;
-`;
-
-const AlignetCheckbox = styled(Checkbox)`
-    margin-bottom: -0.5rem;
-    align-self: flex-end;
 `;
 
 export const Oppgavefiltrering = () => {
@@ -74,6 +69,18 @@ export const Oppgavefiltrering = () => {
     return (
         <VStack gap="4">
             <FlexDiv>
+                <Select
+                    value={oppgaveRequest.oppgaverPåVent ? 'På vent' : 'Klar'}
+                    label="Benk"
+                    onChange={(event) => {
+                        nullstillFiltrering();
+                        oppdaterOppgave('oppgaverPåVent')(event.target.value === 'På vent');
+                    }}
+                    size="small"
+                >
+                    <option value="Klar">Klar</option>
+                    <option value="På vent">På vent</option>
+                </Select>
                 <Select
                     value={oppgaveRequest.oppgavetype || ''}
                     label="Type"
@@ -128,15 +135,6 @@ export const Oppgavefiltrering = () => {
                     oppgaveRequest={oppgaveRequest}
                     settOppgaveRequest={settOppgaveRequest}
                 />
-                <AlignetCheckbox
-                    checked={oppgaveRequest['oppgaverPåVent'] || false}
-                    onChange={(e) => {
-                        nullstillFiltrering();
-                        oppdaterOppgave('oppgaverPåVent')(e.target.checked);
-                    }}
-                >
-                    Oppgaver på vent
-                </AlignetCheckbox>
             </FlexDiv>
             <KnappWrapper>
                 <Button onClick={sjekkFeilOgHentOppgaver} type={'submit'} size="small">


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det er tenkt at select skal gjøre det tydligere enn checkbox.
Vi valgte å kun kunne velge `Klar` eller `På vent`. Å kunne vise "Alle" trenger api-endringer.

* https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21728

### Etter
![image](https://github.com/user-attachments/assets/513efcc9-41b8-454a-a895-df46674afe53)

### Før
![image](https://github.com/user-attachments/assets/23bc25c4-449a-4115-9b2d-4fb3370d2f1f)

