### PR TITLE
✨ Vis oppsummering av simuleringen

### DIFF
--- a/src/frontend/Sider/Behandling/Simulering/Oppsumering.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/Oppsumering.tsx
@@ -2,43 +2,37 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Box, Label, Table } from '@navikt/ds-react';
+import { BodyShort, Box, Label } from '@navikt/ds-react';
 
+import { ResultatVerdi } from './ResultatVerdi';
 import { SimuleringOppsummering } from './simuleringTyper';
 import { FlexColumn } from '../../../komponenter/Visningskomponenter/Flex';
-import { formaterDato } from '../../../utils/dato';
 import { formaterTallMedTusenSkilleEllerStrek } from '../../../utils/fomatering';
 
-const Tabell = styled(Table)`
-    width: fit-content;
+const FlexRow = styled.div`
+    display: flex;
+    gap: 3rem;
+    justify-content: space-between;
 `;
 
-const Oppsumering: React.FC<{ oppsumering: SimuleringOppsummering }> = ({ oppsumering }) => {
-    return (
-        <Box padding="4" background={'bg-subtle'}>
-            <FlexColumn>
-                <Label>
-                    Totalt for periode {formaterDato(oppsumering.fom)} til og med{' '}
-                    {formaterDato(oppsumering.tom)}
-                </Label>
-                <Tabell>
-                    <Table.Body>
-                        <Table.Row>
-                            <Table.HeaderCell scope={'row'}>Etterbetaling</Table.HeaderCell>
-                            <Table.DataCell align={'right'}>
-                                {formaterTallMedTusenSkilleEllerStrek(oppsumering.etterbetaling)}
-                            </Table.DataCell>
-                        </Table.Row>
-                        <Table.Row>
-                            <Table.HeaderCell scope={'row'}>Feilutbetaling</Table.HeaderCell>
-                            <Table.DataCell align={'right'}>
-                                {formaterTallMedTusenSkilleEllerStrek(oppsumering.feilutbetaling)}
-                            </Table.DataCell>
-                        </Table.Row>
-                    </Table.Body>
-                </Tabell>
-            </FlexColumn>
-        </Box>
-    );
-};
+const Oppsumering: React.FC<{ oppsummering: SimuleringOppsummering }> = ({ oppsummering }) => (
+    <Box padding="4" borderWidth="1" borderRadius={'medium'} style={{ display: 'flex' }}>
+        <FlexColumn>
+            <Label>Totalt for perioden</Label>
+            <FlexRow>
+                <BodyShort>Feilutbetaling</BodyShort>
+                <ResultatVerdi $verdi={-oppsummering.feilutbetaling}>
+                    {formaterTallMedTusenSkilleEllerStrek(-oppsummering.feilutbetaling)} kr
+                </ResultatVerdi>
+            </FlexRow>
+            <FlexRow>
+                <BodyShort>Etterbetaling</BodyShort>
+                <ResultatVerdi $verdi={oppsummering.etterbetaling}>
+                    {formaterTallMedTusenSkilleEllerStrek(oppsummering.etterbetaling)} kr
+                </ResultatVerdi>
+            </FlexRow>
+        </FlexColumn>
+    </Box>
+);
+
 export default Oppsumering;

--- a/src/frontend/Sider/Behandling/Simulering/ResultatVerdi.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/ResultatVerdi.tsx
@@ -1,0 +1,11 @@
+import styled from 'styled-components';
+
+import { BodyShort } from '@navikt/ds-react';
+import { AGreen500, ARed500 } from '@navikt/ds-tokens/dist/tokens';
+
+/**
+ * Komponent for å vise en verdi med farge rød eller grønn basert på om verdien er positiv eller negativ.
+ */
+export const ResultatVerdi = styled(BodyShort)<{ $verdi: number }>`
+    color: ${(props) => props.$verdi && (props.$verdi > 0 ? AGreen500 : ARed500)};
+`;

--- a/src/frontend/Sider/Behandling/Simulering/Simulering.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/Simulering.tsx
@@ -12,6 +12,7 @@ const Container = styled.div`
     flex-direction: column;
     gap: 1rem;
     width: fit-content;
