### PR TITLE
Forskjellig visning for fakta tilsynbarn og laremidler

### DIFF
--- a/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarn.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarn.tsx
@@ -4,6 +4,7 @@ import { automatiskVurdert } from './automatiskVurdert';
 import { PassBarnLesMer } from './PassBarnLesMer';
 import { InlineKopiknapp } from '../../../../komponenter/Knapper/InlineKopiknapp';
 import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Regler } from '../../../../typer/regel';
 import {
     lenkerForskriftPassBarn,
@@ -25,6 +26,9 @@ const PassBarn: React.FC<Props> = ({ vilkårsregler, vilkårsvurdering }) => {
         (v) => v.vilkårType === Inngangsvilkårtype.PASS_BARN
     );
 
+    if (vilkårsvurdering.grunnlag['@type'] !== Stønadstype.BARNETILSYN) {
+        return <>Feil faktatype for pass av barn</>;
+    }
     return vilkårsvurdering.grunnlag.barn.map((barn) => {
         const vilkårForDetteBarnet = vilkårsett.filter((e) => e.barnId === barn.barnId);
 

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringLæremidler.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { CalendarIcon } from '@navikt/aksel-icons';
+import { BodyShort } from '@navikt/ds-react';
+
+import ArbeidOgOpphold from './ArbeidOgOpphold';
+import Hovedytelse from './Hovedytelse';
+import Utdanning from './Utdanning';
+import Vedlegg from './Vedlegg';
+import { InfoSeksjon } from './Visningskomponenter';
+import { BehandlingFaktaLæremidler } from '../../../../typer/behandling/behandlingFakta/behandlingFakta';
+import { formaterDato } from '../../../../utils/dato';
+
+const OppsummeringLæremidler: React.FC<{
+    behandlingFakta: BehandlingFaktaLæremidler;
+}> = ({ behandlingFakta }) => {
+    return (
+        <>
+            {behandlingFakta.søknadMottattTidspunkt && (
+                <InfoSeksjon label="Søknadsdato" ikon={<CalendarIcon />}>
+                    <BodyShort size="small">
+                        {formaterDato(behandlingFakta.søknadMottattTidspunkt)}
+                    </BodyShort>
+                </InfoSeksjon>
+            )}
+
+            <Hovedytelse faktaHovedytelse={behandlingFakta.hovedytelse} />
+
+            {behandlingFakta.hovedytelse.søknadsgrunnlag?.arbeidOgOpphold && (
+                <ArbeidOgOpphold
+                    fakta={behandlingFakta.hovedytelse.søknadsgrunnlag.arbeidOgOpphold}
+                />
+            )}
+            <Utdanning faktaUtdanning={behandlingFakta.utdanning} />
+            <Vedlegg fakta={behandlingFakta.dokumentasjon} />
+        </>
+    );
+};
+
+export default OppsummeringLæremidler;

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringSøknad.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringSøknad.tsx
@@ -1,47 +1,24 @@
 import React from 'react';
 
-import { CalendarIcon } from '@navikt/aksel-icons';
-import { BodyShort, VStack } from '@navikt/ds-react';
+import { VStack } from '@navikt/ds-react';
 
-import Aktivitet from './Aktivitet';
-import ArbeidOgOpphold from './ArbeidOgOpphold';
-import BarnDetaljer from './BarnDetaljer';
-import Hovedytelse from './Hovedytelse';
+import OppsummeringLæremidler from './OppsummeringLæremidler';
+import OppsummeringTilsynBarn from './OppsummeringTilsynBarn';
 import { RevurderingTag } from './RevurderingTag';
-import Vedlegg from './Vedlegg';
-import { InfoSeksjon } from './Visningskomponenter';
 import { useBehandling } from '../../../../context/BehandlingContext';
-import { formaterDato } from '../../../../utils/dato';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 
 const OppsummeringSøknad: React.FC = () => {
     const { behandlingFakta, behandling } = useBehandling();
-
     return (
         <VStack gap="8">
             <RevurderingTag behandling={behandling} />
-            {behandlingFakta.søknadMottattTidspunkt && (
-                <InfoSeksjon label="Søknadsdato" ikon={<CalendarIcon />}>
-                    <BodyShort size="small">
-                        {formaterDato(behandlingFakta.søknadMottattTidspunkt)}
-                    </BodyShort>
-                </InfoSeksjon>
+            {behandlingFakta['@type'] === Stønadstype.BARNETILSYN && (
+                <OppsummeringTilsynBarn behandlingFakta={behandlingFakta} />
             )}
-
-            <Hovedytelse faktaHovedytelse={behandlingFakta.hovedytelse} />
-
-            {behandlingFakta.hovedytelse.søknadsgrunnlag?.arbeidOgOpphold && (
-                <ArbeidOgOpphold
-                    fakta={behandlingFakta.hovedytelse.søknadsgrunnlag.arbeidOgOpphold}
-                />
+            {behandlingFakta['@type'] === Stønadstype.LÆREMIDLER && (
+                <OppsummeringLæremidler behandlingFakta={behandlingFakta} />
             )}
-            <Aktivitet aktivitet={behandlingFakta.aktivitet}></Aktivitet>
-
-            {behandlingFakta.barn.map((barn) => {
-                const harSøktForBarnet = barn.søknadgrunnlag !== null;
-                return harSøktForBarnet && <BarnDetaljer barn={barn} key={barn.barnId} />;
-            })}
-
-            <Vedlegg fakta={behandlingFakta.dokumentasjon} />
         </VStack>
     );
 };

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringTilsynBarn.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/OppsummeringTilsynBarn.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { CalendarIcon } from '@navikt/aksel-icons';
+import { BodyShort } from '@navikt/ds-react';
+
+import Aktivitet from './Aktivitet';
+import ArbeidOgOpphold from './ArbeidOgOpphold';
+import BarnDetaljer from './BarnDetaljer';
+import Hovedytelse from './Hovedytelse';
+import Vedlegg from './Vedlegg';
+import { InfoSeksjon } from './Visningskomponenter';
+import { BehandlingFaktaTilsynBarn } from '../../../../typer/behandling/behandlingFakta/behandlingFakta';
+import { formaterDato } from '../../../../utils/dato';
+
+const OppsummeringTilsynBarn: React.FC<{
+    behandlingFakta: BehandlingFaktaTilsynBarn;
+}> = ({ behandlingFakta }) => {
+    return (
+        <>
+            {behandlingFakta.søknadMottattTidspunkt && (
+                <InfoSeksjon label="Søknadsdato" ikon={<CalendarIcon />}>
+                    <BodyShort size="small">
+                        {formaterDato(behandlingFakta.søknadMottattTidspunkt)}
+                    </BodyShort>
+                </InfoSeksjon>
+            )}
+
+            <Hovedytelse faktaHovedytelse={behandlingFakta.hovedytelse} />
+
+            {behandlingFakta.hovedytelse.søknadsgrunnlag?.arbeidOgOpphold && (
+                <ArbeidOgOpphold
+                    fakta={behandlingFakta.hovedytelse.søknadsgrunnlag.arbeidOgOpphold}
+                />
+            )}
+
+            {behandlingFakta.aktivitet && (
+                <Aktivitet aktivitet={behandlingFakta.aktivitet}></Aktivitet>
+            )}
+
+            {behandlingFakta.barn &&
+                behandlingFakta.barn.map((barn) => {
+                    const harSøktForBarnet = barn.søknadgrunnlag !== null;
+                    return harSøktForBarnet && <BarnDetaljer barn={barn} key={barn.barnId} />;
+                })}
+
+            <Vedlegg fakta={behandlingFakta.dokumentasjon} />
+        </>
+    );
+};
+
+export default OppsummeringTilsynBarn;

--- a/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Utdanning.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Oppsummering/Utdanning.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+
+import { BankNoteIcon, BriefcaseIcon, HatSchoolIcon, WheelchairIcon } from '@navikt/aksel-icons';
+import { BodyShort } from '@navikt/ds-react';
+
+import { InfoSeksjon } from './Visningskomponenter';
+import {
+    annenUtdanningTypeTilTekst,
+    FaktaUtdanning,
+} from '../../../../typer/behandling/behandlingFakta/faktaUtdanning';
+import { jaNeiTilTekst } from '../../../../typer/common';
+import { tekstEllerKode } from '../../../../utils/tekstformatering';
+
+const Utdanning: React.FC<{ faktaUtdanning: FaktaUtdanning }> = ({ faktaUtdanning }) => {
+    const aktiviteter = faktaUtdanning.søknadsgrunnlag?.aktiviteter;
+    const annenUtdanning = faktaUtdanning.søknadsgrunnlag?.annenUtdanning;
+    const mottarUtstyrsstipend = faktaUtdanning.søknadsgrunnlag?.mottarUtstyrsstipend;
+    const harFunksjonsnedsettelse = faktaUtdanning.søknadsgrunnlag?.harFunksjonsnedsettelse;
+    return (
+        <>
+            {aktiviteter && (
+                <InfoSeksjon label="Aktivitet" ikon={<BriefcaseIcon />}>
+                    <BodyShort size="small">
+                        {aktiviteter?.map((aktivitet) => aktivitet)?.join(', ')}
+                    </BodyShort>
+                </InfoSeksjon>
+            )}
+            {annenUtdanning && (
+                <InfoSeksjon label="Type utdanning" ikon={<HatSchoolIcon />}>
+                    <BodyShort size="small">
+                        {tekstEllerKode(annenUtdanningTypeTilTekst, annenUtdanning)}
+                    </BodyShort>
+                </InfoSeksjon>
+            )}
+            {mottarUtstyrsstipend && (
+                <InfoSeksjon label="Utstyrstipend" ikon={<BankNoteIcon />}>
+                    <BodyShort size="small">{jaNeiTilTekst[mottarUtstyrsstipend]}</BodyShort>
+                </InfoSeksjon>
+            )}
+            {harFunksjonsnedsettelse && (
+                <InfoSeksjon label="Funksjonsnedsettelse" ikon={<WheelchairIcon />}>
+                    <BodyShort size="small">{jaNeiTilTekst[harFunksjonsnedsettelse]}</BodyShort>
+                </InfoSeksjon>
+            )}
+        </>
+    );
+};
+
+export default Utdanning;

--- a/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/behandlingFakta.ts
@@ -3,12 +3,25 @@ import { FaktaArena } from './faktaArena';
 import { FaktaBarn } from './faktaBarn';
 import { FaktaDokumentasjon } from './faktaDokumentasjon';
 import { FaktaHovedytelse } from './faktaHovedytelse';
+import { FaktaUtdanning } from './faktaUtdanning';
+import { Stønadstype } from '../behandlingTema';
 
-export interface BehandlingFakta {
+interface BehandlingFaktaInterface {
     søknadMottattTidspunkt?: string;
     hovedytelse: FaktaHovedytelse;
+    arena?: FaktaArena;
+    dokumentasjon?: FaktaDokumentasjon;
+    '@type': Stønadstype;
+}
+export interface BehandlingFaktaTilsynBarn extends BehandlingFaktaInterface {
     aktivitet: FaktaAktivtet;
     barn: FaktaBarn[];
-    dokumentasjon?: FaktaDokumentasjon;
-    arena?: FaktaArena;
+    '@type': Stønadstype.BARNETILSYN;
 }
+
+export interface BehandlingFaktaLæremidler extends BehandlingFaktaInterface {
+    utdanning: FaktaUtdanning;
+    '@type': Stønadstype.LÆREMIDLER;
+}
+
+export type BehandlingFakta = BehandlingFaktaTilsynBarn | BehandlingFaktaLæremidler;

--- a/src/frontend/typer/behandling/behandlingFakta/faktaUtdanning.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaUtdanning.ts
@@ -1,0 +1,29 @@
+import { JaNei } from '../../common';
+
+export interface FaktaUtdanning {
+    søknadsgrunnlag?: SøknadsgrunnlagUtdanning;
+}
+
+interface SøknadsgrunnlagUtdanning {
+    aktiviteter?: string[];
+    annenUtdanning?: AnnenUtdanningType;
+    mottarUtstyrsstipend?: JaNei;
+    harFunksjonsnedsettelse: JaNei;
+}
+
+enum AnnenUtdanningType {
+    VIDEREGÅENDE_FORKURS = 'VIDEREGÅENDE_FORKURS',
+
+    FAGSKOLE_HØGSKOLE_UNIVERSITET = 'FAGSKOLE_HØGSKOLE_UNIVERSITET',
+
+    KURS_LIKNENDE = 'KURS_LIKNENDE',
+
+    INGEN_UTDANNING = 'INGEN_UTDANNING',
+}
+
+export const annenUtdanningTypeTilTekst: Record<AnnenUtdanningType, string> = {
+    VIDEREGÅENDE_FORKURS: 'Videregående forkurs',
+    FAGSKOLE_HØGSKOLE_UNIVERSITET: 'Fagskole, Høyskole eller Universitet',
+    KURS_LIKNENDE: 'Kurs eller lignende',
+    INGEN_UTDANNING: 'Ingen utdanning',
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Sees i sammenheng med denne PR: https://github.com/navikt/tilleggsstonader-sak/pull/452

******************

**FAKTA LÆREMIDLER**
<img width="310" alt="Skjermbilde 2024-10-09 kl  14 05 03" src="https://github.com/user-attachments/assets/f2f5522e-b53d-4558-b4c3-e1c90ff0fa8c">



******************

**FAKTA BARNETILSYN**

<img width="248" alt="Skjermbilde 2024-10-07 kl  15 51 17" src="https://github.com/user-attachments/assets/be8a7068-bd5b-411b-9432-cb9d3390ab49">

