### PR TITLE
Feilmeldinger styling

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -9,7 +9,7 @@ import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
 import { useTriggRerendringAvDateInput } from '../../../../hooks/useTriggRerendringAvDateInput';
 import TextField from '../../../../komponenter/Skjema/TextField';
-import { Celle } from '../../../../komponenter/Visningskomponenter/Celle';
+import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
@@ -155,7 +155,7 @@ const EndreAktivitetRad: React.FC<{
             tomKeyDato={tomKeyDato}
             ekstraCeller={
                 aktivitetForm.type !== AktivitetType.INGEN_AKTIVITET && (
-                    <Celle $width={140}>
+                    <FeilmeldingMaksBredde $maxWidth={140}>
                         <TextField
                             erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
                             label="Aktivitetsdager"
@@ -175,7 +175,7 @@ const EndreAktivitetRad: React.FC<{
                             autoComplete="off"
                             readOnly={!alleFelterKanEndres}
                         />
-                    </Celle>
+                    </FeilmeldingMaksBredde>
                 )
             }
         >

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -5,6 +5,7 @@ import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPeri
 import { SøppelbøtteKnapp } from '../../../../komponenter/Knapper/SøppelbøtteKnapp';
 import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
 import SelectMedOptions from '../../../../komponenter/Skjema/SelectMedOptions';
+import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { aktivitetTypeOptionsForStønadsperiode, aktivitetTypeTilTekst } from '../typer/aktivitet';
 import { målgruppeTypeOptionsForStønadsperiode, målgruppeTypeTilTekst } from '../typer/målgruppe';
 import { Stønadsperiode } from '../typer/stønadsperiode';
@@ -68,27 +69,30 @@ const StønadsperiodeRad: React.FC<Props> = ({
                 size="small"
                 error={finnFeilmelding('målgruppe')}
             />
-
-            <DateInputMedLeservisning
-                erLesevisning={erLeservisning}
-                label={'Fra'}
-                hideLabel
-                value={stønadsperide.fom}
-                readOnly={!alleFelterKanEndres}
-                onChange={(dato) => oppdaterStønadsperiode('fom', dato || '')}
-                size="small"
-                feil={finnFeilmelding('fom')}
-            />
-            <DateInputMedLeservisning
-                erLesevisning={erLeservisning}
-                label={'Til'}
-                hideLabel
-                value={stønadsperide.tom}
-                readOnly={helePeriodenErLåstForEndring}
-                onChange={(dato) => oppdaterStønadsperiode('tom', dato || '')}
-                size="small"
-                feil={finnFeilmelding('tom')}
-            />
+            <FeilmeldingMaksBredde>
+                <DateInputMedLeservisning
+                    erLesevisning={erLeservisning}
+                    label={'Fra'}
+                    hideLabel
+                    value={stønadsperide.fom}
+                    readOnly={!alleFelterKanEndres}
+                    onChange={(dato) => oppdaterStønadsperiode('fom', dato || '')}
+                    size="small"
+                    feil={finnFeilmelding('fom')}
+                />
+            </FeilmeldingMaksBredde>
+            <FeilmeldingMaksBredde>
+                <DateInputMedLeservisning
+                    erLesevisning={erLeservisning}
+                    label={'Til'}
+                    hideLabel
+                    value={stønadsperide.tom}
+                    readOnly={helePeriodenErLåstForEndring}
+                    onChange={(dato) => oppdaterStønadsperiode('tom', dato || '')}
+                    size="small"
+                    feil={finnFeilmelding('tom')}
+                />
+            </FeilmeldingMaksBredde>
             {!erLeservisning && alleFelterKanEndres && (
                 <SøppelbøtteKnapp onClick={slettPeriode} size="xsmall" type="button" />
             )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -27,6 +27,7 @@ const Grid = styled.div`
     grid-template-columns: repeat(5, max-content);
     grid-row-gap: 0.5rem;
     grid-column-gap: 1.5rem;
+    align-items: start;
 
     .kolonne1 {
         grid-column: 1;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -10,7 +10,7 @@ import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { Feilmelding } from '../../../../../komponenter/Feil/Feilmelding';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import SelectMedOptions, { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
-import { Celle } from '../../../../../komponenter/Visningskomponenter/Celle';
+import { FeilmeldingMaksBredde } from '../../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { EndreAktivitetForm } from '../../Aktivitet/EndreAktivitetRad';
 import { EndreMålgruppeForm } from '../../Målgruppe/EndreMålgruppeRad';
 import { Aktivitet } from '../../typer/aktivitet';
@@ -74,7 +74,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
     return (
         <VilkårperiodeKortBase vilkårperiode={vilkårperiode} redigeres>
             <FeltContainer>
-                <Celle>
+                <FeilmeldingMaksBredde>
                     <SelectMedOptions
                         label={tittelSelectTypeVilkårperiode(type)}
                         readOnly={!alleFelterKanEndres}
@@ -84,9 +84,9 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                         size="small"
                         error={vilkårsperiodeFeil?.type}
                     />
-                </Celle>
+                </FeilmeldingMaksBredde>
 
-                <Celle $width={130}>
+                <FeilmeldingMaksBredde>
                     <DateInputMedLeservisning
                         key={fomKeyDato}
                         erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
@@ -97,9 +97,9 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                         size="small"
                         feil={vilkårsperiodeFeil?.fom}
                     />
-                </Celle>
+                </FeilmeldingMaksBredde>
 
-                <Celle $width={130}>
+                <FeilmeldingMaksBredde>
                     <DateInputMedLeservisning
                         key={tomKeyDato}
                         erLesevisning={vilkårperiode?.kilde === KildeVilkårsperiode.SYSTEM}
@@ -109,7 +109,7 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
                         size="small"
                         feil={vilkårsperiodeFeil?.tom}
                     />
-                </Celle>
+                </FeilmeldingMaksBredde>
                 {ekstraCeller}
             </FeltContainer>
 

--- a/src/frontend/komponenter/Visningskomponenter/FeilmeldingFastBredde.tsx
+++ b/src/frontend/komponenter/Visningskomponenter/FeilmeldingFastBredde.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components';
+
+export const FeilmeldingMaksBredde = styled.div<{ $maxWidth?: number }>`
+    .navds-error-message {
+        max-width: ${({ $maxWidth: $width = 130 }) => $width}px;
+    }
+`;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Så slik ut på saksbehandlernes pc: 
![image](https://github.com/user-attachments/assets/9c3debea-f307-4eb2-b80d-ccc02afb5831)

**Problem:**
Datovelgeren ser ut som den har fast bredde basert på ✨ noe ✨ men den er ulik på ulike pcer, så bruk av celle gjorde at den lå oppå hverandre for de. 

**Løsning:**
 Lage en wrapper som setter bredden direkte på feilmeldingen i de tilfellene det er nødvendig. 

Ser fortsatt helt likt ut som det i originalpr hvor dette ble prøvd fikset:
![image](https://github.com/user-attachments/assets/b88ffacd-698d-4273-befe-ca54d53f15c6)

### Stønadsperioder
Innså at det samme gjalt stønadsperioder så de er også stylet litt

|FØR|ETTER|
|---|---|
|<img width="1140" alt="image" src="https://github.com/user-attachments/assets/8df43b5f-960c-4ba2-a906-66c2b090f2ba">|<img width="858" alt="image" src="https://github.com/user-attachments/assets/967858c7-9b1a-46bc-87ba-2bd2c41fe9fd">|