### PR TITLE
Legg til validering i vilkårspanel på at fom og tom må være inkludert, og i riktig rekkefølge. Utgifter skal kunne være tom, men det kan endre seg seinere.

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -16,7 +16,7 @@ import {
     leggTilNesteIdHvis,
     oppdaterSvarIListe,
 } from './utils';
-import { Feilmeldinger, validerVilkårsvurderinger } from './validering';
+import { Feilmeldinger, ingenFeil, validerVilkårsvurderinger } from './validering';
 import { useApp } from '../../../context/AppContext';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
 import { Skillelinje } from '../../../komponenter/Skillelinje';
@@ -26,7 +26,6 @@ import SmallWarningTag from '../../../komponenter/SmallWarningTag';
 import { FlexColumn } from '../../../komponenter/Visningskomponenter/Flex';
 import { BegrunnelseRegel, Regler, Svaralternativ } from '../../../typer/regel';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
-import { erTomtObjekt } from '../../../typer/typeUtils';
 import { tilSisteDagenIMåneden } from '../../../utils/dato';
 import { harTallverdi, tilHeltall } from '../../../utils/tall';
 import { Toggle } from '../../../utils/toggles';
@@ -75,7 +74,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     const [tom, settTom] = useState(props.redigerbareVilkårfelter.tom);
     const [utgift, settUtgift] = useState(props.redigerbareVilkårfelter.utgift);
 
-    const [feilmeldinger, settFeilmeldinger] = useState<Feilmeldinger>({});
+    const [feilmeldinger, settFeilmeldinger] = useState<Feilmeldinger>(ingenFeil);
 
     const [feilmeldingerVedLagring, settFeilmeldingVedLagring] = useState<string | null>();
 
