### PR TITLE
Slette vilkår opprettet i denne behandlingen

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -3,6 +3,7 @@ import React, { FC, useEffect, useId, useState } from 'react';
 import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
+import { TrashIcon } from '@navikt/aksel-icons';
 import { ErrorMessage, HStack, VStack } from '@navikt/ds-react';
 import { ABorderAction, AShadowXsmall } from '@navikt/ds-tokens/dist/tokens';
 
@@ -52,6 +53,16 @@ const StyledForm = styled.form`
     box-shadow: ${AShadowXsmall};
 `;
 
+const Knapper = styled.div`
+    display: flex;
+    justify-content: space-between;
+    gap: 1.5rem;
+
+    .right {
+        margin-left: auto;
+    }
+`;
+
 type EndreVilkårProps = {
     regler: Regler;
     redigerbareVilkårfelter: RedigerbareVilkårfelter;
@@ -59,6 +70,7 @@ type EndreVilkårProps = {
     lagreVurdering: (
         redigerbareVilkårfelter: RedigerbareVilkårfelter
     ) => Promise<RessursSuksess<Vilkår> | RessursFeilet>;
+    slettVilkår: undefined | (() => void);
 };
 
 export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
@@ -258,6 +270,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
         });
     });
 
+    const slettVilkår = props.slettVilkår;
     return (
         <StyledForm onSubmit={validerOgLagreVilkårsvurderinger}>
             <FlexColumn gap={1}>
@@ -265,12 +278,27 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                 <Skillelinje />
                 {EndreDelvilkår}
                 <VStack gap="4">
-                    <HStack gap="3">
+                    <Knapper>
                         <SmallButton>Lagre</SmallButton>
                         <SmallButton variant="secondary" onClick={props.avsluttRedigering}>
                             Avbryt
                         </SmallButton>
-                    </HStack>
+                        <div className={'right'}>
+                            {periodiserteVilkårIsEnabled && slettVilkår && (
+                                <SmallButton
+                                    variant={'tertiary'}
+                                    icon={<TrashIcon />}
+                                    iconPosition={'right'}
+                                    onClick={(e) => {
+                                        e.preventDefault();
+                                        slettVilkår();
+                                    }}
+                                >
+                                    Slett vilkår
+                                </SmallButton>
+                            )}
+                        </div>
+                    </Knapper>
                     {detFinnesUlagredeEndringer && (
                         <SmallWarningTag>Du har ulagrede endringer</SmallWarningTag>
                     )}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
@@ -56,6 +56,7 @@ export const NyttVilkår: React.FC<{
             redigerbareVilkårfelter={{ delvilkårsett: lagTomtDelvilkårsett(vilkårsregler) }}
             avsluttRedigering={() => settLeggerTilNyttVilkår(false)}
             lagreVurdering={opprettVilkår}
+            slettVilkår={undefined}
         />
     );
 };

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
@@ -14,7 +14,7 @@ type LesEllerEndreDelvilkårProps = {
 
 export const VisEllerEndreVilkår: FC<LesEllerEndreDelvilkårProps> = ({ regler, vilkår }) => {
     const { erStegRedigerbart } = useSteg();
-    const { lagreVilkår } = useVilkår();
+    const { lagreVilkår, slettVilkår } = useVilkår();
 
     const [redigerer, settRedigerer] = useState<boolean>(
         vilkår.resultat === Vilkårsresultat.IKKE_TATT_STILLING_TIL
@@ -37,6 +37,13 @@ export const VisEllerEndreVilkår: FC<LesEllerEndreDelvilkårProps> = ({ regler,
                 })
             }
             avsluttRedigering={() => settRedigerer(false)}
+            slettVilkår={
+                vilkår.opphavsvilkår
+                    ? undefined
+                    : () => {
+                          slettVilkår(vilkår);
+                      }
+            }
         />
     ) : (
         <LesevisningVilkår vilkår={vilkår} startRedigering={() => settRedigerer(true)} />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det er ønskelig å kunne slette et vilkår som er opprettet i den samme behandlingen for å fjerne et vilkår i tilfelle det har blitt opprettet ved en feil.
Sletting av vilkår opprettet i tidligere behandlingen blir kanskje utført i en senere endring

❗ Denne kan kun merges etter at backend ikke oppretter vilkår automatisk når man går inn på vilkårsiden. 
Det må dog gjøres etter at man har aktivert vilkårperiode sånn at man ikke fjerner vilkår i prod uten mulighet for å kunne legge til et vilkår

<img width="918" alt="image" src="https://github.com/user-attachments/assets/42c06110-ad0c-457b-84ed-ed017d2ec529">
