### PR TITLE
✨ Resultat kabal behandlingsoversikt

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
@@ -7,15 +7,13 @@ import { Button, Table } from '@navikt/ds-react';
 import HenleggModal from './HenleggModal';
 import { useApp } from '../../../context/AppContext';
 import { Behandling } from '../../../typer/behandling/behandling';
-import { BehandlingResultat } from '../../../typer/behandling/behandlingResultat';
 import {
     BehandlingStatus,
     erBehandlingRedigerbar,
 } from '../../../typer/behandling/behandlingStatus';
 import { BehandlingType } from '../../../typer/behandling/behandlingType';
-import { BehandlingÅrsak } from '../../../typer/behandling/behandlingÅrsak';
 import { PartialRecord } from '../../../typer/common';
-import { KlagebehandlingResultat, KlagebehandlingStatus, KlageÅrsak } from '../../../typer/klage';
+import { TabellBehandling, utledBehandlingResultatTilTekst } from '../../../utils/behandlingutil';
 import { formaterIsoDatoTid, formaterNullableIsoDatoTid } from '../../../utils/dato';
 import { formaterEnumVerdi } from '../../../utils/tekstformatering';
 
@@ -27,16 +25,6 @@ const TabellData: PartialRecord<keyof Behandling | 'vedtaksdato', string> = {
     vedtaksdato: 'Vedtaksdato',
     resultat: 'Resultat',
 };
-
-export interface TabellBehandling {
-    id: string;
-    opprettet: string;
-    type: BehandlingType;
-    behandlingsårsak: BehandlingÅrsak | KlageÅrsak | undefined;
-    status: BehandlingStatus | KlagebehandlingStatus;
-    vedtaksdato?: string | undefined;
-    resultat: BehandlingResultat | KlagebehandlingResultat | undefined;
-}
 
 interface Props {
     tabellbehandlinger: TabellBehandling[];
@@ -87,7 +75,7 @@ const BehandlingTabell: React.FC<Props> = ({ tabellbehandlinger, hentBehandlinge
                                         pathname: `${utledUrl(behandling.type)}/${behandling.id}`,
                                     }}
                                 >
-                                    {formaterEnumVerdi(behandling.resultat)}
+                                    {utledBehandlingResultatTilTekst(behandling)}
                                 </Link>
                             </Table.DataCell>
                             <Table.DataCell>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
@@ -1,8 +1,10 @@
 import React, { useState } from 'react';
 
 import { Link } from 'react-router-dom';
+import styled from 'styled-components';
 
-import { Button, Table } from '@navikt/ds-react';
+import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
+import { Button, Table, Tooltip } from '@navikt/ds-react';
 
 import HenleggModal from './HenleggModal';
 import { useApp } from '../../../context/AppContext';
@@ -13,9 +15,17 @@ import {
 } from '../../../typer/behandling/behandlingStatus';
 import { BehandlingType } from '../../../typer/behandling/behandlingType';
 import { PartialRecord } from '../../../typer/common';
-import { TabellBehandling, utledBehandlingResultatTilTekst } from '../../../utils/behandlingutil';
+import {
+    erKlageOgFeilregistrertAvKA,
+    TabellBehandling,
+    utledBehandlingResultatTilTekst,
+} from '../../../utils/behandlingutil';
 import { formaterIsoDatoTid, formaterNullableIsoDatoTid } from '../../../utils/dato';
 import { formaterEnumVerdi } from '../../../utils/tekstformatering';
+
+const AdvarselIkon = styled(ExclamationmarkTriangleIcon)`
+    margin-left: 1rem;
+`;
 
 const TabellData: PartialRecord<keyof Behandling | 'vedtaksdato', string> = {
     opprettet: 'Behandling opprettetdato',
@@ -77,6 +87,13 @@ const BehandlingTabell: React.FC<Props> = ({ tabellbehandlinger, hentBehandlinge
                                 >
                                     {utledBehandlingResultatTilTekst(behandling)}
                                 </Link>
+                                {erKlageOgFeilregistrertAvKA(behandling) && (
+                                    <Tooltip content="Klagen er feilregistrert av NAV klageinstans. Gå inn på klagebehandlingens resultatside for å se detaljer">
+                                        <AdvarselIkon
+                                            title={'Behandling feilregistrert av NAV klageinstans'}
+                                        />
+                                    </Tooltip>
+                                )}
                             </Table.DataCell>
                             <Table.DataCell>
                                 {skalViseHenleggKnapp(behandling) && (

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
@@ -4,9 +4,10 @@ import { styled } from 'styled-components';
 
 import { BodyShort, Heading, Tag } from '@navikt/ds-react';
 
-import BehandlingTabell, { TabellBehandling } from './BehandlingTabell';
+import BehandlingTabell from './BehandlingTabell';
 import OpprettNyBehandlingModal from './OpprettNyBehandling/OpprettNyBehandlingModal';
 import { Stønadstype, stønadstypeTilTekst } from '../../../typer/behandling/behandlingTema';
+import { TabellBehandling } from '../../../utils/behandlingutil';
 
 const Container = styled.div`
     display: flex;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når en klagebehandling får et resultat fra kabal ønsker vi å vise dette i behandlingsoversikten.

Har kopiert fra EF.

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22481

![image](https://github.com/user-attachments/assets/d936e9c9-cb15-4715-9a8b-f8c4b461f3f0)


![image](https://github.com/user-attachments/assets/de64de63-461c-4ab0-943d-36e73db75f00)
(Denne er ikke faktisk feilregistret, men ville bare vise ikonet)
