### PR TITLE
Returner REVUDERING-mappe i sanity dersom behandlingen er en revurdering

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -7,6 +7,7 @@ import { ABreakpointLgDown } from '@navikt/ds-tokens/dist/tokens';
 
 import BrevLesevisning from './BrevLesevisning';
 import Brevmeny from './Brevmeny';
+import { finnSanityMappe } from './brevUtils';
 import { PersonopplysningerIBrevmottakere } from './typer';
 import useBrev from './useBrev';
 import useMellomlagrignBrev from './useMellomlagrignBrev';
@@ -18,7 +19,7 @@ import DataViewer from '../../../komponenter/DataViewer';
 import PdfVisning from '../../../komponenter/PdfVisning';
 import { Personopplysninger } from '../../../typer/personopplysninger';
 import { RessursStatus } from '../../../typer/ressurs';
-import { erVedtakInnvilgelse, typeVedtakTilSanitytype } from '../../../typer/vedtak';
+import { erVedtakInnvilgelse } from '../../../typer/vedtak';
 import SendTilBeslutterKnapp from '../Totrinnskontroll/SendTilBeslutterKnapp';
 
 const Container = styled.div`
@@ -66,9 +67,9 @@ const Brev: React.FC = () => {
 
     useEffect(() => {
         if (behandlingErRedigerbar && vedtak.status === RessursStatus.SUKSESS) {
-            hentBrevmaler(typeVedtakTilSanitytype(vedtak.data.type));
+            hentBrevmaler(finnSanityMappe(behandling.type, vedtak.data.type));
         }
-    }, [behandlingErRedigerbar, hentBrevmaler, vedtak, vedtak.status]);
+    }, [behandlingErRedigerbar, hentBrevmaler, vedtak, vedtak.status, behandling.type]);
 
     useEffect(() => {
         if (behandlingErRedigerbar) {

--- a/src/frontend/Sider/Behandling/Brev/brevUtils.ts
+++ b/src/frontend/Sider/Behandling/Brev/brevUtils.ts
@@ -24,7 +24,7 @@ export const finnSanityMappe = (
 /**
  * Mapper fra type vedtak til typen malen er definert som i Sanity.
  */
-export const typeVedtakTilSanitytype = (type: TypeVedtak): string => {
+const typeVedtakTilSanitytype = (type: TypeVedtak): string => {
     switch (type) {
         case TypeVedtak.INNVILGELSE:
             return 'INNVILGET';

--- a/src/frontend/Sider/Behandling/Brev/brevUtils.ts
+++ b/src/frontend/Sider/Behandling/Brev/brevUtils.ts
@@ -1,4 +1,6 @@
 import { Valg } from './typer';
+import { BehandlingType } from '../../../typer/behandling/behandlingType';
+import { TypeVedtak } from '../../../typer/vedtak';
 
 export const idEllerFritekst = (valg?: Valg): string | undefined => {
     switch (valg?._type) {
@@ -6,5 +8,27 @@ export const idEllerFritekst = (valg?: Valg): string | undefined => {
             return valg?._id;
         case 'fritekst':
             return 'fritekst';
+    }
+};
+
+export const finnSanityMappe = (
+    behandlingstype: BehandlingType,
+    vedtakType: TypeVedtak
+): string => {
+    if (behandlingstype === BehandlingType.REVURDERING) {
+        return 'REVURDERING';
+    }
+    return typeVedtakTilSanitytype(vedtakType);
+};
+
+/**
+ * Mapper fra type vedtak til typen malen er definert som i Sanity.
+ */
+export const typeVedtakTilSanitytype = (type: TypeVedtak): string => {
+    switch (type) {
+        case TypeVedtak.INNVILGELSE:
+            return 'INNVILGET';
+        default:
+            return type;
     }
 };

--- a/src/frontend/typer/vedtak.ts
+++ b/src/frontend/typer/vedtak.ts
@@ -10,18 +10,6 @@ export const typeVedtakTilTekst: Record<TypeVedtak, string> = {
     AVSLAG: 'Avslag',
 };
 
-/**
- * Mapper fra type vedtak til typen malen er definert som i Sanity.
- */
-export const typeVedtakTilSanitytype = (type: TypeVedtak): string => {
-    switch (type) {
-        case TypeVedtak.INNVILGELSE:
-            return 'INNVILGET';
-        default:
-            return type;
-    }
-};
-
 export type VedtakBarnetilsyn = InnvilgelseBarnetilsyn | AvslagBarnetilsyn;
 
 export const erVedtakInnvilgelse = (vedtak: VedtakBarnetilsyn): vedtak is InnvilgelseBarnetilsyn =>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Til nå henter vi kun brev basert på resultatet (type) på vedtaket.
For å vise revurderingsbrev må vi også se på behandlingType