### PR TITLE
💄 Fjern visuell bruk av ordet "stønadsperiode"

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Aksjonsknapper.tsx
@@ -22,7 +22,7 @@ const Aksjonsknapper: React.FC<{
         return (
             <HStack gap="2" align="center">
                 <Button size="small" type="submit" disabled={laster}>
-                    Lagre stønadsperioder
+                    Lagre perioder
                 </Button>
                 <Button
                     type="button"
@@ -61,7 +61,7 @@ const Aksjonsknapper: React.FC<{
                 }}
                 style={{ maxWidth: 'fit-content' }}
             >
-                Legg til stønadsperiode
+                Legg til periode
             </Button>
         );
     } else {
@@ -76,7 +76,7 @@ const Aksjonsknapper: React.FC<{
                 }}
                 style={{ maxWidth: 'fit-content' }}
             >
-                Endre stønadsperioder
+                Endre perioder
             </Button>
         );
     }

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/LesMerStønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/LesMerStønadsperioder.tsx
@@ -4,17 +4,15 @@ import { BodyLong, ReadMore } from '@navikt/ds-react';
 
 export const LesMerStønadsperioder = () => {
     return (
-        <ReadMore header={'Slik settes stønadsperiode'} size={'small'}>
+        <ReadMore header={'Slik settes perioden'} size={'small'}>
             <BodyLong size={'small'} spacing>
-                Stønadsperioden er perioden søker har arbeidsrettet aktivitet og samtidig er i
-                riktig målgruppe. Stønadsperioden vil komme med i vedtaksbrev og skal begrense
-                perioden bruker kan få utbetalt stønad. Som hovedregel kan den settes maks 3 måneder
-                tilbake i tid (fra søknadsdato) og ut skole/barnehageår. Søker må søke på nytt ved
-                nytt skole/barnehageår.
+                Registrer hele perioden det er overlapp mellom målgruppe og aktivitet. Maks 3
+                måneder tilbake i tid, men ubegrenset fremover i tid. Perioden kontrolleres opp mot
+                det du har lagt til av periode og type aktivitet og målgruppe.
             </BodyLong>
             <BodyLong size={'small'}>
-                Du kan legge inn flere stønadsperioder hvis bruker f.eks. er i flere målgrupper mens
-                det gjennomføres en aktivitet.
+                Du kan legge inn flere perioder hvis bruker f.eks. er i flere målgrupper mens det
+                gjennomføres en aktivitet.
             </BodyLong>
         </ReadMore>
     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -145,10 +145,13 @@ const Stønadsperioder: React.FC = () => {
     };
 
     return (
-        <Panel tittel="Stønadsperioder" ikon={<SealCheckmarkIcon />}>
+        <Panel
+            tittel="Perioder med overlapp mellom aktivitet og målgruppe"
+            ikon={<SealCheckmarkIcon />}
+        >
             {stønadsperioderState.value.length === 0 && !erStegRedigerbart && (
                 <BodyShort>
-                    Det ble ikke registrert noen stønadsperioder i denne behandlingen
+                    Det ble ikke registrert noen overlappende perioder i denne behandlingen
                 </BodyShort>
             )}
             <LesMerStønadsperioder />

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/OppsummeringStønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/OppsummeringStønadsperioder.tsx
@@ -16,7 +16,7 @@ const OppsummeringStønadsperioder: React.FC<{ stønadsperioder: Stønadsperiode
 
     return (
         <Box padding="4" background="surface-selected">
-            <List as="ul" title="Stønadsperioder" size="small">
+            <List as="ul" title="Perioder med overlapp mellom aktivitet og målgruppe" size="small">
                 {!stønadsperioder.length && <>Ingen stønadsperioder</>}
                 {stønadsperioder.map((stønadsperiode, index) => (
                     <List.Item key={index}>{oppsummerStønadsperiode(stønadsperiode)}</List.Item>

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarnLesMer.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarnLesMer.tsx
@@ -1,17 +1,23 @@
 import React from 'react';
 
-import { BodyLong, ReadMore } from '@navikt/ds-react';
+import { BodyLong, ReadMore, List } from '@navikt/ds-react';
 
 export const PassBarnLesMer = () => {
     return (
         <ReadMore header={'Slik legger du inn utgifter'} size={'small'}>
+            <BodyLong size="small">Perioden for utgiften skal settes til:</BodyLong>
+            <List size="small">
+                <List.Item>
+                    fra og med første mulig dato i dette skoleåret hvor bruker har rettighet.
+                </List.Item>
+                <List.Item>
+                    til og med så lenge søker har rett på tilleggsstønad, men maks ut juni i
+                    gjeldende skoleår
+                </List.Item>
+            </List>
             <BodyLong size={'small'} spacing>
                 Hvis et barn har har ulike utgifter fra en måned til en annen, kan du legge til
                 flere perioder med utgift.
-            </BodyLong>
-            <BodyLong size={'small'} spacing>
-                Pass på at du legger inn utgifter på alle perioder barnet har utgifter, innenfor
-                stønadsperioden(e) som er satt.
             </BodyLong>
             <BodyLong size={'small'}>
                 Månedlig utgift skal bare være utgifter til pass. Utgifter til mat eller bleier må


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi skal gå vekk fra ordet "stønadsperiode". FOM mandag skal vi ta i bruk "overlappsperiode" (kun internt) og "Periode med overlapp mellom aktivitet og målgruppe" o.l. formuleringer visuelt i løsningen. 

I første omgang fjerner jeg bruken av ordet visuelt. Byttet ut med en blanding av formuleringen over og bare bruk av ordet "periode". Har også oppdatert readMores som ikke lenger var aktuelle med nye regler. 

⚠️ Har sparret med Marie om tekstene underveis

<img width="1183" alt="image" src="https://github.com/user-attachments/assets/26f46715-b220-40c7-81f3-44fd73c8062c">
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/7dd931b4-f329-4ad4-88a7-7bc4f59fa009">
<img width="1036" alt="image" src="https://github.com/user-attachments/assets/f640c521-5b60-4603-8ae4-b5f25c9c0265">

