### PR TITLE
Legg til mulighet for å filtrere på klage i oppgavebenk

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
+++ b/src/frontend/Sider/Oppgavebenk/filter/Oppgavefiltrering.tsx
@@ -16,7 +16,7 @@ import {
     oppgaveRequestMedDefaultEnhet,
 } from '../oppgaverequestUtil';
 import { enhetTilTekst } from '../typer/enhet';
-import { behandlingstemaTilTekst, OppgaveRequest } from '../typer/oppgave';
+import { behandlingstemaTilTekst, OppgaveBehandlingstype, OppgaveRequest } from '../typer/oppgave';
 import {
     oppgaverTyperSomSkalVisesFørst,
     oppgaveTypeTilTekst,
@@ -66,6 +66,17 @@ export const Oppgavefiltrering = () => {
         settOppgaveRequest(tomOppgaveRequest);
     };
 
+    // Type brukes både for oppgavetype og behandlingstypen "klage"
+    const håndterOppdaterType = (e: ChangeEvent<HTMLSelectElement | HTMLInputElement>) => {
+        if (e.target.value === OppgaveBehandlingstype.Klage) {
+            oppdaterOppgave('oppgavetype')(undefined);
+            oppdaterOppgaveTargetValue('behandlingstype')(e);
+        } else {
+            oppdaterOppgave('behandlingstype')(undefined);
+            oppdaterOppgaveTargetValue('oppgavetype')(e);
+        }
+    };
+
     return (
         <VStack gap="4">
             <FlexDiv>
@@ -82,9 +93,9 @@ export const Oppgavefiltrering = () => {
                     <option value="På vent">På vent</option>
                 </Select>
                 <Select
-                    value={oppgaveRequest.oppgavetype || ''}
+                    value={oppgaveRequest.oppgavetype || oppgaveRequest.behandlingstype || ''}
                     label="Type"
-                    onChange={oppdaterOppgaveTargetValue('oppgavetype')}
+                    onChange={håndterOppdaterType}
                     size="small"
                 >
                     <option value="">Alle</option>
@@ -93,6 +104,7 @@ export const Oppgavefiltrering = () => {
                             {oppgaveTypeTilTekst[type]}
                         </option>
                     ))}
+                    <option value={OppgaveBehandlingstype.Klage}>Klage</option>
                     <optgroup label={'Øvrige'}>
                         {øvrigeOppgaveTyper.map((type) => (
                             <option key={type} value={type}>

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -4,6 +4,7 @@ import { Stønadstype } from '../../../typer/behandling/behandlingTema';
 
 export interface OppgaveRequest {
     behandlingstema?: Behandlingstema;
+    behandlingstype?: OppgaveBehandlingstype;
     oppgavetype?: Oppgavetype;
     enhet?: FortroligEnhet | IkkeFortroligEnhet;
     oppgaverPåVent: boolean;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker mulighet for å filtrere på klage i oppgavebenk.

Ingen filtrering (som tidligere):
![Screenshot 2024-10-15 at 13 23 36](https://github.com/user-attachments/assets/2c24c2c5-b791-4047-861c-24672767f9c0)
Filtering på behandlingstype "klage" (nytt):
![Screenshot 2024-10-15 at 13 23 54](https://github.com/user-attachments/assets/a5a2aa0d-ffb8-4f86-8817-d90ba9b83a95)
Filtering på oppgavetype (som tidligere):
![Screenshot 2024-10-15 at 13 23 44](https://github.com/user-attachments/assets/8f278641-533c-4266-a653-173ddd14857f)

