### PR TITLE
Legger til kildeId på inngangsvilkår for å kunne koble en aktivitet s…

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetRad.tsx
@@ -35,6 +35,7 @@ export interface EndreAktivitetForm extends Periode {
     type: AktivitetType | '';
     delvilkår: DelvilkårAktivitet;
     begrunnelse?: string;
+    kildeId?: string;
 }
 
 const initaliserForm = (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utils.ts
@@ -35,6 +35,7 @@ function nyAktivitetFraRegister(
         aktivitetsdager: aktivitetsdagerFraRegister(aktivitetFraRegister),
         begrunnelse: lagBegrunnelseForAktivitet(aktivitetFraRegister),
         delvilkår: { '@type': 'AKTIVITET' },
+        kildeId: aktivitetFraRegister.id,
     };
 }
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreVilkårperiode/EndreVilkårperiodeRad.tsx
@@ -12,6 +12,7 @@ import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInpu
 import SelectMedOptions, { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
 import { FeilmeldingMaksBredde } from '../../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { EndreAktivitetForm } from '../../Aktivitet/EndreAktivitetRad';
+import { erFormForAktivitet } from '../../Aktivitet/utils';
 import { EndreMålgruppeForm } from '../../Målgruppe/EndreMålgruppeRad';
 import { Aktivitet } from '../../typer/aktivitet';
 import { Målgruppe } from '../../typer/målgruppe';
@@ -71,13 +72,16 @@ const EndreVilkårperiodeRad: React.FC<Props> = ({
 
     const delvilkårSomKreverBegrunnelse = finnBegrunnelseGrunner(form);
 
+    const aktivitetErBruktFraSystem = erFormForAktivitet(form) ? form.kildeId !== undefined : false;
+    const kanEndreType = vilkårperiode === undefined && !aktivitetErBruktFraSystem;
+
     return (
         <VilkårperiodeKortBase vilkårperiode={vilkårperiode} redigeres>
             <FeltContainer>
                 <FeilmeldingMaksBredde>
                     <SelectMedOptions
                         label={tittelSelectTypeVilkårperiode(type)}
-                        readOnly={vilkårperiode !== undefined}
+                        readOnly={!kanEndreType}
                         value={form.type}
                         valg={typeOptions}
                         onChange={(e) => oppdaterType(e.target.value)}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
@@ -6,6 +6,7 @@ export interface Aktivitet extends VilkårPeriode {
     type: AktivitetType;
     aktivitetsdager: number;
     delvilkår: DelvilkårAktivitet;
+    kildeId?: string;
 }
 
 export interface DelvilkårAktivitet {


### PR DESCRIPTION
…om er lagt inn til grunnlaget

 - Muliggjør å kunne vise endringer og hente endringer for gitt aktivitet i inngangsvilkår
 - Det gir ikke mening å gjøre dette for ytelser då ytelser ikke har et unikt id, men er bare en periode av X ytelsestype

### Hvorfor er denne endringen nødvendig? ✨
For å senere kunne legge til "sporing" på inngangsvilkår

* https://github.com/navikt/tilleggsstonader-sak/pull/466 
