### PR TITLE
Oppdaterer tittel på aktiviteter, og legger lenken til personoversikten inni hjelpeteksten

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteter.tsx
@@ -40,7 +40,7 @@ const RegisterAktiviteter: React.FC<{
     return (
         <VStack>
             <ExpansionCard
-                tittel={`Relevante aktiviteter registrert på bruker fra og med ${formaterNullableIsoDato(hentetInformasjon.fom)}`}
+                tittel={`Aktiviteter hentet fra Arena fra og med ${formaterNullableIsoDato(hentetInformasjon.fom)}`}
                 maxWidth={800}
             >
                 <VStack gap="4">
@@ -55,19 +55,16 @@ const RegisterAktiviteter: React.FC<{
                             </Detail>
                             <HelpText>
                                 Vi henter kun stønadsberettigede aktiviteter fra Arena. Du finner
-                                alle aktiviteter i personoversikten.
+                                alle aktiviteter i{' '}
+                                <Link
+                                    href={`/person/${behandling.fagsakPersonId}/aktiviteter`}
+                                    target="_blank"
+                                    variant={'neutral'}
+                                >
+                                    personoversikten.
+                                </Link>{' '}
                             </HelpText>
                         </HStack>
-                        <Detail>
-                            <Link
-                                href={`/person/${behandling.fagsakPersonId}/aktiviteter`}
-                                target="_blank"
-                                variant={'neutral'}
-                            >
-                                Se flere aktiviteter bruker mottar
-                            </Link>{' '}
-                            i personoversikten.
-                        </Detail>
                     </VStack>
                 </VStack>
             </ExpansionCard>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
* Oppdaterer tittel
* Legger lenken til Personoverikten inni Hjelpeteksten

Ny versjon:
![Forbedringen](https://github.com/user-attachments/assets/e8eb012c-70a4-4fa2-bdde-4dea0f2f2428)


*********
Gammel versjon:

![gammel versjon](https://github.com/user-attachments/assets/44499d6b-89e0-4dd8-b262-43c3093849a1)

