### PR TITLE
Hent innvilgelsesmaler for revurdering

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
+++ b/src/frontend/Sider/Behandling/Brev/Sanity/queries.ts
@@ -2,8 +2,8 @@ import groq from 'groq';
 
 export const hentMalerQuery = (hentUPubliserte: boolean = false) =>
     hentUPubliserte
-        ? groq`*[ytelse == $ytelse && resultat == $resultat]`
-        : groq`*[ytelse == $ytelse && resultat == $resultat && publisert == true]`;
+        ? groq`*[ytelse == $ytelse && resultat in $resultat]`
+        : groq`*[ytelse == $ytelse && resultat in $resultat && publisert == true]`;
 
 export const malQuery = (id: string, målform: 'bokmål' = 'bokmål') => groq`*[_id == "${id}"][0]{
 ...,

--- a/src/frontend/Sider/Behandling/Brev/brevUtils.ts
+++ b/src/frontend/Sider/Behandling/Brev/brevUtils.ts
@@ -23,18 +23,18 @@ enum SanityMappe {
 export const finnSanityMappe = (
     behandlingstype: BehandlingType,
     vedtakType: TypeVedtak
-): string => {
+): string[] => {
     // Avslagsbrev er like for revurdering og førstegangsbehandling
     if (vedtakType === TypeVedtak.AVSLAG) {
-        return SanityMappe.AVSLAG;
+        return [SanityMappe.AVSLAG];
     }
 
     if (behandlingstype === BehandlingType.REVURDERING) {
-        return SanityMappe.REVURDERING;
+        return [SanityMappe.REVURDERING, SanityMappe.INNVILGET];
     }
 
     if (vedtakType === TypeVedtak.INNVILGELSE) {
-        return SanityMappe.INNVILGET;
+        return [SanityMappe.INNVILGET];
     }
 
     return vedtakType;

--- a/src/frontend/Sider/Behandling/Brev/useBrev.ts
+++ b/src/frontend/Sider/Behandling/Brev/useBrev.ts
@@ -25,7 +25,7 @@ const useBrev = (ytelse: Stønadstype, behandling?: Behandling) => {
     const [brevmottakere, settBrevmottakere] = useState<Ressurs<Brevmottakere>>(byggTomRessurs());
     const [fil, settFil] = useState<Ressurs<string>>(byggTomRessurs());
 
-    const hentBrevmaler = useCallback((resultat: string) => {
+    const hentBrevmaler = useCallback((resultat: string[]) => {
         sanityClient
             .fetch<Brevmal[]>(hentMalerQuery(!erProd()), {
                 resultat: resultat,

--- a/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
+++ b/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
@@ -53,7 +53,7 @@ const FrittståendeBrev: React.FC<{ valgtStønadstype: Stønadstype; fagsakId: s
     }, [mellomlagretBrev, settBrevmal]);
 
     useEffect(() => {
-        hentBrevmaler('FRITTSTAENDE');
+        hentBrevmaler(['FRITTSTAENDE']);
     }, [hentBrevmaler]);
 
     useEffect(() => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Quickfix. Ønsker å vise innvilgelsesmalene også det er en revurering.
Testet lokalt:
<img width="628" alt="image" src="https://github.com/user-attachments/assets/ba089840-dd2f-4d31-a018-0aab8a1c0deb">
