### PR TITLE
Skal vise hvorfor en periode er slettet

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/OppsummertVilkårsvurdering.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/OppsummertVilkårsvurdering.tsx
@@ -34,7 +34,7 @@ export const informasjonForFaktisktMålgruppe: Record<FaktiskMålgruppe, string>
     INGEN_MÅLGRUPPE: 'Ikke i målgruppe',
 };
 
-const OppsummertVilkårsvurdering: React.FC<{
+export const OppsummertVilkårsvurdering: React.FC<{
     vilkårperiode?: Målgruppe | Aktivitet;
     redigeres: boolean;
     className?: string;
@@ -43,34 +43,17 @@ const OppsummertVilkårsvurdering: React.FC<{
         return <OppsummeringKommer className={className} />;
     }
 
-    const delvilkårSomMåOppsummeres = finnDelvilkårTilOppsummering(
-        vilkårperiode.delvilkår,
-        vilkårperiode.resultat
-    );
-
     return (
         <Container className={className}>
             <HStack align="center" gap="4">
                 <VilkårsresultatIkon vilkårsresultat={vilkårperiode.resultat} />
                 <Label size="small">{VilkårperiodeResultatTilTekst[vilkårperiode.resultat]}</Label>
             </HStack>
-            <VStack gap="2">
-                {erMålgruppe(vilkårperiode) && (
-                    <Detail>
-                        <strong>Målgruppe: </strong>
-                        {
-                            informasjonForFaktisktMålgruppe[
-                                MålgruppeTypeTilFaktiskMålgruppe[vilkårperiode.type]
-                            ]
-                        }
-                    </Detail>
-                )}
-                {delvilkårSomMåOppsummeres.length > 0 && (
-                    <Detail>
-                        {`${formaterEnumVerdi(vilkårperiode.resultat)}: ${formaterDelvilkårKeys(delvilkårSomMåOppsummeres)}`}
-                    </Detail>
-                )}
-            </VStack>
+            {vilkårperiode.resultat === 'SLETTET' ? (
+                <SlettetPeriodeOppsummering slettetKommentar={vilkårperiode.slettetKommentar} />
+            ) : (
+                <OppsummeringAvDelvilkår vilkårperiode={vilkårperiode} />
+            )}
         </Container>
     );
 };
@@ -88,4 +71,37 @@ const OppsummeringKommer: React.FC<{ className?: string }> = ({ className }) => 
     );
 };
 
-export default OppsummertVilkårsvurdering;
+const SlettetPeriodeOppsummering: React.FC<{ slettetKommentar?: string }> = ({
+    slettetKommentar,
+}) => {
+    return <Detail>{slettetKommentar}</Detail>;
+};
+
+const OppsummeringAvDelvilkår: React.FC<{ vilkårperiode: Målgruppe | Aktivitet }> = ({
+    vilkårperiode,
+}) => {
+    const delvilkårSomMåOppsummeres = finnDelvilkårTilOppsummering(
+        vilkårperiode.delvilkår,
+        vilkårperiode.resultat
+    );
+
+    return (
+        <VStack gap="2">
+            {erMålgruppe(vilkårperiode) && (
+                <Detail>
+                    <strong>Målgruppe: </strong>
+                    {
+                        informasjonForFaktisktMålgruppe[
+                            MålgruppeTypeTilFaktiskMålgruppe[vilkårperiode.type]
+                        ]
+                    }
+                </Detail>
+            )}
+            {delvilkårSomMåOppsummeres.length > 0 && (
+                <Detail>
+                    {`${formaterEnumVerdi(vilkårperiode.resultat)}: ${formaterDelvilkårKeys(delvilkårSomMåOppsummeres)}`}
+                </Detail>
+            )}
+        </VStack>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase.tsx
@@ -5,7 +5,7 @@ import { styled } from 'styled-components';
 
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 
-import OppsummertVilkårsvurdering from './OppsummertVilkårsvurdering';
+import { OppsummertVilkårsvurdering } from './OppsummertVilkårsvurdering';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { Statusbånd } from '../../../../../komponenter/Statusbånd';
 import { BehandlingType } from '../../../../../typer/behandling/behandlingType';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Før viste vi ikke kommentaren som ble lagt inn ved sletting av en vilkårperiode

<img width="1057" alt="image" src="https://github.com/user-attachments/assets/487e76f1-0b5c-4977-8a4a-62b4244ba90d">
