### PR TITLE
Dersom man velger Journalpost-Type "KLAGE", og trykker på "Opprett ny…

### DIFF
--- a/src/frontend/Sider/Journalføring/Felles/utils.ts
+++ b/src/frontend/Sider/Journalføring/Felles/utils.ts
@@ -104,7 +104,19 @@ export const alleBehandlingerErFerdigstiltEllerSattPåVent = (behandlinger: Beha
                 behandling.type === BehandlingType.REVURDERING)
     );
 
-export const utledBehandlingstype = (tidligereBehandlinger: Behandling[]): BehandlingType => {
+export const utledBehandlingstype = (
+    tidligereBehandlinger: Behandling[],
+    journalføringsårsak: Journalføringsårsak
+): BehandlingType => {
+    const journalføringsårsakErEnKlagesak = (journalføringsårsak: Journalføringsårsak): boolean => {
+        return (
+            journalføringsårsak === Journalføringsårsak.KLAGE ||
+            journalføringsårsak === Journalføringsårsak.KLAGE_TILBAKEKREVING
+        );
+    };
+    if (journalføringsårsakErEnKlagesak(journalføringsårsak)) {
+        return BehandlingType.KLAGE;
+    }
     const harIverksattTidligereBehandlinger = tidligereBehandlinger.some(
         (tidligereBehandling) => tidligereBehandling.resultat !== BehandlingResultat.HENLAGT
     );

--- a/src/frontend/Sider/Journalføring/Felles/utils.ts
+++ b/src/frontend/Sider/Journalføring/Felles/utils.ts
@@ -108,13 +108,11 @@ export const utledBehandlingstype = (
     tidligereBehandlinger: Behandling[],
     journalføringsårsak: Journalføringsårsak
 ): BehandlingType => {
-    const journalføringsårsakErEnKlagesak = (journalføringsårsak: Journalføringsårsak): boolean => {
-        return (
-            journalføringsårsak === Journalføringsårsak.KLAGE ||
-            journalføringsårsak === Journalføringsårsak.KLAGE_TILBAKEKREVING
-        );
-    };
-    if (journalføringsårsakErEnKlagesak(journalføringsårsak)) {
+    if (
+        [Journalføringsårsak.KLAGE, Journalføringsårsak.KLAGE_TILBAKEKREVING].includes(
+            journalføringsårsak
+        )
+    ) {
         return BehandlingType.KLAGE;
     }
     const harIverksattTidligereBehandlinger = tidligereBehandlinger.some(

--- a/src/frontend/Sider/Journalføring/Standard/Behandlinger.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Behandlinger.tsx
@@ -70,7 +70,9 @@ const Behandlinger: React.FC<Props> = ({ journalpostState, settFeilmelding }) =>
         <DataViewer response={{ behandlinger }}>
             {({ behandlinger }) => {
                 const behandlingstypePåNyBehandling =
-                    behandlingTypeTilTekst[utledBehandlingstype(behandlinger)];
+                    behandlingTypeTilTekst[
+                        utledBehandlingstype(behandlinger, journalpostState.journalføringsårsak)
+                    ];
 
                 return (
                     <VStack gap="4">

--- a/src/frontend/typer/behandling/behandlingType.ts
+++ b/src/frontend/typer/behandling/behandlingType.ts
@@ -9,5 +9,5 @@ export const behandlingTypeTilTekst: Record<BehandlingType, string> = {
     FØRSTEGANGSBEHANDLING: 'Førstegangsbehandling',
     REVURDERING: 'Revurdering',
     TILBAKEKREVING: 'Tilbakekreving',
-    KLAGE: 'Klage',
+    KLAGE: 'Klagebehandling',
 };

--- a/src/frontend/typer/behandling/behandlingType.ts
+++ b/src/frontend/typer/behandling/behandlingType.ts
@@ -9,5 +9,5 @@ export const behandlingTypeTilTekst: Record<BehandlingType, string> = {
     FØRSTEGANGSBEHANDLING: 'Førstegangsbehandling',
     REVURDERING: 'Revurdering',
     TILBAKEKREVING: 'Tilbakekreving',
-    KLAGE: 'Klagebehandling',
+    KLAGE: 'Klage',
 };


### PR DESCRIPTION
… behandling": Den nye behandlingen i listen skal vises med teksten "Klagebehandling".

### Hvorfor er denne endringen nødvendig? ✨
Frontend skal vise riktig type behandling som skal opprettes i backend

### **FØR**

![klage_gammel](https://github.com/user-attachments/assets/79103294-9afa-4f69-bc24-5ce85fac084e)

---
### **ETTER**

![klage_ny](https://github.com/user-attachments/assets/c2f6a4d4-a63c-4fc7-9d3c-70af3c93a180)

