### PR TITLE
Endring av brevmottakere i SAK

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { VStack } from '@navikt/ds-react';
@@ -15,11 +16,14 @@ import VelgBrevmal from './VelgBrevmal';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { usePersonopplysninger } from '../../../context/PersonopplysningerContext';
 import { useVedtak } from '../../../hooks/useVedtak';
+import BrevMottakere from '../../../komponenter/Brevmottakere/BrevMottakere';
+import { Applikasjonskontekst } from '../../../komponenter/Brevmottakere/typer';
 import DataViewer from '../../../komponenter/DataViewer';
 import PdfVisning from '../../../komponenter/PdfVisning';
 import { Personopplysninger } from '../../../typer/personopplysninger';
 import { RessursStatus } from '../../../typer/ressurs';
 import { erVedtakInnvilgelse } from '../../../typer/vedtak';
+import { Toggle } from '../../../utils/toggles';
 import SendTilBeslutterKnapp from '../Totrinnskontroll/SendTilBeslutterKnapp';
 
 const Container = styled.div`
@@ -37,7 +41,7 @@ const ToKolonner = styled.div`
 
 const Brev: React.FC = () => {
     const { behandling, behandlingErRedigerbar } = useBehandling();
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+
     const { personopplysninger } = usePersonopplysninger();
     const {
         brevmaler,
@@ -77,7 +81,6 @@ const Brev: React.FC = () => {
         }
     }, [behandlingErRedigerbar, hentMalStruktur]);
 
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     const mapPersonopplysningerTilPersonopplysningerIBrevmottakere = (
         personopplysninger: Personopplysninger
     ): PersonopplysningerIBrevmottakere => {
@@ -91,6 +94,8 @@ const Brev: React.FC = () => {
         };
     };
 
