### PR TITLE
💅 Personoversikt del 1 - oppgaver

### DIFF
--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgavelisteArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgavelisteArena.tsx
@@ -10,7 +10,7 @@ import { FlexColumn } from '../../../../komponenter/Visningskomponenter/Flex';
 import { formaterNullableIsoDato } from '../../../../utils/dato';
 
 const Tabell = styled(Table)`
-    max-width: 900px;
+    max-width: 1000px;
     border: 1px solid ${ABorderDivider};
     --ac-table-row-border: ${ABorderDivider};
     --ac-table-row-hover: none;

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
@@ -1,12 +1,13 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Button, Heading, VStack } from '@navikt/ds-react';
+import { Button, Detail, Heading, VStack, HStack } from '@navikt/ds-react';
 
 import OppgavelisteArena from './OppgavelisteArena';
 import { OppgaveArena } from './typer';
 import { useApp } from '../../../../context/AppContext';
 import DataViewer from '../../../../komponenter/DataViewer';
 import { Ressurs, byggTomRessurs } from '../../../../typer/ressurs';
+import { formaterDatoMedTidspunkt } from '../../../../utils/dato';
 
 const OppgaverArena: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     const { request } = useApp();
@@ -14,16 +15,18 @@ const OppgaverArena: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId })
     const [oppgaveResponse, settOppgaveResponse] =
         useState<Ressurs<OppgaveArena[]>>(byggTomRessurs());
 
-    const hentOppgaver = useCallback(() => {
-        request<OppgaveArena[], null>(`/api/sak/oppgave/arena/${fagsakPersonId}`).then(
-            settOppgaveResponse
+    const [oppdatertTidspunkt, settOppdatertTidspunkt] = useState<Date | undefined>();
+
+    const hentOppgaver = useCallback(async () => {
+        settOppgaveResponse(
+            await request<OppgaveArena[], null>(`/api/sak/oppgave/arena/${fagsakPersonId}`)
         );
+        settOppdatertTidspunkt(new Date());
     }, [request, fagsakPersonId]);
 
     useEffect(() => {
-        hentOppgaver();
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-    }, []);
+        void hentOppgaver();
+    }, [hentOppgaver]);
 
     return (
         <VStack gap={'2'}>
@@ -32,14 +35,19 @@ const OppgaverArena: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId })
                 {({ oppgaveResponse }) => (
                     <>
                         <OppgavelisteArena oppgaver={oppgaveResponse} />
-                        <Button
-                            onClick={() => hentOppgaver()}
-                            size="small"
-                            variant="secondary"
-                            style={{ maxWidth: 'fit-content' }}
-                        >
-                            Hent oppgaver på nytt
-                        </Button>
+                        <HStack gap="2" align="baseline">
+                            <Detail>
+                                Informasjon hentet: {formaterDatoMedTidspunkt(oppdatertTidspunkt)}
+                            </Detail>
+                            <Button
+                                onClick={() => hentOppgaver()}
+                                size="xsmall"
+                                variant="tertiary"
+                                style={{ maxWidth: 'fit-content' }}
+                            >
+                                Hent på nytt
+                            </Button>
+                        </HStack>
                     </>
                 )}
             </DataViewer>

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Button, Detail, Heading, VStack, HStack } from '@navikt/ds-react';
+import { Detail, Heading, VStack } from '@navikt/ds-react';
 
 import OppgavelisteArena from './OppgavelisteArena';
 import { OppgaveArena } from './typer';
@@ -17,37 +17,25 @@ const OppgaverArena: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId })
 
     const [oppdatertTidspunkt, settOppdatertTidspunkt] = useState<Date | undefined>();
 
-    const hentOppgaver = useCallback(async () => {
-        settOppgaveResponse(
-            await request<OppgaveArena[], null>(`/api/sak/oppgave/arena/${fagsakPersonId}`)
-        );
-        settOppdatertTidspunkt(new Date());
-    }, [request, fagsakPersonId]);
-
     useEffect(() => {
-        void hentOppgaver();
-    }, [hentOppgaver]);
+        request<OppgaveArena[], null>(`/api/sak/oppgave/arena/${fagsakPersonId}`).then(
+            (oppgaverArenaResponse) => {
+                settOppgaveResponse(oppgaverArenaResponse);
+                settOppdatertTidspunkt(new Date());
+            }
+        );
+    }, [fagsakPersonId, request]);
 
     return (
-        <VStack gap={'2'}>
+        <VStack gap="2">
             <Heading size={'xsmall'}>Arena</Heading>
             <DataViewer response={{ oppgaveResponse }}>
                 {({ oppgaveResponse }) => (
                     <>
                         <OppgavelisteArena oppgaver={oppgaveResponse} />
-                        <HStack gap="2" align="baseline">
-                            <Detail>
-                                Informasjon hentet: {formaterDatoMedTidspunkt(oppdatertTidspunkt)}
-                            </Detail>
-                            <Button
-                                onClick={() => hentOppgaver()}
-                                size="xsmall"
-                                variant="tertiary"
-                                style={{ maxWidth: 'fit-content' }}
-                            >
-                                Hent på nytt
-                            </Button>
-                        </HStack>
+                        <Detail>
+                            Informasjon hentet: {formaterDatoMedTidspunkt(oppdatertTidspunkt)}
+                        </Detail>
                     </>
                 )}
             </DataViewer>

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
@@ -15,7 +15,7 @@ import { Mappe, Oppgave } from '../../Oppgavebenk/typer/oppgave';
 import { oppgaveTypeTilVisningstekstSomTarHensynTilKlage } from '../../Oppgavebenk/typer/oppgavetema';
 
 const Tabell = styled(Table)`
