### PR TITLE
Specify debian12 based image to fix openssl security vulnerabilities.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/distroless/nodejs:18
+FROM gcr.io/distroless/nodejs18-debian12
 
 WORKDIR /app
 COPY ./src/backend server


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Før deploy:

<img width="1228" alt="Screenshot 2024-10-31 at 13 39 25" src="https://github.com/user-attachments/assets/b0636f78-4423-413d-8ee5-71b3fb8d69c5">

Etter deploy: 

<img width="1233" alt="image" src="https://github.com/user-attachments/assets/7812a2a2-0e30-438b-ae94-07c279614cf7">
