### PR TITLE
Endrer Layout på brevsiden etter tilbakemelding fra saksbehandler

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -102,7 +102,7 @@ const Brev: React.FC = () => {
                 <DataViewer response={{ brevmaler, mellomlagretBrev }}>
                     {({ brevmaler, mellomlagretBrev }) => (
                         <ToKolonner>
-                            <VStack gap="8">
+                            <VStack gap="8" align="start">
                                 {isEnabled && (
                                     <BrevMottakere
                                         behandlingId={behandling.id}

--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -102,7 +102,7 @@ const Brev: React.FC = () => {
                 <DataViewer response={{ brevmaler, mellomlagretBrev }}>
                     {({ brevmaler, mellomlagretBrev }) => (
                         <ToKolonner>
-                            <VStack gap="8" align="start">
+                            <VStack gap="8">
                                 {isEnabled && (
                                     <BrevMottakere
                                         behandlingId={behandling.id}

--- a/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
+++ b/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
@@ -1,30 +1,14 @@
 import React, { useState } from 'react';
 
-import styled from 'styled-components';
-
-import { Alert, BodyShort, Button, Label, Tooltip } from '@navikt/ds-react';
+import { PencilIcon } from '@navikt/aksel-icons';
+import { BodyShort, Button, HStack, Label, Tooltip, VStack } from '@navikt/ds-react';
 
 import { EndreBrevmottakereModal } from './EndreBrevmottakereModal';
-import { Applikasjonskontekst, EBrevmottakerRolle, IBrevmottakere } from './typer';
+import { Applikasjonskontekst, IBrevmottakere } from './typer';
 import { useBrevmottakere } from '../../hooks/useBrevmottakere';
 import { PersonopplysningerIBrevmottakere } from '../../Sider/Behandling/Brev/typer';
 import { leggTilKolonOgMellomrom, tilLitenSkriftMedStorForbokstav } from '../../utils/fomatering';
 import DataViewer from '../DataViewer';
-
-const Grid = styled.div`
-    display: flex;
-    justify-content: space-between;
-    align-items: flex-start;
-`;
-
-const InfoHeader = styled.div`
-    display: flex;
-    justify-content: space-between;
-`;
-
-const KompaktButton = styled(Button)`
-    padding: 0;
-`;
 
 const Brevmottakere: React.FC<{
     mottakere: IBrevmottakere;
@@ -45,53 +29,33 @@ const Brevmottakere: React.FC<{
     };
 
     const navn = utledNavnPåMottakere(mottakere);
-    const flereBrevmottakereErValgt = navn.length > 1;
-    const brukerErBrevmottaker = mottakere.personer.find(
-        (person) => person.mottakerRolle === EBrevmottakerRolle.BRUKER
-    );
 
-    return flereBrevmottakereErValgt || !brukerErBrevmottaker ? (
-        <Alert variant={'info'}>
-            <InfoHeader>
-                <Label>Brevmottakere:</Label>
+    return (
+        <VStack gap="2">
+            <HStack align="center">
+                <Label size="small">Brevmottakere</Label>
                 {behandlingErRedigerbar && (
                     <Tooltip content={'Legg til verge eller fullmektige brevmottakere'}>
-                        <KompaktButton
-                            variant={'tertiary'}
+                        <Button
+                            variant="tertiary"
                             onClick={() => settVisBrevmottakereModal(true)}
+                            size="xsmall"
+                            icon={<PencilIcon />}
                         >
-                            Legg til/endre brevmottakere
-                        </KompaktButton>
+                            Endre
+                        </Button>
                     </Tooltip>
                 )}
-            </InfoHeader>
-            <ul>
-                {navn.map((navn, index) => (
-                    <li key={navn + index}>
-                        <BodyShort key={navn + index}>{navn}</BodyShort>
-                    </li>
-                ))}
-            </ul>
-        </Alert>
-    ) : (
-        <Grid>
-            <span>
-                <Label>Brevmottaker:</Label>
-                <BodyShort>{navn.map((navn) => navn)}</BodyShort>
-            </span>
-            {behandlingErRedigerbar && (
-                <Tooltip content={'Legg til verge eller fullmektige brevmottakere'}>
-                    <KompaktButton
-                        variant={'tertiary'}
-                        onClick={() => settVisBrevmottakereModal(true)}
-                    >
-                        Legg til/endre brevmottakere
-                    </KompaktButton>
-                </Tooltip>
-            )}
-        </Grid>
+            </HStack>
+            {navn.map((navn, index) => (
+                <BodyShort size="small" key={navn + index}>
+                    {navn}
+                </BodyShort>
+            ))}
+        </VStack>
     );
 };
+
 const BrevMottakere: React.FC<{
     behandlingId: string;
     applikasjonskontekst: Applikasjonskontekst;

--- a/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
+++ b/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
@@ -12,22 +12,18 @@ import { leggTilKolonOgMellomrom, tilLitenSkriftMedStorForbokstav } from '../../
 import DataViewer from '../DataViewer';
 
 const Grid = styled.div`
-    display: grid;
-    grid-template-columns: 9rem 23rem 16rem;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
 `;
 
 const InfoHeader = styled.div`
-    display: grid;
-    grid-template-columns: 26rem 12rem;
+    display: flex;
+    justify-content: space-between;
 `;
 
 const KompaktButton = styled(Button)`
     padding: 0;
-    justify-content: right;
-
-    .navds-button__inner {
-        margin: 0;
-    }
 `;
 
 const Brevmottakere: React.FC<{
@@ -79,8 +75,10 @@ const Brevmottakere: React.FC<{
         </Alert>
     ) : (
         <Grid>
-            <Label>Brevmottaker:</Label>
-            <BodyShort>{navn.map((navn) => navn)}</BodyShort>
+            <span>
+                <Label>Brevmottaker:</Label>
+                <BodyShort>{navn.map((navn) => navn)}</BodyShort>
+            </span>
             {behandlingErRedigerbar && (
                 <Tooltip content={'Legg til verge eller fullmektige brevmottakere'}>
                     <KompaktButton


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Endrer Layout på Brevsiden etter innspill fra Tone.

Har ikke sjekket hvordan dette ser ut i Klage-løsningen enda

**Update: ** Endret så det er samme layout på både 1 og flere mottakere. Fjernet alert og gjort knapp mindre

FAVRO: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22520
******
**FØR**:

![Skjermbilde 2024-09-19 kl  15 54 38](https://github.com/user-attachments/assets/dce155ab-e0bc-4e20-895c-849600a9f867)
![Skjermbilde 2024-09-19 kl  15 54 53](https://github.com/user-attachments/assets/a72ae617-c569-4521-91d6-58d8a83d9ea2)
******
**ETTER**:
En brevmottaker: 
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/57fe5d0e-379f-4f53-9387-d4355cf61815">

Flere brevmottakere: 
<img width="1286" alt="image" src="https://github.com/user-attachments/assets/d61ed691-5b1e-4e98-a17f-59921d436abd">