-    max-width: 900px;
+    max-width: 1300px;
     border: 1px solid ${ABorderDivider};
     --ac-table-row-border: ${ABorderDivider};
     --ac-table-row-hover: none;

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
@@ -22,10 +22,13 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     const [oppdatertTidspunkt, settOppdatertTidspunkt] = useState<Date | undefined>();
 
     const hentOppgaverOgMapper = useCallback(async () => {
-        settOppgaveResponse(
-            await request<OppgaverResponse, null>(`/api/sak/oppgave/soek/person/${fagsakPersonId}`)
-        );
-        settMapper(await request<Mappe[], null>(`/api/sak/oppgave/mapper`, 'GET'));
+        const [oppgaveResponse, mapperResponse] = await Promise.all([
+            request<OppgaverResponse, null>(`/api/sak/oppgave/soek/person/${fagsakPersonId}`),
+            request<Mappe[], null>(`/api/sak/oppgave/mapper`, 'GET'),
+        ]);
+
+        settOppgaveResponse(oppgaveResponse);
+        settMapper(mapperResponse);
 
         settOppdatertTidspunkt(new Date());
     }, [fagsakPersonId, request]);

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useState } from 'react';
 
-import { Button, Heading, VStack } from '@navikt/ds-react';
+import { Button, Heading, HelpText, HStack, VStack } from '@navikt/ds-react';
 
 import Oppgaveliste from './Oppgaveliste';
 import { mapperTilIdRecord } from './utils';
