### PR TITLE
Åpner opp for saksbehandling av førstegangsbhenadlinger, men låser be…

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 
-import { useFlag } from '@unleash/proxy-client-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -14,7 +13,6 @@ import { useBehandling } from '../../context/BehandlingContext';
 import { StegProvider } from '../../context/StegContext';
 import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
 import { Toast } from '../../typer/toast';
-import { Toggle } from '../../utils/toggles';
 
 const StickyTablistContainer = styled(Sticky)`
     top: 97px;
@@ -43,9 +41,7 @@ const DisabledTab = styled(Tabs.Tab)`
 const BehandlingTabsInnhold = () => {
     const navigate = useNavigate();
     const { settToast } = useApp();
-    const { behandling, behandlingErRedigerbar } = useBehandling();
-
-    const kanSaksbehandle = useFlag(Toggle.KAN_SAKSBEHANDLE);
+    const { behandling, behandlingErRedigerbar, kanBehandleRevurdering } = useBehandling();
 
     const path = useLocation().pathname.split('/')[3];
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
@@ -110,7 +106,7 @@ const BehandlingTabsInnhold = () => {
                     </TabsList>
                 </StickyTablistContainer>
 
-                {!kanSaksbehandle && (
+                {!kanBehandleRevurdering && (
                     <Alert variant={'error'}>Mulighet for å saksbehandle er skrudd av</Alert>
                 )}
                 <SettPåVentContainer

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { FC, useEffect, useState } from 'react';
 
-import { useFlag } from '@unleash/proxy-client-react';
 import { useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -18,7 +17,6 @@ import { ModalWrapper } from '../../../komponenter/Modal/ModalWrapper';
 import { Behandling } from '../../../typer/behandling/behandling';
 import { BehandlingStatus } from '../../../typer/behandling/behandlingStatus';
 import { Ressurs, RessursStatus } from '../../../typer/ressurs';
-import { Toggle } from '../../../utils/toggles';
 
 const BorderBox = styled.div`
     border: 1px solid ${ABorderSubtle};
@@ -80,12 +78,10 @@ const skalHenteTotrinnskontroll = (
 };
 const Totrinnskontroll: FC = () => {
     const navigate = useNavigate();
-    const { behandling } = useBehandling();
+    const { behandling, kanBehandleRevurdering } = useBehandling();
     const prevBehandling = usePrevious(behandling);
 
     const [visGodkjentModal, settVisGodkjentModal] = useState(false);
-
-    const kanSaksbehandle = useFlag(Toggle.KAN_SAKSBEHANDLE);
 
     const { totrinnskontroll, hentTotrinnskontroll, settTotrinnskontroll } =
         useHentTotrinnskontroll();
@@ -100,7 +96,7 @@ const Totrinnskontroll: FC = () => {
         totrinnskontroll.status === RessursStatus.SUKSESS &&
         totrinnskontroll.data.status !== TotrinnskontrollStatus.UAKTUELT;
 
-    if (!kanSaksbehandle) {
+    if (!kanBehandleRevurdering) {
         return null;
     }
 

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -20,13 +20,15 @@ export const [BehandlingProvider, useBehandling] = constate(
 
         const kanSaksbehandle = useFlag(Toggle.KAN_SAKSBEHANDLE);
 
+        const kanBehandleRevurdering = !behandling.forrigeBehandlingId || kanSaksbehandle;
         const behandlingErRedigerbar =
-            kanSaksbehandle && erBehandlingRedigerbar(behandling.status) && erSaksbehandler;
+            kanBehandleRevurdering && erBehandlingRedigerbar(behandling.status) && erSaksbehandler;
         return {
             behandling,
             behandlingErRedigerbar,
             hentBehandling,
             behandlingFakta,
+            kanBehandleRevurdering,
         };
     }
 );


### PR DESCRIPTION
…handlinger der tidligere behandling har blitt iverksatt.

Vi skal ta en ny vurdering av hvordan det skal virke med disse.

### Hvorfor er denne endringen nødvendig? ✨
Har valgt å bruke `forrigeBehandlingId` fordi jeg kun skal stoppe de revurderinger der førstegangsbehandlingen blitt stoppet. 