### PR TITLE
Oppdater simuleringssiden slik at den default viser inneværende år

### DIFF
--- a/src/frontend/Sider/Behandling/Simulering/useSimuleringÅrvelger.ts
+++ b/src/frontend/Sider/Behandling/Simulering/useSimuleringÅrvelger.ts
@@ -6,9 +6,7 @@ import { formaterIsoÅr } from '../../../utils/dato';
 const useSimuleringÅrvelger = (perioder: OppsummeringForPeriode[]) => {
     const muligeÅr = [...new Set(perioder.map((periode) => formaterIsoÅr(periode.fom)))];
 
-    const [valgtÅr, settValgtÅr] = useState(
-        muligeÅr.length ? Math.max(...muligeÅr) : new Date().getFullYear()
-    );
+    const [valgtÅr, settValgtÅr] = useState(new Date().getFullYear());
 
     const kanVelgeForrigeÅr = muligeÅr.some((muligÅr) => muligÅr < valgtÅr);
     const kanVelgeNesteÅr = muligeÅr.some((muligÅr) => muligÅr > valgtÅr);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Informasjonen for inneværende år er mest interresant. Oppsummeringsboksen "Totalt for perioden" kan brukes for å raskt se feil i kommende år. 

![Screenshot 2024-10-16 at 15 43 08](https://github.com/user-attachments/assets/5f070e1c-82de-47be-89f4-1cf2db2527ca)