+    align-items: flex-start;
 `;
 
 const Simulering: React.FC = () => {

--- a/src/frontend/Sider/Behandling/Simulering/SimuleringResultatWrapper.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/SimuleringResultatWrapper.tsx
@@ -1,7 +1,8 @@
 import React, { useEffect, useState } from 'react';
 
-import { Alert } from '@navikt/ds-react';
+import { Alert, Heading } from '@navikt/ds-react';
 
+import Oppsumering from './Oppsumering';
 import SimuleringTabell from './SimuleringTabell';
 import { SimuleringResponse } from './simuleringTyper';
 import { useApp } from '../../../context/AppContext';
@@ -9,6 +10,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import DataViewer from '../../../komponenter/DataViewer';
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
 import { VedtakBarnetilsyn } from '../../../typer/vedtak';
+import { formaterDato } from '../../../utils/dato';
 
 const SimuleringResultatWrapper: React.FC<{ vedtak: VedtakBarnetilsyn }> = ({ vedtak }) => {
     const { behandling, hentBehandling } = useBehandling();
@@ -39,17 +41,20 @@ const SimuleringResultatWrapper: React.FC<{ vedtak: VedtakBarnetilsyn }> = ({ ve
     return (
         <DataViewer response={{ simuleringsresultat }}>
             {({ simuleringsresultat }) => {
-                const perioder = simuleringsresultat?.perioder;
-                return (
+                const { perioder, oppsummering } = simuleringsresultat || {};
+
+                return perioder && oppsummering ? (
                     <>
-                        {perioder ? (
-                            <SimuleringTabell perioder={perioder} />
-                        ) : (
-                            <Alert variant={'info'} inline>
-                                {utledBeskrivelseIngenSimulering(simuleringsresultat)}
-                            </Alert>
-                        )}
+                        <Heading size={'medium'}>
+                            {`Simulering for perioden ${formaterDato(oppsummering.fom)} - ${formaterDato(oppsummering.tom)}`}
+                        </Heading>
+                        <Oppsumering oppsummering={oppsummering} />
+                        <SimuleringTabell perioder={perioder} />
                     </>
+                ) : (
+                    <Alert variant={'info'} inline>
+                        {utledBeskrivelseIngenSimulering(simuleringsresultat)}
+                    </Alert>
                 );
             }}
         </DataViewer>

--- a/src/frontend/Sider/Behandling/Simulering/SimuleringTabell.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/SimuleringTabell.tsx
@@ -2,19 +2,15 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, Table } from '@navikt/ds-react';
-import { AGreen500, ARed500 } from '@navikt/ds-tokens/dist/tokens';
+import { Table } from '@navikt/ds-react';
 
+import { ResultatVerdi } from './ResultatVerdi';
 import { OppsummeringForPeriode } from './simuleringTyper';
 import useSimuleringÅrvelger from './useSimuleringÅrvelger';
 import ÅrVelger from './ÅrVelger';
 import { formaterÅrMåned } from '../../../utils/dato';
 import { formaterTallMedTusenSkilleEllerStrek } from '../../../utils/fomatering';
 import { toTitleCase } from '../../../utils/tekstformatering';
-
-const ResultatVerdi = styled(BodyShort)<{ $verdi: number }>`
-    color: ${(props) => props.$verdi && (props.$verdi > 0 ? AGreen500 : ARed500)};
-`;
 
 const Tabell = styled(Table)`
     margin-top: 1rem;

--- a/src/frontend/Sider/Behandling/Simulering/simuleringTyper.ts
+++ b/src/frontend/Sider/Behandling/Simulering/simuleringTyper.ts
@@ -1,6 +1,7 @@
 export interface SimuleringResponse {
     perioder: OppsummeringForPeriode[] | null;
     ingenEndringIUtbetaling: boolean;
+    oppsummering: SimuleringOppsummering | null;
 }
 
 export interface SimuleringOppsummering {
@@ -8,7 +9,6 @@ export interface SimuleringOppsummering {
     tom: string;
     etterbetaling: number;
     feilutbetaling: number;
-    nesteUtbetaling: null;
 }
 
 export interface OppsummeringForPeriode {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vil sammenstille informasjon fra simulering så saksbehandler forstår om det blir feilutbetaling og det evt. må nevnes i brev.

Alert om feilutbetaling kommer i egen PR.

![image](https://github.com/user-attachments/assets/98475eb4-4b8f-4c90-b884-26f5d7fd5dd3)