@@ -40,9 +40,15 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     return (
         <VStack gap={'2'}>
             <Heading size="small" spacing>
-                Ubehandlede oppgaver på bruker
+                Ubehandlede oppgaver på bruker{' '}
             </Heading>
-            <Heading size="xsmall">TS-sak og GOSYS</Heading>
+            <HStack gap="2">
+                <Heading size="xsmall">TS-sak og GOSYS </Heading>
+                <HelpText>
+                    TS-sak og Gosys bruker samme oppgavesystem, men det er bare støtte for å
+                    behandle noen typer oppgaver for tilsyn barn i TS-sak.
+                </HelpText>
+            </HStack>
             <DataViewer response={{ oppgaveResponse, mapper }}>
                 {({ oppgaveResponse, mapper }) => (
                     <>

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
@@ -1,6 +1,6 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React, { useEffect, useState } from 'react';
 
-import { Button, Detail, Heading, HelpText, HStack, VStack } from '@navikt/ds-react';
+import { Detail, Heading, HelpText, HStack, VStack } from '@navikt/ds-react';
 
 import Oppgaveliste from './Oppgaveliste';
 import { mapperTilIdRecord } from './utils';
@@ -21,21 +21,16 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
 
     const [oppdatertTidspunkt, settOppdatertTidspunkt] = useState<Date | undefined>();
 
-    const hentOppgaverOgMapper = useCallback(async () => {
-        const [oppgaveResponse, mapperResponse] = await Promise.all([
+    useEffect(() => {
+        Promise.all([
             request<OppgaverResponse, null>(`/api/sak/oppgave/soek/person/${fagsakPersonId}`),
             request<Mappe[], null>(`/api/sak/oppgave/mapper`, 'GET'),
-        ]);
-
-        settOppgaveResponse(oppgaveResponse);
-        settMapper(mapperResponse);
-
-        settOppdatertTidspunkt(new Date());
+        ]).then(([oppgaverRespons, mappeRespons]) => {
+            settOppgaveResponse(oppgaverRespons);
+            settMapper(mappeRespons);
+            settOppdatertTidspunkt(new Date());
+        });
     }, [fagsakPersonId, request]);
-
-    useEffect(() => {
-        void hentOppgaverOgMapper();
-    }, [hentOppgaverOgMapper]);
 
     const oppdaterOppgaveEtterOppdatering = (oppdatertOppgave: Oppgave) => {
         settOppgaveResponse((prevState) =>
@@ -46,7 +41,7 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
     return (
         <VStack gap={'2'}>
             <Heading size="small" spacing>
-                Ubehandlede oppgaver på bruker{' '}
+                Ubehandlede oppgaver på bruker
             </Heading>
             <HStack gap="2">
                 <Heading size="xsmall">TS-sak og GOSYS </Heading>
@@ -63,19 +58,9 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
                             mapper={mapperTilIdRecord(mapper)}
                             oppdaterOppgaveEtterOppdatering={oppdaterOppgaveEtterOppdatering}
                         />
-                        <HStack gap="2" align="baseline">
-                            <Detail>
-                                Informasjon hentet: {formaterDatoMedTidspunkt(oppdatertTidspunkt)}
-                            </Detail>
-                            <Button
-                                onClick={hentOppgaverOgMapper}
-                                size="xsmall"
-                                variant="tertiary"
-                                style={{ maxWidth: 'fit-content' }}
-                            >
-                                Hent på nytt
-                            </Button>
-                        </HStack>
+                        <Detail>
+                            Informasjon hentet: {formaterDatoMedTidspunkt(oppdatertTidspunkt)}
+                        </Detail>
                     </>
                 )}
             </DataViewer>

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
@@ -39,7 +39,10 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
 
     return (
         <VStack gap={'2'}>
-            <Heading size={'xsmall'}>TS-sak og GOSYS</Heading>
+            <Heading size="small" spacing>
+                Ubehandlede oppgaver på bruker
+            </Heading>
+            <Heading size="xsmall">TS-sak og GOSYS</Heading>
             <DataViewer response={{ oppgaveResponse, mapper }}>
                 {({ oppgaveResponse, mapper }) => (
                     <>

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -20,12 +20,12 @@ type TabWithRouter = {
 
 const tabs: TabWithRouter[] = [
     {
-        label: 'Oppgaver',
+        label: 'Åpne oppgaver',
         path: 'oppgaver',
         komponent: (fagsakPersonId: string) => <Oppgaveoversikt fagsakPersonId={fagsakPersonId} />,
     },
     {
-        label: 'Behandlinger',
+        label: 'Saker',
         path: 'behandlinger',
         komponent: (fagsakPersonId) => <Behandlingsoversikt fagsakPersonId={fagsakPersonId} />,
     },
@@ -40,12 +40,12 @@ const tabs: TabWithRouter[] = [
         komponent: (fagsakPersonId) => <Ytelseoversikt fagsakPersonId={fagsakPersonId} />,
     },
     {
-        label: 'Dokumenter',
+        label: 'Dokumentoversikt',
         path: 'dokumentoversikt',
         komponent: (fagsakPersonId) => <Dokumentoversikt fagsakPersonId={fagsakPersonId} />,
     },
     {
-        label: 'Brev',
+        label: 'Frittstående brev',
         path: 'brev',
         komponent: (fagsakPersonId) => <FrittståendeBrevFane fagsakPersonId={fagsakPersonId} />,
     },

--- a/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, CopyButton, Heading, HStack, Link, Tag } from '@navikt/ds-react';
+import { BodyShort, CopyButton, HStack, Link, Tag } from '@navikt/ds-react';
 import { ABorderStrong, ASpacing2, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 import TagAdressebeskyttelse from './TagAdressebeskyttelse';
@@ -25,14 +25,15 @@ const PersonHeader: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) 
 
     return (
         <Container>
-            <Heading size="xsmall">{personopplysninger.navn.visningsnavn}</Heading>
+            <Link href={`/person/${fagsakPersonId}`}>
+                <BodyShort>{personopplysninger.navn.visningsnavn}</BodyShort>
+            </Link>
             <BodyShort>|</BodyShort>
             <HStack gap="2" align="center">
-                <Link href={`/person/${fagsakPersonId}`}>{personopplysninger.personIdent}</Link>
+                <BodyShort>{personopplysninger.personIdent}</BodyShort>
                 <CopyButton copyText={personopplysninger.personIdent} size="small" />
             </HStack>
             <BodyShort>|</BodyShort>
-
             <TagAdressebeskyttelse adressebeskyttelse={personopplysninger.adressebeskyttelse} />
             {personopplysninger.harVergemål && (
                 <Tag variant={'warning'} size={'small'}>

--- a/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, CopyButton, HStack, Link, Tag } from '@navikt/ds-react';
+import { BodyShort, CopyButton, Heading, HStack, Link, Tag } from '@navikt/ds-react';
 import { ABorderStrong, ASpacing2, ASpacing4 } from '@navikt/ds-tokens/dist/tokens';
 
 import TagAdressebeskyttelse from './TagAdressebeskyttelse';
@@ -25,15 +25,14 @@ const PersonHeader: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) 
 
     return (
         <Container>
-            <Link href={`/person/${fagsakPersonId}`}>
-                <BodyShort>{personopplysninger.navn.visningsnavn}</BodyShort>
-            </Link>
+            <Heading size="xsmall">{personopplysninger.navn.visningsnavn}</Heading>
             <BodyShort>|</BodyShort>
             <HStack gap="2" align="center">
-                <BodyShort>{personopplysninger.personIdent}</BodyShort>
+                <Link href={`/person/${fagsakPersonId}`}>{personopplysninger.personIdent}</Link>
                 <CopyButton copyText={personopplysninger.personIdent} size="small" />
             </HStack>
             <BodyShort>|</BodyShort>
+
             <TagAdressebeskyttelse adressebeskyttelse={personopplysninger.adressebeskyttelse} />
             {personopplysninger.harVergemål && (
                 <Tag variant={'warning'} size={'small'}>

--- a/src/frontend/utils/dato.ts
+++ b/src/frontend/utils/dato.ts
@@ -28,6 +28,10 @@ export const formaterIsoDatoTid = (dato: string): string => {
     return format(parseISO(dato), "dd.MM.yyyy 'kl'. HH:mm");
 };
 
+// Eksempel: formaterDatoMedTidspunkt(new Date()) -> '18.09.2023 kl.10:30'
+export const formaterDatoMedTidspunkt = (dato?: Date) =>
+    dato && formaterIsoDatoTid(formatISO(dato));
+
 // Eksempel: formaterIsoDatoTidKort('2023-09-18T10:30:00') -> '18.09.2023 10:30'
 export const formaterIsoDatoTidKort = (dato: string): string => {
     return format(parseISO(dato), 'dd.MM.yyyy HH:mm');


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Personoversikten trenger en liten gjennomgang for å bedre matche skissene. 

[favro-oppgave](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22179)

Jeg stareter med oppgavelista - [se skisse her](https://www.figma.com/design/7eVA9o9YdfQi7MRuzx9wWu/TS-sak%3A-Personoversikt?node-id=1-7681&t=DSPXboKKo6me2LQO-4)

**Gjort i denne PR-en:** 

- Endrer faneoverskrifter
- Gjør maks-bredden til tabellene større
- Legger til overskrift 
- Legger til oppdateringstidspunkt
- Flytter personoversikten-lenka fra ident til navn

**Dette er _ikke_ gjort i denne PR-en, og jeg er usikker på om vi egentlig trenger å gjøre det nå:** 

- Gjøre tabellen sorterbar 
- Legge inn knapp for å gå til Gosys og Arena 

Før: 
![image](https://github.com/user-attachments/assets/edbb9624-5b80-4d97-89d9-e3c815a14594)


Etter: 
<img width="1559" alt="image" src="https://github.com/user-attachments/assets/441cc3b2-768f-4f5b-becc-ece23b0f34e9">

