### PR TITLE
💄 Feilmeldinger skal ikke påvirke visning av 

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -9,6 +9,7 @@ import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
 import { useTriggRerendringAvDateInput } from '../../../../hooks/useTriggRerendringAvDateInput';
 import TextField from '../../../../komponenter/Skjema/TextField';
+import { Celle } from '../../../../komponenter/Visningskomponenter/Celle';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
@@ -27,7 +28,6 @@ import {
 } from '../typer/vilkårperiode';
 import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad';
 import { EndreVilkårsperiode, validerVilkårsperiode } from '../Vilkårperioder/validering';
-import { Celle } from '../Vilkårperioder/VilkårperiodeRad';
 
 export interface EndreAktivitetForm extends Periode {
     aktivitetsdager?: number;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -27,6 +27,7 @@ import {
 } from '../typer/vilkårperiode';
 import EndreVilkårperiodeRad from '../Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad';
 import { EndreVilkårsperiode, validerVilkårsperiode } from '../Vilkårperioder/validering';
+import { Celle } from '../Vilkårperioder/VilkårperiodeRad';
 
 export interface EndreAktivitetForm extends Periode {
     aktivitetsdager?: number;
@@ -154,25 +155,27 @@ const EndreAktivitetRad: React.FC<{
             tomKeyDato={tomKeyDato}
             ekstraCeller={
                 aktivitetForm.type !== AktivitetType.INGEN_AKTIVITET && (
-                    <TextField
-                        erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
-                        label="Aktivitetsdager"
-                        value={
-                            harTallverdi(aktivitetForm.aktivitetsdager)
-                                ? aktivitetForm.aktivitetsdager
-                                : ''
-                        }
-                        onChange={(event) =>
-                            settAktivitetForm((prevState) => ({
-                                ...prevState,
-                                aktivitetsdager: tilHeltall(event.target.value),
-                            }))
-                        }
-                        size="small"
-                        error={vilkårsperiodeFeil?.aktivitetsdager}
-                        autoComplete="off"
-                        readOnly={!alleFelterKanEndres}
-                    />
+                    <Celle $width={140}>
+                        <TextField
+                            erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
+                            label="Aktivitetsdager"
+                            value={
+                                harTallverdi(aktivitetForm.aktivitetsdager)
+                                    ? aktivitetForm.aktivitetsdager
+                                    : ''
+                            }
+                            onChange={(event) =>
+                                settAktivitetForm((prevState) => ({
+                                    ...prevState,
+                                    aktivitetsdager: tilHeltall(event.target.value),
+                                }))
+                            }
+                            size="small"
+                            error={vilkårsperiodeFeil?.aktivitetsdager}
+                            autoComplete="off"
+                            readOnly={!alleFelterKanEndres}
+                        />
+                    </Celle>
                 )
             }
         >

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -10,6 +10,7 @@ import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { Feilmelding } from '../../../../../komponenter/Feil/Feilmelding';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import SelectMedOptions, { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
+import { Celle } from '../../../../../komponenter/Visningskomponenter/Celle';
 import { EndreAktivitetForm } from '../../Aktivitet/EndreAktivitetRad';
 import { EndreMålgruppeForm } from '../../Målgruppe/EndreMålgruppeRad';
 import { Aktivitet } from '../../typer/aktivitet';
@@ -19,7 +20,6 @@ import SlettVilkårperiodeModal from '../SlettVilkårperiodeModal';
 import { EndreVilkårsperiode } from '../validering';
 import { tittelSelectTypeVilkårperiode, TypeVilkårperiode } from '../VilkårperiodeKort/utils';
 import VilkårperiodeKortBase from '../VilkårperiodeKort/VilkårperiodeKortBase';
-import { Celle } from '../VilkårperiodeRad';
 
 const FeltContainer = styled.div`
     flex-grow: 1;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -19,6 +19,7 @@ import SlettVilkårperiodeModal from '../SlettVilkårperiodeModal';
 import { EndreVilkårsperiode } from '../validering';
 import { tittelSelectTypeVilkårperiode, TypeVilkårperiode } from '../VilkårperiodeKort/utils';
 import VilkårperiodeKortBase from '../VilkårperiodeKort/VilkårperiodeKortBase';
+import { Celle } from '../VilkårperiodeRad';
 
 const FeltContainer = styled.div`
     flex-grow: 1;
@@ -73,37 +74,42 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
     return (
         <VilkårperiodeKortBase vilkårperiode={vilkårperiode} redigeres>
             <FeltContainer>
-                <SelectMedOptions
-                    label={tittelSelectTypeVilkårperiode(type)}
-                    readOnly={!alleFelterKanEndres}
-                    value={form.type}
-                    valg={typeOptions}
-                    onChange={(e) => oppdaterType(e.target.value)}
-                    size="small"
-                    error={vilkårsperiodeFeil?.type}
-                />
+                <Celle>
+                    <SelectMedOptions
+                        label={tittelSelectTypeVilkårperiode(type)}
+                        readOnly={!alleFelterKanEndres}
+                        value={form.type}
+                        valg={typeOptions}
+                        onChange={(e) => oppdaterType(e.target.value)}
+                        size="small"
+                        error={vilkårsperiodeFeil?.type}
+                    />
+                </Celle>
 
-                <DateInputMedLeservisning
-                    key={fomKeyDato}
-                    erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
-                    readOnly={!alleFelterKanEndres}
-                    label={'Fra'}
-                    value={form?.fom}
-                    onChange={(dato) => oppdaterForm('fom', dato || '')}
-                    size="small"
-                    feil={vilkårsperiodeFeil?.fom}
-                />
+                <Celle $width={130}>
+                    <DateInputMedLeservisning
+                        key={fomKeyDato}
+                        erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
+                        readOnly={!alleFelterKanEndres}
+                        label={'Fra'}
+                        value={form?.fom}
+                        onChange={(dato) => oppdaterForm('fom', dato || '')}
+                        size="small"
+                        feil={vilkårsperiodeFeil?.fom}
+                    />
+                </Celle>
 
-                <DateInputMedLeservisning
-                    key={tomKeyDato}
-                    erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
-                    label={'Til'}
-                    value={form?.tom}
-                    onChange={(dato) => oppdaterForm('tom', dato || '')}
-                    size="small"
-                    feil={vilkårsperiodeFeil?.tom}
-                />
-
+                <Celle $width={130}>
+                    <DateInputMedLeservisning
+                        key={tomKeyDato}
+                        erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
+                        label={'Til'}
+                        value={form?.tom}
+                        onChange={(dato) => oppdaterForm('tom', dato || '')}
+                        size="small"
+                        feil={vilkårsperiodeFeil?.tom}
+                    />
+                </Celle>
                 {ekstraCeller}
             </FeltContainer>
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -9,6 +9,7 @@ import DelvilkårDetaljer from './VilkårperiodeKort/DelvilkårDetaljer';
 import VilkårperiodeKortBase from './VilkårperiodeKort/VilkårperiodeKortBase';
 import { useSteg } from '../../../../context/StegContext';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
+import { Celle } from '../../../../komponenter/Visningskomponenter/Celle';
 import { formaterIsoPeriode } from '../../../../utils/dato';
 import { Aktivitet } from '../typer/aktivitet';
 import { Målgruppe } from '../typer/målgruppe';
@@ -19,10 +20,6 @@ const CelleContainer = styled.div`
     display: flex;
     gap: 1rem;
     flex-wrap: wrap;
-`;
-
-export const Celle = styled.div<{ $width?: number }>`
-    width: ${({ $width = 180 }) => $width}px;
 `;
 
 // TODO: Endre navn til VilkårperiodeKort

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeRad.tsx
@@ -21,7 +21,7 @@ const CelleContainer = styled.div`
     flex-wrap: wrap;
 `;
 
-const Celle = styled.div<{ $width?: number }>`
+export const Celle = styled.div<{ $width?: number }>`
     width: ${({ $width = 180 }) => $width}px;
 `;
 

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -211,7 +211,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     const EndrePerioder = (
         <PeriodeGrid>
             <MonthInput
-                label="Periode fra og med"
+                label="Fra"
                 size="small"
                 value={fom}
                 feil={feilmeldinger.fom}
@@ -223,7 +223,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                 }}
             />
             <MonthInput
-                label="Periode til og med"
+                label="Til"
                 size="small"
                 value={tom}
                 feil={feilmeldinger.tom}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -3,7 +3,7 @@ import React, { FC, useEffect, useId, useState } from 'react';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
-import { ErrorMessage, HStack, VStack } from '@navikt/ds-react';
+import { ErrorMessage, VStack } from '@navikt/ds-react';
 import { ABorderAction, AShadowXsmall } from '@navikt/ds-tokens/dist/tokens';
 
 import Begrunnelse from './Begrunnelse';
@@ -58,6 +58,13 @@ const Knapper = styled.div`
     .right {
         margin-left: auto;
     }
+`;
+
+const PeriodeGrid = styled.div`
+    display: grid;
+    grid-template-columns: repeat(3, 150px);
+    align-items: start;
+    gap: 1rem;
 `;
 
 type EndreVilkårProps = {
@@ -202,7 +209,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     };
 
     const EndrePerioder = (
-        <HStack gap="6">
+        <PeriodeGrid>
             <MonthInput
                 label="Periode fra og med"
                 size="small"
@@ -237,7 +244,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                     settUtgift(tilHeltall(fjernSpaces(e.target.value)));
                 }}
             />
-        </HStack>
+        </PeriodeGrid>
     );
 
     const EndreDelvilkår = delvilkårsett.map((delvikår, delvilkårIndex) => {
@@ -279,6 +286,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     });
 
     const slettVilkår = props.slettVilkår;
+
     return (
         <StyledForm onSubmit={validerOgLagreVilkårsvurderinger}>
             <FlexColumn $gap={1}>

--- a/src/frontend/komponenter/Visningskomponenter/Celle.tsx
+++ b/src/frontend/komponenter/Visningskomponenter/Celle.tsx
@@ -1,0 +1,5 @@
+import styled from 'styled-components';
+
+export const Celle = styled.div<{ $width?: number }>`
+    width: ${({ $width = 180 }) => $width}px;
+`;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Før fikk feilmeldingene så mye plass de ønsket og dyttet andre felter vekk: 
<img width="986" alt="image" src="https://github.com/user-attachments/assets/39ea7f2c-c7a1-4e9b-98a5-7d4694f9e983">

<img width="986" alt="image" src="https://github.com/user-attachments/assets/a48f0d44-9cc3-4023-906b-fb4d9384bfaa">

Etter: 
<img width="986" alt="image" src="https://github.com/user-attachments/assets/47dba7d8-2c05-47d4-8304-105362737c1f">

<img width="986" alt="image" src="https://github.com/user-attachments/assets/aa042836-513f-4208-b004-45f6fbb3a398">