### PR TITLE
Gjør lesevisningen av Pass barn-tabellen mer kompakt

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
@@ -1,4 +1,5 @@
 import { DelvilkårKey } from './utils';
+import { Vilkårsresultat } from '../../../vilkår';
 import { SvarJaNei, VilkårPeriodeResultat } from '../../typer/vilkårperiode';
 
 export const medlemskapSvarTilTekst: Record<SvarJaNei, string> = {
@@ -24,6 +25,15 @@ export const VilkårperiodeResultatTilTekst: Record<VilkårPeriodeResultat, stri
     [VilkårPeriodeResultat.IKKE_OPPFYLT]: 'Vilkår ikke oppfylt',
     [VilkårPeriodeResultat.IKKE_VURDERT]: 'Mangelfull vurdering',
     [VilkårPeriodeResultat.SLETTET]: 'Slettet',
+};
+
+export const VilkårsresultatTilTekst: Record<Vilkårsresultat, string> = {
+    [Vilkårsresultat.OPPFYLT]: 'Vilkår oppfylt',
+    [Vilkårsresultat.IKKE_OPPFYLT]: 'Vilkår ikke oppfylt',
+    [Vilkårsresultat.AUTOMATISK_OPPFYLT]: 'Vilkår automatisk oppfylt',
+    [Vilkårsresultat.IKKE_AKTUELL]: 'Ikke aktuelt',
+    [Vilkårsresultat.IKKE_TATT_STILLING_TIL]: 'Ikke vurdert',
+    [Vilkårsresultat.SKAL_IKKE_VURDERES]: 'Skal ikke vurderes',
 };
 
 export const delvilkårKeyTilTekst: Record<DelvilkårKey, string> = {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
@@ -15,11 +15,11 @@ import { Statusbånd } from '../../../komponenter/Statusbånd';
 import { FlexColumn } from '../../../komponenter/Visningskomponenter/Flex';
 import { BehandlingType } from '../../../typer/behandling/behandlingType';
 import { formaterNullablePeriode } from '../../../utils/dato';
-import { harTallverdi } from '../../../utils/tall';
 import { Toggle } from '../../../utils/toggles';
 import { VilkårsresultatTilTekst } from '../Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping';
 import { Vilkår } from '../vilkår';
 import { Vurderingsrad } from './Vurderingsrad';
+import { formaterTallMedTusenSkilleEllerStrek } from '../../../utils/fomatering';
 
 const Container = styled(FlexColumn)`
     position: relative;
@@ -28,7 +28,7 @@ const Container = styled(FlexColumn)`
     box-shadow: ${AShadowXsmall};
 `;
 
-const StyledButton = styled(SmallButton)`
+const Redigeringsknapp = styled(SmallButton)`
     position: relative;
     top: 10px;
     right: 10px;
@@ -60,7 +60,7 @@ const LesevisningVilkår: FC<{
                         <Label size="small">{VilkårsresultatTilTekst[resultat]}</Label>
                     </HStack>
                     <BodyShort size="small">
-                        kr {harTallverdi(utgift) ? `${utgift},-` : '-'}
+                        kr {formaterTallMedTusenSkilleEllerStrek(utgift)}
                     </BodyShort>
                 </VStack>
                 <VStack>
@@ -72,7 +72,7 @@ const LesevisningVilkår: FC<{
                     ))}
                 </VStack>
                 {skalViseRedigeringsknapp && (
-                    <StyledButton
+                    <Redigeringsknapp
                         variant="tertiary"
                         size="small"
                         onClick={startRedigering}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
@@ -3,28 +3,23 @@ import React, { FC } from 'react';
 import { useFlag } from '@unleash/proxy-client-react';
 import { styled } from 'styled-components';
 
-import { HStack } from '@navikt/ds-react';
+import { PencilIcon } from '@navikt/aksel-icons';
+import { BodyShort, HGrid, HStack, Label, VStack } from '@navikt/ds-react';
 import { AShadowXsmall } from '@navikt/ds-tokens/dist/tokens';
 
-import { regelIdTilSpørsmål, svarIdTilTekst } from './tekster';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { VilkårsresultatIkon } from '../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
 import { Skillelinje } from '../../../komponenter/Skillelinje';
-import Lesefelt from '../../../komponenter/Skjema/Lesefelt';
 import { Statusbånd } from '../../../komponenter/Statusbånd';
 import { FlexColumn } from '../../../komponenter/Visningskomponenter/Flex';
 import { BehandlingType } from '../../../typer/behandling/behandlingType';
-import { formaterNullableÅrMåned } from '../../../utils/dato';
+import { formaterNullablePeriode } from '../../../utils/dato';
 import { harTallverdi } from '../../../utils/tall';
 import { Toggle } from '../../../utils/toggles';
+import { VilkårsresultatTilTekst } from '../Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping';
 import { Vilkår } from '../vilkår';
-
-const TwoColumnGrid = styled.div`
-    display: grid;
-    grid-template-columns: auto auto;
-    gap: 2rem;
-`;
+import { Vurderingsrad } from './Vurderingsrad';
 
 const Container = styled(FlexColumn)`
     position: relative;
@@ -33,16 +28,12 @@ const Container = styled(FlexColumn)`
     box-shadow: ${AShadowXsmall};
 `;
 
-const FlexMedMargin = styled(FlexColumn)`
-    margin: 0 45px;
-`;
-
-const Svar = styled(Lesefelt)`
-    grid-column: 1;
-`;
-
-const Begrunnelse = styled(Lesefelt)`
-    grid-column: 2;
+const StyledButton = styled(SmallButton)`
+    position: relative;
+    top: 10px;
+    right: 10px;
+    height: 24px;
+    z-index: 2;
 `;
 
 const LesevisningVilkår: FC<{
@@ -56,58 +47,39 @@ const LesevisningVilkår: FC<{
 
     const skalViseStatus = useFlag(Toggle.SKAL_VISE_STATUS_PERIODER);
 
+    const visStatusbånd = skalViseStatus && behandling.type == BehandlingType.REVURDERING;
+
     return (
-        <Container $gap={1}>
-            {skalViseStatus && behandling.type == BehandlingType.REVURDERING && (
-                <Statusbånd status={vilkår.status} />
-            )}
-            <HStack gap="6" align={'center'}>
-                <VilkårsresultatIkon vilkårsresultat={resultat} />
-                <Lesefelt
-                    label={'Periode fra og med'}
-                    verdi={formaterNullableÅrMåned(fom)}
-                    size={'small'}
-                />
-                <Lesefelt
-                    label={'Periode til og med'}
-                    verdi={formaterNullableÅrMåned(tom)}
-                    size={'small'}
-                />
-                <Lesefelt
-                    label={'Månedlig utgift'}
-                    verdi={harTallverdi(utgift) ? utgift : ''}
-                    size={'small'}
-                />
-            </HStack>
-            <Skillelinje />
-            <FlexMedMargin>
-                <TwoColumnGrid>
-                    {delvilkårsett.map((delvilkår) =>
-                        delvilkår.vurderinger.map((svar) => (
-                            <React.Fragment key={svar.regelId}>
-                                <Svar
-                                    size="small"
-                                    key={svar.regelId}
-                                    label={regelIdTilSpørsmål[svar.regelId]}
-                                    verdi={(svar.svar && svarIdTilTekst[svar.svar]) || '-'}
-                                />
-                                {svar.begrunnelse && (
-                                    <Begrunnelse
-                                        size="small"
-                                        label={'Begrunnelse'}
-                                        verdi={svar.begrunnelse}
-                                    />
-                                )}
-                            </React.Fragment>
-                        ))
-                    )}
-                </TwoColumnGrid>
+        <Container>
+            {visStatusbånd && <Statusbånd status={vilkår.status} />}
+            <HGrid gap={{ md: '4', lg: '8' }} columns="minmax(auto, 175px) auto minmax(auto, 50px)">
+                <VStack gap="3">
+                    <Label size="small">{formaterNullablePeriode(fom, tom)}</Label>
+                    <HStack gap="3" align="center">
+                        <VilkårsresultatIkon vilkårsresultat={resultat} height={14} width={14} />
+                        <Label size="small">{VilkårsresultatTilTekst[resultat]}</Label>
+                    </HStack>
+                    <BodyShort size="small">
+                        kr {harTallverdi(utgift) ? `${utgift},-` : '-'}
+                    </BodyShort>
+                </VStack>
+                <VStack>
+                    {delvilkårsett.map((delvilkår, index) => (
+                        <React.Fragment key={index}>
+                            <Vurderingsrad delvilkår={delvilkår} />
+                            {index !== delvilkårsett.length - 1 && <Skillelinje />}
+                        </React.Fragment>
+                    ))}
+                </VStack>
                 {skalViseRedigeringsknapp && (
-                    <SmallButton variant="secondary" onClick={startRedigering}>
-                        Rediger
-                    </SmallButton>
+                    <StyledButton
+                        variant="tertiary"
+                        size="small"
+                        onClick={startRedigering}
+                        icon={<PencilIcon />}
+                    />
                 )}
-            </FlexMedMargin>
+            </HGrid>
         </Container>
     );
 };

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
@@ -29,11 +29,8 @@ const Container = styled(FlexColumn)`
 `;
 
 const Redigeringsknapp = styled(SmallButton)`
-    position: relative;
-    top: 10px;
-    right: 10px;
-    height: 24px;
-    z-index: 2;
+    max-height: 24px;
+    align-self: end;
 `;
 
 const LesevisningVilkår: FC<{
@@ -52,12 +49,12 @@ const LesevisningVilkår: FC<{
     return (
         <Container>
             {visStatusbånd && <Statusbånd status={vilkår.status} />}
-            <HGrid gap={{ md: '4', lg: '8' }} columns="minmax(auto, 175px) auto minmax(auto, 50px)">
+            <HGrid gap={{ md: '4', lg: '8' }} columns="minmax(auto, 175px) auto minmax(auto, 32px)">
                 <VStack gap="3">
                     <Label size="small">{formaterNullablePeriode(fom, tom)}</Label>
                     <HStack gap="3" align="center">
                         <VilkårsresultatIkon vilkårsresultat={resultat} height={14} width={14} />
-                        <Label size="small">{VilkårsresultatTilTekst[resultat]}</Label>
+                        <BodyShort size="small">{VilkårsresultatTilTekst[resultat]}</BodyShort>
                     </HStack>
                     <BodyShort size="small">
                         kr {formaterTallMedTusenSkilleEllerStrek(utgift)}
@@ -74,7 +71,6 @@ const LesevisningVilkår: FC<{
                 {skalViseRedigeringsknapp && (
                     <Redigeringsknapp
                         variant="tertiary"
-                        size="small"
                         onClick={startRedigering}
                         icon={<PencilIcon />}
                     />

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/Vurderingsrad.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/Vurderingsrad.tsx
@@ -1,35 +1,32 @@
 import React from 'react';
 
-import { BodyShort, HGrid, HStack } from '@navikt/ds-react';
+import { BodyShort, HGrid, HStack, VStack } from '@navikt/ds-react';
 
 import { Delvilkår } from '../vilkår';
-import { regelIdTilSpørsmålKortversjon, svarIdTilTekstKortversjon } from './tekster';
+import { regelIdTilSpørsmålKortversjon, svarIdTilTekst } from './tekster';
 
 export function Vurderingsrad(props: { delvilkår: Delvilkår }) {
+    // Kun siste vurdering i et delvikår har begrunnelse
+    const begrunnelse = props.delvilkår.vurderinger.at(-1)?.begrunnelse;
     return (
         <>
-            {props.delvilkår.vurderinger.map((vurdering, index) => (
-                <HGrid
-                    gap={{ md: '4', lg: '8' }}
-                    columns="minmax(auto, 250px) auto"
-                    key={vurdering.regelId}
-                >
-                    <HStack gap="2">
-                        <BodyShort weight="semibold" size="small">
-                            {regelIdTilSpørsmålKortversjon[vurdering.regelId]}
-                        </BodyShort>
-                        {vurdering.svar && (
-                            <BodyShort size="small">
-                                {svarIdTilTekstKortversjon[vurdering.svar]}
-                            </BodyShort>
-                        )}
-                    </HStack>
-                    {index == props.delvilkår.vurderinger.length - 1 && (
-                        // Vilkårene er satt opp slik at kun "siste" vurdering i et delvilkår vil ha begrunnelse.
-                        <BodyShort size="small">{vurdering.begrunnelse}</BodyShort>
-                    )}
-                </HGrid>
-            ))}
+            <HGrid gap={{ md: '4', lg: '8' }} columns="minmax(100px, 250px) auto">
+                <VStack>
+                    {props.delvilkår.vurderinger.map((vurdering, index) => (
+                        <HStack gap="2" key={vurdering.regelId}>
+                            {index === 0 && (
+                                <BodyShort weight="semibold" size="small">
+                                    {regelIdTilSpørsmålKortversjon[vurdering.regelId]}
+                                </BodyShort>
+                            )}
+                            {vurdering.svar && (
+                                <BodyShort size="small">{svarIdTilTekst[vurdering.svar]}</BodyShort>
+                            )}
+                        </HStack>
+                    ))}
+                </VStack>
+                <BodyShort size="small">{begrunnelse}</BodyShort>
+            </HGrid>
         </>
     );
 }

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/Vurderingsrad.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/Vurderingsrad.tsx
@@ -1,0 +1,35 @@
+import React from 'react';
+
+import { BodyShort, HGrid, HStack } from '@navikt/ds-react';
+
+import { Delvilkår } from '../vilkår';
+import { regelIdTilSpørsmålKortversjon, svarIdTilTekstKortversjon } from './tekster';
+
+export function Vurderingsrad(props: { delvilkår: Delvilkår }) {
+    return (
+        <>
+            {props.delvilkår.vurderinger.map((vurdering, index) => (
+                <HGrid
+                    gap={{ md: '4', lg: '8' }}
+                    columns="minmax(auto, 250px) auto"
+                    key={vurdering.regelId}
+                >
+                    <HStack gap="2">
+                        <BodyShort weight="semibold" size="small">
+                            {regelIdTilSpørsmålKortversjon[vurdering.regelId]}
+                        </BodyShort>
+                        {vurdering.svar && (
+                            <BodyShort size="small">
+                                {svarIdTilTekstKortversjon[vurdering.svar]}
+                            </BodyShort>
+                        )}
+                    </HStack>
+                    {index == props.delvilkår.vurderinger.length - 1 && (
+                        // Vilkårene er satt opp slik at kun "siste" vurdering i et delvilkår vil ha begrunnelse.
+                        <BodyShort size="small">{vurdering.begrunnelse}</BodyShort>
+                    )}
+                </HGrid>
+            ))}
+        </>
+    );
+}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/Vurderingsrad.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/Vurderingsrad.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BodyShort, HGrid, HStack, VStack } from '@navikt/ds-react';
 
 import { Delvilkår } from '../vilkår';
-import { regelIdTilSpørsmålKortversjon, svarIdTilTekst } from './tekster';
+import { regelIdTilSpørsmålKortversjon, svarIdTilTekstKorversjon } from './tekster';
 
 export function Vurderingsrad(props: { delvilkår: Delvilkår }) {
     // Kun siste vurdering i et delvikår har begrunnelse
@@ -20,7 +20,9 @@ export function Vurderingsrad(props: { delvilkår: Delvilkår }) {
                                 </BodyShort>
                             )}
                             {vurdering.svar && (
-                                <BodyShort size="small">{svarIdTilTekst[vurdering.svar]}</BodyShort>
+                                <BodyShort size="small">
+                                    {svarIdTilTekstKorversjon[vurdering.svar]}
+                                </BodyShort>
                             )}
                         </HStack>
                     ))}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -11,6 +11,17 @@ export const svarIdTilTekst: Record<string, string> = {
         'Ja, tiltak/utdanningssted har dokumentert at søker er borte fra hjemmet utover vanlig arbeidstid',
 };
 
+export const svarIdTilTekstKorversjon: Record<string, string> = {
+    JA: 'Ja',
+    NEI: 'Nei',
+
+    // PASS_BARN
+    TRENGER_MER_TILSYN_ENN_JEVNALDRENDE:
+        'Legeerklæring viser at barnet har behov for vesentlig mer pleie/tilsyn',
+    FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID:
+        'Tiltak/utdanningssted har dokumentert at søker er borte fra hjemmet utover vanlig arbeidstid',
+};
+
 export const regelIdTilSpørsmål: Record<RegelId, string> = {
     UTGIFTER_DOKUMENTERT: 'Er utgifter til pass tilfredsstillende dokumentert?',
     ANNEN_FORELDER_MOTTAR_STØTTE: 'Mottar den andre forelderen støtte til pass av barnet?',

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -11,12 +11,28 @@ export const svarIdTilTekst: Record<string, string> = {
         'Ja, tiltak/utdanningssted har dokumentert at søker er borte fra hjemmet utover vanlig arbeidstid',
 };
 
+export const svarIdTilTekstKortversjon: Record<string, string> = {
+    JA: 'Ja',
+    NEI: 'Nei',
+
+    // PASS_BARN
+    TRENGER_MER_TILSYN_ENN_JEVNALDRENDE: 'Ja',
+    FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID: 'Ja',
+};
+
 export const regelIdTilSpørsmål: Record<RegelId, string> = {
     UTGIFTER_DOKUMENTERT: 'Er utgifter til pass tilfredsstillende dokumentert?',
     ANNEN_FORELDER_MOTTAR_STØTTE: 'Mottar den andre forelderen støtte til pass av barnet?',
     HAR_FULLFØRT_FJERDEKLASSE: 'Er barnet ferdig med 4. skoleår?',
     UNNTAK_ALDER:
         'Har barnet behov for pass utover 4. skoleår, og er behovet tilfredsstillende dokumentert?',
+};
+
+export const regelIdTilSpørsmålKortversjon: Record<RegelId, string> = {
+    UTGIFTER_DOKUMENTERT: 'Dokumentert utgifter?',
+    ANNEN_FORELDER_MOTTAR_STØTTE: 'Mottar annen forelder støtte?',
+    HAR_FULLFØRT_FJERDEKLASSE: 'Ferdig med 4. skoleår?',
+    UNNTAK_ALDER: 'Unntak fra aldersregelen?',
 };
 
 export const hjelpetekster: Record<RegelId, string[]> = {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -11,15 +11,6 @@ export const svarIdTilTekst: Record<string, string> = {
         'Ja, tiltak/utdanningssted har dokumentert at søker er borte fra hjemmet utover vanlig arbeidstid',
 };
 
-export const svarIdTilTekstKortversjon: Record<string, string> = {
-    JA: 'Ja',
-    NEI: 'Nei',
-
-    // PASS_BARN
-    TRENGER_MER_TILSYN_ENN_JEVNALDRENDE: 'Ja',
-    FORSØRGER_HAR_LANGVARIG_ELLER_UREGELMESSIG_ARBEIDSTID: 'Ja',
-};
-
 export const regelIdTilSpørsmål: Record<RegelId, string> = {
     UTGIFTER_DOKUMENTERT: 'Er utgifter til pass tilfredsstillende dokumentert?',
     ANNEN_FORELDER_MOTTAR_STØTTE: 'Mottar den andre forelderen støtte til pass av barnet?',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det blir mindre scrollebehov hos saksbehandlerne. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22883

![image](https://github.com/user-attachments/assets/801ddb8e-777e-4e07-ba35-08ada4148853)