@@ -172,11 +171,17 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     const validerOgLagreVilkårsvurderinger = async (event: React.FormEvent<HTMLFormElement>) => {
         event.preventDefault();
 
-        const valideringsfeil = validerVilkårsvurderinger(delvilkårsett, props.regler);
+        const valideringsfeil = validerVilkårsvurderinger(
+            periodiserteVilkårIsEnabled,
+            delvilkårsett,
+            props.regler,
+            fom,
+            tom
+        );
 
         settFeilmeldinger(valideringsfeil);
 
-        if (erTomtObjekt(valideringsfeil)) {
+        if (JSON.stringify(valideringsfeil) === JSON.stringify(ingenFeil)) {
             const response = await props.lagreVurdering({ delvilkårsett, fom, tom, utgift });
             if (response.status === RessursStatus.SUKSESS) {
                 props.avsluttRedigering();
@@ -187,18 +192,34 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
         }
     };
 
-    const nullstillFeilmelding = (regelId: string) => {
-        settFeilmeldinger({ ...feilmeldinger, [regelId]: undefined });
+    const nullstillFeilmeldingForRegel = (regelId: string) => {
+        settFeilmeldinger({
+            ...feilmeldinger,
+            vilkårsvurdering: { ...feilmeldinger.vilkårsvurdering, [regelId]: undefined },
+        });
     };
 
     const EndrePerioder = (
         <HStack gap="6">
-            <MonthInput label="Periode fra og med" size="small" value={fom} onChange={settFom} />
+            <MonthInput
+                label="Periode fra og med"
+                size="small"
+                value={fom}
+                feil={feilmeldinger.fom}
+                onChange={(dato) => {
+                    settFom(dato);
+                    settFeilmeldinger((prevState) => ({ ...prevState, fom: undefined }));
+                }}
+            />
             <MonthInput
                 label="Periode til og med"
                 size="small"
                 value={tom}
-                onChange={(dato) => settTom(dato ? tilSisteDagenIMåneden(dato) : undefined)}
+                feil={feilmeldinger.tom}
+                onChange={(dato) => {
+                    settTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
+                    settFeilmeldinger((prevState) => ({ ...prevState, tom: undefined }));
+                }}
             />
             <TextField
                 label="Månedlig utgift"
@@ -225,8 +246,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                                 settDetFinnesUlagredeEndringer(true);
                                 oppdaterSvar(delvikår.vurderinger, delvilkårIndex, nyVurdering);
                             }}
-                            feilmelding={feilmeldinger[gjeldendeRegel.regelId]}
-                            nullstillFeilmelding={nullstillFeilmelding}
+                            feilmelding={feilmeldinger.vilkårsvurdering[gjeldendeRegel.regelId]}
+                            nullstillFeilmelding={nullstillFeilmeldingForRegel}
                         />
                         <Begrunnelse
                             oppdaterBegrunnelse={(begrunnelse) => {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -16,7 +16,7 @@ import {
     leggTilNesteIdHvis,
     oppdaterSvarIListe,
 } from './utils';
-import { Feilmeldinger, ingenFeil, validerVilkårsvurderinger } from './validering';
+import { Feilmeldinger, ingenFeil, ingen, validerVilkårsvurderinger } from './validering';
 import { useApp } from '../../../context/AppContext';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
 import { Skillelinje } from '../../../komponenter/Skillelinje';
@@ -181,7 +181,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
 
         settFeilmeldinger(valideringsfeil);
 
-        if (JSON.stringify(valideringsfeil) === JSON.stringify(ingenFeil)) {
+        if (ingen(valideringsfeil)) {
             const response = await props.lagreVurdering({ delvilkårsett, fom, tom, utgift });
             if (response.status === RessursStatus.SUKSESS) {
                 props.avsluttRedigering();
@@ -195,7 +195,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     const nullstillFeilmeldingForRegel = (regelId: string) => {
         settFeilmeldinger({
             ...feilmeldinger,
-            vilkårsvurdering: { ...feilmeldinger.vilkårsvurdering, [regelId]: undefined },
+            delvilkårsvurderinger: { ...feilmeldinger.delvilkårsvurderinger, [regelId]: undefined },
         });
     };
 
@@ -246,7 +246,9 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                                 settDetFinnesUlagredeEndringer(true);
                                 oppdaterSvar(delvikår.vurderinger, delvilkårIndex, nyVurdering);
                             }}
-                            feilmelding={feilmeldinger.vilkårsvurdering[gjeldendeRegel.regelId]}
+                            feilmelding={
+                                feilmeldinger.delvilkårsvurderinger[gjeldendeRegel.regelId]
+                            }
                             nullstillFeilmelding={nullstillFeilmeldingForRegel}
                         />
                         <Begrunnelse

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
@@ -1,13 +1,36 @@
 import { BegrunnelseRegel, Regel, RegelId, Regler } from '../../../typer/regel';
+import { erDatoEtterEllerLik } from '../../../utils/dato';
+import { harIkkeVerdi } from '../../../utils/utils';
 import { Delvilkår } from '../vilkår';
 
-export type Feilmeldinger = Record<RegelId, string | undefined>;
+export type Feilmeldinger = {
+    vilkårsvurdering: Record<RegelId, string | undefined>;
+    fom?: string;
+    tom?: string;
+};
+
+export const ingenFeil = { vilkårsvurdering: {} };
 
 export const validerVilkårsvurderinger = (
+    periodiserteVilkårIsEnabled: boolean,
     delvilkårsett: Delvilkår[],
-    regler: Regler
+    regler: Regler,
+    fom?: string,
+    tom?: string
 ): Feilmeldinger => {
-    const valideringsfeil: Feilmeldinger = {};
+    const valideringsfeil: Feilmeldinger = { vilkårsvurdering: {} };
+
+    if (periodiserteVilkårIsEnabled) {
+        if (harIkkeVerdi(fom)) {
+            valideringsfeil.fom = 'Må angis';
+        }
+        if (harIkkeVerdi(tom)) {
+            valideringsfeil.tom = 'Må angis';
+        }
+        if (fomErEtterTom(fom, tom)) {
+            valideringsfeil.tom = 'Må være etter fra-datoen';
+        }
+    }
 
     delvilkårsett
         .flatMap((delvilkår) => delvilkår.vurderinger)
@@ -15,15 +38,16 @@ export const validerVilkårsvurderinger = (
             const gjeldendeRegel = vurdering.regelId;
 
             if (!vurdering.svar) {
-                valideringsfeil[gjeldendeRegel] = 'Du må ta et valg';
+                valideringsfeil.vilkårsvurdering[gjeldendeRegel] = 'Du må ta et valg';
                 return;
             }
 
             if (
                 begrunnelseKreves(vurdering.svar, regler[gjeldendeRegel]) &&
-                erUtenInnhold(vurdering.begrunnelse)
+                harIkkeVerdi(vurdering.begrunnelse)
             ) {
-                valideringsfeil[gjeldendeRegel] = 'Begrunnelse er obligatorisk for dette valget';
+                valideringsfeil.vilkårsvurdering[gjeldendeRegel] =
+                    'Begrunnelse er obligatorisk for dette valget';
                 return;
             }
         });
@@ -31,12 +55,10 @@ export const validerVilkårsvurderinger = (
     return valideringsfeil;
 };
 
+const fomErEtterTom = (fom?: string, tom?: string) => fom && tom && !erDatoEtterEllerLik(fom, tom);
+
 const begrunnelseKreves = (svar: string, regel: Regel): boolean => {
     const valgtSvaralternativ = regel?.svarMapping[svar];
 
     return valgtSvaralternativ?.begrunnelseType === BegrunnelseRegel.PÅKREVD;
-};
-
-const erUtenInnhold = (str: string | undefined | null): boolean => {
-    return !str || str.trim() === '';
 };

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
@@ -4,12 +4,16 @@ import { harIkkeVerdi } from '../../../utils/utils';
 import { Delvilkår } from '../vilkår';
 
 export type Feilmeldinger = {
-    vilkårsvurdering: Record<RegelId, string | undefined>;
+    delvilkårsvurderinger: Record<RegelId, string | undefined>;
     fom?: string;
     tom?: string;
 };
 
-export const ingenFeil = { vilkårsvurdering: {} };
+export const ingenFeil = { delvilkårsvurderinger: {} };
+
+export function ingen(valideringsfeil: Feilmeldinger) {
+    return JSON.stringify(valideringsfeil) === JSON.stringify(ingenFeil);
+}
 
 export const validerVilkårsvurderinger = (
     periodiserteVilkårIsEnabled: boolean,
@@ -18,7 +22,7 @@ export const validerVilkårsvurderinger = (
     fom?: string,
     tom?: string
 ): Feilmeldinger => {
-    const valideringsfeil: Feilmeldinger = { vilkårsvurdering: {} };
+    const valideringsfeil: Feilmeldinger = { delvilkårsvurderinger: {} };
 
     if (periodiserteVilkårIsEnabled) {
         if (harIkkeVerdi(fom)) {
@@ -38,7 +42,7 @@ export const validerVilkårsvurderinger = (
             const gjeldendeRegel = vurdering.regelId;
 
             if (!vurdering.svar) {
-                valideringsfeil.vilkårsvurdering[gjeldendeRegel] = 'Du må ta et valg';
+                valideringsfeil.delvilkårsvurderinger[gjeldendeRegel] = 'Du må ta et valg';
                 return;
             }
 
@@ -46,7 +50,7 @@ export const validerVilkårsvurderinger = (
                 begrunnelseKreves(vurdering.svar, regler[gjeldendeRegel]) &&
                 harIkkeVerdi(vurdering.begrunnelse)
             ) {
-                valideringsfeil.vilkårsvurdering[gjeldendeRegel] =
+                valideringsfeil.delvilkårsvurderinger[gjeldendeRegel] =
                     'Begrunnelse er obligatorisk for dette valget';
                 return;
             }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det gir en bedre brukeropplevelse når brukeren i de fleste tilfeller slipper å forholde seg til feilmeldinger fra backend. 

![image](https://github.com/user-attachments/assets/06bfa2be-b44f-4fe4-a5e4-940062628cd1)
