### PR TITLE
Fjernet ident fra local storage etter journalføring i Journalføring.tsx

### DIFF
--- a/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
@@ -20,11 +20,6 @@ import DataViewer from '../../../komponenter/DataViewer';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
 import { JournalpostResponse } from '../../../typer/journalpost';
 import { RessursStatus } from '../../../typer/ressurs';
-import {
-    hentFraLocalStorage,
-    lagreTilLocalStorage,
-    oppgaveRequestKey,
-} from '../../Oppgavebenk/filter/oppgavefilterStorage';
 import { JOURNALPOST_QUERY_STRING, OPPGAVEID_QUERY_STRING } from '../../Oppgavebenk/oppgaveutils';
 import PdfVisning from '../Felles/PdfVisning';
 import { journalføringGjelderKlage, skalViseBekreftelsesmodal } from '../Felles/utils';
@@ -108,15 +103,6 @@ const JournalføringSide: React.FC<Props> = ({ journalResponse, oppgaveId }) => 
 
     useEffect(() => {
         if (journalpostState.innsending.status === RessursStatus.SUKSESS) {
-            const lagredeOppgaveFiltreringer = hentFraLocalStorage(
-                oppgaveRequestKey(saksbehandler.navIdent),
-                {}
-            );
-
-            lagreTilLocalStorage(oppgaveRequestKey(saksbehandler.navIdent), {
-                ...lagredeOppgaveFiltreringer,
-                ident: journalResponse.personIdent,
-            });
             navigate('/');
         }
     }, [saksbehandler, journalResponse, journalpostState, navigate]);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23094

Etter journalføring ble oppgavebanken filtrert med det ID-nummeret knyttet til den journalføring oppgave. Så det var bare å vise alle oppgavene knyttet til det ident nummeret. For å få alle oppgavene måtte vi klikke på nullstill-filtre hele tiden. 

Nå trenger vi ikke gjøre det. Etter journalføring blir den automatisk omdirigert til oppgavebenk og vi kan se alle oppgavene til alle ident nummerene.

