### PR TITLE
Viser tittel på logiske vedlegg under tilhørende dokument i dokumento…

### DIFF
--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/DokumentRad.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import { Table } from '@navikt/ds-react';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 
+import LogiskeVedlegg from './LogiskeVedlegg';
 import { Lenke } from '../../../komponenter/Lenke';
 import { arkivtemaerTilTekst } from '../../../typer/arkivtema';
 import { DokumentInfo } from '../../../typer/dokument';
@@ -21,6 +22,7 @@ const DokumentRad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
                 >
                     {dokument.tittel}
                 </Lenke>
+                <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg}></LogiskeVedlegg>
             </Table.DataCell>
             <Table.DataCell>{dokument.avsenderMottaker?.navn}</Table.DataCell>
             <Table.DataCell>{dokument.tema && arkivtemaerTilTekst[dokument.tema]}</Table.DataCell>

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/LogiskeVedlegg.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/LogiskeVedlegg.tsx
@@ -4,7 +4,7 @@ import { LogiskVedlegg } from '../../../typer/dokument';
 
 const LogiskeVedlegg: React.FC<{ logiskeVedlegg: LogiskVedlegg[] }> = ({ logiskeVedlegg }) => {
     return logiskeVedlegg.map((logiskVedlegg) => (
-        <div key={`${logiskVedlegg.tittel}-${logiskVedlegg.logiskVedleggId}`}>
+        <div key={logiskVedlegg.logiskVedleggId}>
             {logiskVedlegg.tittel}
         </div>
     ));

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/LogiskeVedlegg.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/LogiskeVedlegg.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+
+import { LogiskVedlegg } from '../../../typer/dokument';
+
+const LogiskeVedlegg: React.FC<{ logiskeVedlegg: LogiskVedlegg[] }> = ({ logiskeVedlegg }) => {
+    return logiskeVedlegg.map((logiskVedlegg) => (
+        <div key={`${logiskVedlegg.tittel}-${logiskVedlegg.logiskVedleggId}`}>
+            {logiskVedlegg.tittel}
+        </div>
+    ));
+};
+
+export default LogiskeVedlegg;

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Underrad.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Underrad.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Link, Table } from '@navikt/ds-react';
 
+import LogiskeVedlegg from './LogiskeVedlegg';
 import { DokumentInfo } from '../../../typer/dokument';
 
 export const Underrad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => {
@@ -16,6 +17,7 @@ export const Underrad: React.FC<{ dokument: DokumentInfo }> = ({ dokument }) => 
                 >
                     {dokument.tittel}
                 </Link>
+                <LogiskeVedlegg logiskeVedlegg={dokument.logiskeVedlegg}></LogiskeVedlegg>
             </Table.DataCell>
             <Table.DataCell></Table.DataCell>
             <Table.DataCell></Table.DataCell>


### PR DESCRIPTION
…versikten

### Hvorfor er denne endringen nødvendig? ✨

Viser titlene på logiske vedlegg under de dokumentene de tilhører i Dokumentoversikten

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-20569

****

**FØR**:
![Capture-2024-10-14-143318](https://github.com/user-attachments/assets/209686ca-5212-4e11-9d0f-ec89cc1e5d74)

****

**ETTER**
![Capture-2024-10-14-143129](https://github.com/user-attachments/assets/af72c362-466a-409a-994e-e953f09f6354)

