### PR TITLE
Skal kunne opprette ny klagebehandling selv om det allerede finnes åp…

### DIFF
--- a/src/frontend/Sider/Journalføring/Felles/utils.ts
+++ b/src/frontend/Sider/Journalføring/Felles/utils.ts
@@ -133,3 +133,7 @@ export const skalViseBekreftelsesmodal = (
     journalføringsaksjon === Journalføringsaksjon.OPPRETT_BEHANDLING
         ? false
         : journalResponse.harStrukturertSøknad || erPapirSøknad || erKlage;
+
+export const journalføringsÅrsakErKlage = (journalføringsårsak: Journalføringsårsak): boolean =>
+    journalføringsårsak === Journalføringsårsak.KLAGE ||
+    journalføringsårsak === Journalføringsårsak.KLAGE_TILBAKEKREVING;

--- a/src/frontend/Sider/Journalføring/Standard/Behandlinger.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Behandlinger.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { Alert, BodyShort, Button, HStack, Table, VStack } from '@navikt/ds-react';
 
-import { JournalføringState, Journalføringsaksjon } from '../../../hooks/useJournalføringState';
+import { Journalføringsaksjon, JournalføringState } from '../../../hooks/useJournalføringState';
 import DataViewer from '../../../komponenter/DataViewer';
 import { SøppelbøtteKnapp } from '../../../komponenter/Knapper/SøppelbøtteKnapp';
 import { Behandling } from '../../../typer/behandling/behandling';
@@ -18,6 +18,7 @@ import { behandlingTypeTilTekst } from '../../../typer/behandling/behandlingType
 import { formaterIsoDatoTid } from '../../../utils/dato';
 import {
     alleBehandlingerErFerdigstiltEllerSattPåVent,
+    journalføringsÅrsakErKlage,
     utledBehandlingstype,
 } from '../Felles/utils';
 
@@ -48,11 +49,13 @@ interface Props {
 }
 
 const Behandlinger: React.FC<Props> = ({ journalpostState, settFeilmelding }) => {
-    const { behandlinger, journalføringsaksjon, settJournalføringsaksjon } = journalpostState;
-
+    const { behandlinger, journalføringsaksjon, settJournalføringsaksjon, journalføringsårsak } =
+        journalpostState;
     const leggTilNyBehandlingForOpprettelse = (behandlinger: Behandling[]) => {
         settFeilmelding('');
-        const kanOppretteNyBehandling = alleBehandlingerErFerdigstiltEllerSattPåVent(behandlinger);
+        const kanOppretteNyBehandling =
+            alleBehandlingerErFerdigstiltEllerSattPåVent(behandlinger) ||
+            journalføringsÅrsakErKlage(journalføringsårsak);
 
         if (kanOppretteNyBehandling) {
             settJournalføringsaksjon(Journalføringsaksjon.OPPRETT_BEHANDLING);


### PR DESCRIPTION
…ne behandlinger

### Hvorfor er denne endringen nødvendig? ✨

Dersom man prøver å opprette en ny behandling selv om det eksisterer tidligere behandlinger så er dette ikke tillatt

![ettersending](https://github.com/user-attachments/assets/229e7f01-b3a9-442e-ae90-779f6fdafcf3)
******

Dersom man prøver å opprette en Klagebehandling, så er dette mulig selv om det eksisterer tidligere åpne behandlinger

![klage](https://github.com/user-attachments/assets/82479c97-b455-4bd6-871f-7da949fe9536)


