### PR TITLE
Oppdater ordlyden i vilkåret om dokumentasjon av utgifter til pass

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -23,7 +23,7 @@ export const svarIdTilTekstKorversjon: Record<string, string> = {
 };
 
 export const regelIdTilSpørsmål: Record<RegelId, string> = {
-    UTGIFTER_DOKUMENTERT: 'Er utgifter til pass tilfredsstillende dokumentert?',
+    UTGIFTER_DOKUMENTERT: 'Har bruker dokumenterte utgifter til pass?',
     ANNEN_FORELDER_MOTTAR_STØTTE: 'Mottar den andre forelderen støtte til pass av barnet?',
     HAR_FULLFØRT_FJERDEKLASSE: 'Er barnet ferdig med 4. skoleår?',
     UNNTAK_ALDER:


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vilkåret passer nå bedre med lovverket

Frontend:
![Screenshot 2024-10-31 at 10 47 09](https://github.com/user-attachments/assets/50046bfc-5660-4f70-ba6f-16b1e46469f7)

Pdf:
![Screenshot 2024-10-31 at 10 45 35](https://github.com/user-attachments/assets/37648dd7-776f-4459-8cbf-d8b3c382d0a6)

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22824
https://github.com/navikt/tilleggsstonader-sak/pull/474