### PR TITLE
Flytt vilkårcontext så det først lastes når side besøkes

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingInnhold.tsx
@@ -6,7 +6,6 @@ import BehandlingTabsInnhold from './BehandlingTabsInnhold';
 import VenstreMeny from './Venstremeny/Venstremeny';
 import { BehandlingProvider } from '../../context/BehandlingContext';
 import { PersonopplysningerProvider } from '../../context/PersonopplysningerContext';
-import { VilkårProvider } from '../../context/VilkårContext';
 import { RerrunnableEffect } from '../../hooks/useRerunnableEffect';
 import PersonHeader from '../../komponenter/PersonHeader/PersonHeader';
 import { Behandling } from '../../typer/behandling/behandling';
@@ -38,12 +37,10 @@ const BehandlingInnhold: React.FC<{
             <PersonopplysningerProvider personopplysninger={personopplysninger}>
                 <PersonHeader fagsakPersonId={behandling.fagsakPersonId} />
                 <BehandlingContainer>
-                    <VilkårProvider behandling={behandling}>
-                        <VenstreMeny />
-                        <InnholdWrapper>
-                            <BehandlingTabsInnhold />
-                        </InnholdWrapper>
-                    </VilkårProvider>
+                    <VenstreMeny />
+                    <InnholdWrapper>
+                        <BehandlingTabsInnhold />
+                    </InnholdWrapper>
                 </BehandlingContainer>
             </PersonopplysningerProvider>
         </BehandlingProvider>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/FyllUtVilkårKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/FyllUtVilkårKnapp.tsx
@@ -6,7 +6,6 @@ import { Alert, Button } from '@navikt/ds-react';
 
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
-import { useVilkår } from '../../../context/VilkårContext';
 import { RessursStatus } from '../../../typer/ressurs';
 
 const Knapp = styled(Button)`
@@ -16,7 +15,6 @@ const Knapp = styled(Button)`
 const FyllUtVilkårKnapp: React.FC = () => {
     const { request } = useApp();
     const { hentBehandling, behandling } = useBehandling();
-    const { hentVilkårsvurdering } = useVilkår();
 
     const [feilmelding, settFeilmelding] = useState<string>('');
 
@@ -25,14 +23,13 @@ const FyllUtVilkårKnapp: React.FC = () => {
             (res) => {
                 if (res.status === RessursStatus.SUKSESS) {
                     settFeilmelding('');
-                    hentVilkårsvurdering();
                     hentBehandling.rerun();
                 } else {
                     settFeilmelding(res.frontendFeilmelding);
                 }
             }
         );
-    }, [behandling, hentBehandling, hentVilkårsvurdering, request]);
+    }, [behandling, hentBehandling, request]);
 
     return (
         <>

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
 import { styled } from 'styled-components';
 
@@ -7,25 +7,41 @@ import { VStack } from '@navikt/ds-react';
 import OppsummeringStønadsperioder from './OppsummeringStønadsperioder';
 import PassBarn from './PassBarn/PassBarn';
 import { VarselBarnUnder2År } from './PassBarn/VarselBarnUnder2år';
+import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
-import { useVilkår } from '../../../context/VilkårContext';
+import { VilkårProvider } from '../../../context/VilkårContext';
 import { useRegler } from '../../../hooks/useRegler';
 import { useVilkårsoppsummering } from '../../../hooks/useVilkårsoppsummering';
 import DataViewer from '../../../komponenter/DataViewer';
 import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Steg } from '../../../typer/behandling/steg';
+import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
 import { FanePath } from '../faner';
+import { Vilkårsvurdering } from '../vilkår';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
     margin: 2rem;
 `;
 
 const Stønadsvilkår = () => {
+    const { request } = useApp();
     const { behandling } = useBehandling();
     const { regler, hentRegler } = useRegler();
-    const { vilkårsvurdering } = useVilkår();
-
     const { vilkårsoppsummering } = useVilkårsoppsummering(behandling.id);
+
+    const [vilkårsvurdering, settVilkårsvurdering] =
+        useState<Ressurs<Vilkårsvurdering>>(byggTomRessurs());
+
+    const hentVilkårsvurdering = useCallback(() => {
+        settVilkårsvurdering(byggHenterRessurs());
+        return request<Vilkårsvurdering, void>(`/api/sak/vilkar/${behandling.id}`).then(
+            settVilkårsvurdering
+        );
+    }, [request, behandling.id]);
+
+    useEffect(() => {
+        hentVilkårsvurdering();
+    }, [hentVilkårsvurdering]);
 
     useEffect(() => {
         hentRegler();
@@ -41,7 +57,7 @@ const Stønadsvilkår = () => {
                 }}
             >
                 {({ regler, vilkårsvurdering, vilkårsoppsummering }) => (
-                    <>
+                    <VilkårProvider hentetVilkårsvurdering={vilkårsvurdering}>
                         {vilkårsoppsummering.visVarselKontantstøtte && <VarselBarnUnder2År />}
                         <OppsummeringStønadsperioder
                             stønadsperioder={vilkårsoppsummering.stønadsperioder}
@@ -50,7 +66,7 @@ const Stønadsvilkår = () => {
                             vilkårsregler={regler.vilkårsregler.PASS_BARN.regler}
                             vilkårsvurdering={vilkårsvurdering}
                         />
-                    </>
+                    </VilkårProvider>
                 )}
             </DataViewer>
             <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Stønadsvilkår (pass av barn) lastes ikke inn på nytt når man endrer revurder fra. Dette gjør at man ikke får endre på noen av vilkårene fordi de ikke lenger eksisterer og de nye ikke blir hentet. 

Løsning: 
- Flyttet context inn
- Bonus: Context forholder seg ikke lenger til ressurs