+    const isEnabled = useFlag(Toggle.KAN_ENDRE_BREVMOTTAKERE);
+
     return (
         <Container>
             {behandlingErRedigerbar ? (
@@ -98,14 +103,16 @@ const Brev: React.FC = () => {
                     {({ brevmaler, mellomlagretBrev }) => (
                         <ToKolonner>
                             <VStack gap="8" align="start">
-                                {/*<BrevMottakere*/}
-                                {/*    behandlingId={behandling.id}*/}
-                                {/*    applikasjonskontekst={Applikasjonskontekst.SAK}*/}
-                                {/*    behandlingErRedigerbar={behandlingErRedigerbar}*/}
-                                {/*    personopplysninger={mapPersonopplysningerTilPersonopplysningerIBrevmottakere(*/}
-                                {/*        personopplysninger*/}
-                                {/*    )}*/}
-                                {/*/>*/}
+                                {isEnabled && (
+                                    <BrevMottakere
+                                        behandlingId={behandling.id}
+                                        applikasjonskontekst={Applikasjonskontekst.SAK}
+                                        behandlingErRedigerbar={behandlingErRedigerbar}
+                                        personopplysninger={mapPersonopplysningerTilPersonopplysningerIBrevmottakere(
+                                            personopplysninger
+                                        )}
+                                    />
+                                )}
                                 <VelgBrevmal
                                     brevmaler={brevmaler}
                                     brevmal={brevmal}

--- a/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
+++ b/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
@@ -8,6 +8,7 @@ import { EndreBrevmottakereModal } from './EndreBrevmottakereModal';
 import { Applikasjonskontekst, EBrevmottakerRolle, IBrevmottakere } from './typer';
 import { useBrevmottakere } from '../../hooks/useBrevmottakere';
 import { PersonopplysningerIBrevmottakere } from '../../Sider/Behandling/Brev/typer';
+import { tilLitenSkriftMedStorForbokstav } from '../../utils/fomatering';
 import DataViewer from '../DataViewer';
 
 const Grid = styled.div`
@@ -37,19 +38,14 @@ const Brevmottakere: React.FC<{
     const utledNavnPåMottakere = (brevMottakere: IBrevmottakere) => {
         return [
             ...brevMottakere.personer.map(
-                (person) => `${formatterBeskrivelseAvBrevmottakersRolle(person.mottakerRolle)}`
+                (person) =>
+                    `${person?.navn + ': ' || ''}${tilLitenSkriftMedStorForbokstav(person.mottakerRolle)}`
             ),
             ...brevMottakere.organisasjoner.map(
                 (org) =>
-                    `${org.navnHosOrganisasjon} - ${org.organisasjonsnavn} (${org.organisasjonsnummer})`
+                    `${org.navnHosOrganisasjon} - ${org.organisasjonsnavn} (${org.organisasjonsnummer}): Fullmakt`
             ),
         ];
-    };
-
-    const formatterBeskrivelseAvBrevmottakersRolle = (mottakerRolle: string): string => {
-        const rolleLowerCase = mottakerRolle.toLowerCase();
-        const firstLetterUpperCase = mottakerRolle.charAt(0).toUpperCase();
-        return firstLetterUpperCase + rolleLowerCase.slice(1);
     };
 
     const navn = utledNavnPåMottakere(mottakere);

--- a/src/frontend/komponenter/Brevmottakere/BrevmottakereListe.tsx
+++ b/src/frontend/komponenter/Brevmottakere/BrevmottakereListe.tsx
@@ -48,6 +48,7 @@ export const BrevmottakereListe: FC<Props> = ({
             prevState.filter((mottaker) => mottaker.organisasjonsnummer !== organisasjonsnummer)
         );
     };
+
     return (
         <>
             <Undertittel>Brevmottakere</Undertittel>
@@ -55,7 +56,7 @@ export const BrevmottakereListe: FC<Props> = ({
                 <StyledMottakerBoks key={mottaker.navn + index}>
                     <Flexboks>
                         <BodyShort>
-                            {`${mottaker.navn} (${mottaker.mottakerRolle.toLowerCase()})`}
+                            {`${mottaker?.navn || ''} (${mottaker.mottakerRolle.toLowerCase()})`}
                             <Fødselsnummer fødselsnummer={mottaker.personIdent} />
                         </BodyShort>
                     </Flexboks>

--- a/src/frontend/komponenter/Brevmottakere/SkalBrukerHaBrev.tsx
+++ b/src/frontend/komponenter/Brevmottakere/SkalBrukerHaBrev.tsx
@@ -1,6 +1,7 @@
 import React, { Dispatch, FC, SetStateAction } from 'react';
 
 import styled from 'styled-components';
+import { v4 as uuidv4 } from 'uuid';
 
 import { Ingress, Radio, RadioGroup } from '@navikt/ds-react';
 
@@ -38,7 +39,6 @@ export const SkalBrukerHaBrev: FC<Props> = ({
             const brukerErIListe = mottakere.some(
                 (mottaker) => mottaker.mottakerRolle === EBrevmottakerRolle.BRUKER
             );
-
             if (brukerErIListe) {
                 return mottakere.filter(
                     (mottaker) => mottaker.mottakerRolle !== EBrevmottakerRolle.BRUKER
@@ -46,6 +46,7 @@ export const SkalBrukerHaBrev: FC<Props> = ({
             } else {
                 return [
                     {
+                        id: uuidv4(),
                         mottakerRolle: EBrevmottakerRolle.BRUKER,
                         personIdent: personopplysninger.personIdent,
                         navn: personopplysninger.navn,

--- a/src/frontend/komponenter/Brevmottakere/SøkOrganisasjon.tsx
+++ b/src/frontend/komponenter/Brevmottakere/SøkOrganisasjon.tsx
@@ -1,5 +1,7 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 
+import { v4 as uuidv4 } from 'uuid';
+
 import { BodyShort, Button, TextField } from '@navikt/ds-react';
 
 import { Søkefelt, Søkeresultat } from './brevmottakereStyling';
@@ -28,6 +30,7 @@ export const SøkOrganisasjon: React.FC<Props> = ({ settValgteMottakere }) => {
         settFeil('');
         settValgteMottakere([
             {
+                id: uuidv4(),
                 organisasjonsnummer,
                 organisasjonsnavn,
                 navnHosOrganisasjon,

--- a/src/frontend/komponenter/Brevmottakere/SøkPerson.tsx
+++ b/src/frontend/komponenter/Brevmottakere/SøkPerson.tsx
@@ -1,5 +1,7 @@
 import React, { Dispatch, SetStateAction, useState } from 'react';
 
+import { v4 as uuidv4 } from 'uuid';
+
 import { BodyShort, Button } from '@navikt/ds-react';
 
 import { Søkefelt, Søkeresultat } from './brevmottakereStyling';
@@ -21,7 +23,12 @@ export const SøkPerson: React.FC<Props> = ({ settValgteMottakere, behandlingId 
     const leggTilBrevmottaker = (personIdent: string, navn: string) => () => {
         settValgteMottakere((prevState) => [
             ...prevState,
-            { navn, personIdent, mottakerRolle: EBrevmottakerRolle.VERGE },
+            {
+                id: uuidv4(),
+                personIdent: personIdent,
+                navn: navn,
+                mottakerRolle: EBrevmottakerRolle.VERGE,
+            },
         ]);
     };
 

--- a/src/frontend/komponenter/Brevmottakere/brevmottakerUtils.ts
+++ b/src/frontend/komponenter/Brevmottakere/brevmottakerUtils.ts
@@ -1,12 +1,16 @@
+import { v4 as uuidv4 } from 'uuid';
+
 import { EBrevmottakerRolle, IBrevmottaker } from './typer';
 import { Fullmakt, Vergemål } from '../../Sider/Klage/typer/personopplysningerFraKlage';
 
 export const vergemålTilBrevmottaker = (vergemål: Vergemål): IBrevmottaker => ({
+    id: uuidv4(),
     navn: vergemål.navn || '',
     personIdent: vergemål.motpartsPersonident || '',
     mottakerRolle: EBrevmottakerRolle.VERGE,
 });
 export const fullmaktTilBrevMottaker = (fullmakt: Fullmakt): IBrevmottaker => ({
+    id: uuidv4(),
     navn: fullmakt.navn || '',
     personIdent: fullmakt.motpartsPersonident,
     mottakerRolle: EBrevmottakerRolle.FULLMAKT,

--- a/src/frontend/komponenter/Brevmottakere/typer.ts
+++ b/src/frontend/komponenter/Brevmottakere/typer.ts
@@ -1,4 +1,5 @@
 export interface IBrevmottaker {
+    id: string;
     personIdent: string;
     navn: string;
     mottakerRolle: EBrevmottakerRolle;
@@ -10,6 +11,7 @@ export interface IBrevmottakere {
 }
 
 export interface IOrganisasjonMottaker {
+    id: string;
     organisasjonsnummer: string;
     organisasjonsnavn: string;
     navnHosOrganisasjon: string;

--- a/src/frontend/utils/fomatering.ts
+++ b/src/frontend/utils/fomatering.ts
@@ -7,3 +7,9 @@ export const formaterTallMedTusenSkilleEllerStrek = (verdi?: number): string =>
     harTallverdi(verdi) && verdi !== 0
         ? Number(verdi).toLocaleString('no-NO', { currency: 'NOK' })
         : '-';
+
+export const tilLitenSkriftMedStorForbokstav = (mottakerRolle: string): string => {
+    const rolleLowerCase = mottakerRolle.toLowerCase();
+    const firstLetterUpperCase = mottakerRolle.charAt(0).toUpperCase();
+    return firstLetterUpperCase + rolleLowerCase.slice(1);
+};

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -11,4 +11,6 @@ export enum Toggle {
     ADMIN_KAN_OPPRETTE_BEHANDLING = 'sak.admin-kan-opprette-behandling',
 
     KAN_SAKSBEHANDLE = 'sak.frontend.kan-saksbehandle',
+
+    KAN_ENDRE_BREVMOTTAKERE = 'sak.kan-endre-brevmottakere',
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Åpner opp for lagring av brev-mottakere i SAK-backend:

![Skjermbilde 2024-09-03 kl  15 17 51](https://github.com/user-attachments/assets/42859afe-a0c7-499d-be7c-47b66e0dde59)

![Skjermbilde 2024-09-03 kl  15 17 56](https://github.com/user-attachments/assets/4c558882-7989-4ae1-9af5-3038fae9fd25)


Sees i sammenheng med PR: https://github.com/navikt/tilleggsstonader-sak/pull/403