### PR TITLE
Fullmaktsmottakere

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/brevUtils.ts
+++ b/src/frontend/Sider/Behandling/Brev/brevUtils.ts
@@ -48,7 +48,6 @@ export const mapPersonopplysningerTilPersonopplysningerIBrevmottakere = (
         personIdent: personopplysninger.personIdent,
         navn: personopplysninger.navn.visningsnavn,
         harVergemål: personopplysninger.harVergemål,
-        fullmakt: personopplysninger.fullmakt,
         vergemål: personopplysninger.vergemål,
     };
 };

--- a/src/frontend/Sider/Behandling/Brev/typer.ts
+++ b/src/frontend/Sider/Behandling/Brev/typer.ts
@@ -63,7 +63,6 @@ export interface PersonopplysningerIBrevmottakere {
     personIdent: string;
     navn: string;
     harVergemål: boolean;
-    fullmakt: Fullmakt[];
     vergemål: Vergemål[];
 }
 
@@ -73,12 +72,4 @@ export interface Vergemål {
     motpartsPersonident?: string;
     navn?: string;
     omfang?: string;
-}
-
-export interface Fullmakt {
-    gyldigFraOgMed: string;
-    gyldigTilOgMed: string;
-    motpartsPersonident: string;
-    navn?: string;
-    områder: string[];
 }

--- a/src/frontend/Sider/Klage/Steg/Brev/Brev.tsx
+++ b/src/frontend/Sider/Klage/Steg/Brev/Brev.tsx
@@ -140,7 +140,6 @@ export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
             personIdent: personopplysninger.personIdent,
             navn: personopplysninger.navn,
             harVergemål: personopplysninger.vergemål.length !== 0,
-            fullmakt: personopplysninger.fullmakt,
             vergemål: personopplysninger.vergemål,
         };
     };

--- a/src/frontend/Sider/Klage/typer/personopplysningerFraKlage.ts
+++ b/src/frontend/Sider/Klage/typer/personopplysningerFraKlage.ts
@@ -7,7 +7,6 @@ export interface PersonopplysningerFraKlage {
     dødsdato?: string;
     fødselsdato?: string;
     egenAnsatt: boolean;
-    fullmakt: Fullmakt[];
     navEnhet: string;
     vergemål: Vergemål[];
     harFullmektig: boolean;
@@ -17,14 +16,6 @@ export enum kjønnType {
     KVINNE = 'KVINNE',
     MANN = 'MANN',
     UKJENT = 'UKJENT',
-}
-
-export interface Fullmakt {
-    gyldigFraOgMed: string;
-    gyldigTilOgMed: string;
-    motpartsPersonident: string;
-    navn?: string;
-    områder: string[];
 }
 
 export interface Vergemål {

--- a/src/frontend/hooks/useHentFullmektige.ts
+++ b/src/frontend/hooks/useHentFullmektige.ts
@@ -3,14 +3,14 @@ import { useCallback, useEffect, useState } from 'react';
 import { useApp } from '../context/AppContext';
 import { FullmektigDto } from '../typer/fullmakt';
 import { IdentRequest } from '../typer/identrequest';
-import { byggTomRessurs, erFeilressurs, pakkUtHvisSuksess, Ressurs } from '../typer/ressurs';
+import { byggTomRessurs, feilmeldingVedFeil, pakkUtHvisSuksess, Ressurs } from '../typer/ressurs';
 
-interface Response {
+interface FullmektigeEllerFeilmelding {
     fullmektige?: FullmektigDto[];
-    hentFullmektigeFeilet?: string;
+    hentFullmektigeFeil?: string;
 }
 
-export function useHentFullmektige(fullmaktigiverIdent: string): Response {
+export function useHentFullmektige(fullmaktigiverIdent: string): FullmektigeEllerFeilmelding {
     const { request } = useApp();
 
     const [fullmektigeResponse, settFullmektigeResponse] =
@@ -28,8 +28,6 @@ export function useHentFullmektige(fullmaktigiverIdent: string): Response {
 
     return {
         fullmektige: pakkUtHvisSuksess(fullmektigeResponse),
-        hentFullmektigeFeilet: erFeilressurs(fullmektigeResponse)
-            ? fullmektigeResponse.frontendFeilmelding
-            : undefined,
+        hentFullmektigeFeil: feilmeldingVedFeil(fullmektigeResponse),
     };
 }

--- a/src/frontend/hooks/useHentFullmektige.ts
+++ b/src/frontend/hooks/useHentFullmektige.ts
@@ -6,11 +6,11 @@ import { IdentRequest } from '../typer/identrequest';
 import { byggTomRessurs, erFeilressurs, pakkUtHvisSuksess, Ressurs } from '../typer/ressurs';
 
 interface Response {
-    fullmektige: FullmektigDto[];
+    fullmektige?: FullmektigDto[];
     hentFullmektigeFeilet?: string;
 }
 
-export const useHentFullmektige = (fullmaktigiverIdent: string): Response => {
+export function useHentFullmektige(fullmaktigiverIdent: string): Response {
     const { request } = useApp();
 
     const [fullmektigeResponse, settFullmektigeResponse] =
@@ -27,9 +27,9 @@ export const useHentFullmektige = (fullmaktigiverIdent: string): Response => {
     }, [hentFullmektige]);
 
     return {
-        fullmektige: pakkUtHvisSuksess(fullmektigeResponse) || [],
+        fullmektige: pakkUtHvisSuksess(fullmektigeResponse),
         hentFullmektigeFeilet: erFeilressurs(fullmektigeResponse)
             ? fullmektigeResponse.frontendFeilmelding
             : undefined,
     };
-};
+}

--- a/src/frontend/hooks/useHentFullmektige.ts
+++ b/src/frontend/hooks/useHentFullmektige.ts
@@ -7,7 +7,7 @@ import { byggTomRessurs, feilmeldingVedFeil, pakkUtHvisSuksess, Ressurs } from '
 
 interface FullmektigeEllerFeilmelding {
     fullmektige?: FullmektigDto[];
-    hentFullmektigeFeil?: string;
+    feilmeldingFraHentFullmektige?: string;
 }
 
 export function useHentFullmektige(fullmaktigiverIdent: string): FullmektigeEllerFeilmelding {
@@ -28,6 +28,6 @@ export function useHentFullmektige(fullmaktigiverIdent: string): FullmektigeElle
 
     return {
         fullmektige: pakkUtHvisSuksess(fullmektigeResponse),
-        hentFullmektigeFeil: feilmeldingVedFeil(fullmektigeResponse),
+        feilmeldingFraHentFullmektige: feilmeldingVedFeil(fullmektigeResponse),
     };
 }

--- a/src/frontend/hooks/useHentFullmektige.ts
+++ b/src/frontend/hooks/useHentFullmektige.ts
@@ -1,0 +1,35 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useApp } from '../context/AppContext';
+import { FullmektigDto } from '../typer/fullmakt';
+import { IdentRequest } from '../typer/identrequest';
+import { byggTomRessurs, erFeilressurs, pakkUtHvisSuksess, Ressurs } from '../typer/ressurs';
+
+interface Response {
+    fullmektige: FullmektigDto[];
+    uthentingAvFullmektigeFeilet?: string;
+}
+
+export const useHentFullmektige = (fullmaktigiverIdent: string): Response => {
+    const { request } = useApp();
+
+    const [fullmektigeResponse, settFullmektigeResponse] =
+        useState<Ressurs<FullmektigDto[]>>(byggTomRessurs());
+
+    const hentFullmektige = useCallback(() => {
+        request<FullmektigDto[], IdentRequest>(`/api/sak/fullmakt/fullmektige`, 'POST', {
+            ident: fullmaktigiverIdent,
+        }).then(settFullmektigeResponse);
+    }, [fullmaktigiverIdent, request]);
+
+    useEffect(() => {
+        hentFullmektige();
+    }, [hentFullmektige]);
+
+    return {
+        fullmektige: pakkUtHvisSuksess(fullmektigeResponse) || [],
+        uthentingAvFullmektigeFeilet: erFeilressurs(fullmektigeResponse)
+            ? fullmektigeResponse.frontendFeilmelding
+            : undefined,
+    };
+};

--- a/src/frontend/hooks/useHentFullmektige.ts
+++ b/src/frontend/hooks/useHentFullmektige.ts
@@ -7,7 +7,7 @@ import { byggTomRessurs, erFeilressurs, pakkUtHvisSuksess, Ressurs } from '../ty
 
 interface Response {
     fullmektige: FullmektigDto[];
-    uthentingAvFullmektigeFeilet?: string;
+    hentFullmektigeFeilet?: string;
 }
 
 export const useHentFullmektige = (fullmaktigiverIdent: string): Response => {
@@ -28,7 +28,7 @@ export const useHentFullmektige = (fullmaktigiverIdent: string): Response => {
 
     return {
         fullmektige: pakkUtHvisSuksess(fullmektigeResponse) || [],
-        uthentingAvFullmektigeFeilet: erFeilressurs(fullmektigeResponse)
+        hentFullmektigeFeilet: erFeilressurs(fullmektigeResponse)
             ? fullmektigeResponse.frontendFeilmelding
             : undefined,
     };

--- a/src/frontend/komponenter/Brevmottakere/EndreBrevmottakereModal.tsx
+++ b/src/frontend/komponenter/Brevmottakere/EndreBrevmottakereModal.tsx
@@ -119,7 +119,7 @@ export const EndreBrevmottakereModal: FC<{
                 <Venstrekolonne>
                     <VergerOgFullmektigeFraRegister
                         verger={personopplysninger.vergemål ?? []}
-                        fullmakter={personopplysninger.fullmakt ?? []}
+                        personIdent={personopplysninger.personIdent}
                         valgteMottakere={valgtePersonMottakere}
                         settValgteMottakere={settValgtePersonMottakere}
                     />

--- a/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
@@ -37,7 +37,7 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
     settValgteMottakere,
     verger,
 }) => {
-    const { fullmektige, hentFullmektigeFeilet } = useHentFullmektige(personIdent);
+    const { fullmektige, hentFullmektigeFeil } = useHentFullmektige(personIdent);
 
     const muligeMottakere = [
         ...(fullmektige?.map(fullmektigDtoTilBrevMottaker) ?? []),
@@ -85,8 +85,8 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
             ) : (
                 <BodyShort>Ingen verge/fullmektig i register</BodyShort>
             )}
-            {hentFullmektigeFeilet && (
-                <ErrorMessage>Henting av fullmakter feilet: {hentFullmektigeFeilet}</ErrorMessage>
+            {hentFullmektigeFeil && (
+                <ErrorMessage>Henting av fullmakter feilet: {hentFullmektigeFeil}</ErrorMessage>
             )}
         </>
     );

--- a/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
@@ -40,7 +40,7 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
     const { fullmektige, hentFullmektigeFeilet } = useHentFullmektige(personIdent);
 
     const muligeMottakere = [
-        ...fullmektige.map(fullmektigDtoTilBrevMottaker),
+        ...(fullmektige?.map(fullmektigDtoTilBrevMottaker) ?? []),
         ...verger.map(vergemålTilBrevmottaker),
     ];
 

--- a/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
@@ -2,19 +2,20 @@ import React, { Dispatch, FC, SetStateAction } from 'react';
 
 import styled from 'styled-components';
 
-import { Button, BodyShort, BodyLong } from '@navikt/ds-react';
+import { BodyLong, BodyShort, Button, ErrorMessage } from '@navikt/ds-react';
 
-import { fullmaktTilBrevMottaker, vergemålTilBrevmottaker } from './brevmottakerUtils';
+import { fullmektigDtoTilBrevMottaker, vergemålTilBrevmottaker } from './brevmottakerUtils';
 import { Fødselsnummer } from './Fødselsnummer';
 import { IBrevmottaker } from './typer';
 import { VertikalSentrering } from './VertikalSentrering';
-import { Fullmakt, Vergemål } from '../../Sider/Klage/typer/personopplysningerFraKlage';
+import { useHentFullmektige } from '../../hooks/useHentFullmektige';
+import { Vergemål } from '../../Sider/Klage/typer/personopplysningerFraKlage';
 
 interface Props {
     valgteMottakere: IBrevmottaker[];
+    personIdent: string;
     settValgteMottakere: Dispatch<SetStateAction<IBrevmottaker[]>>;
     verger: Vergemål[];
-    fullmakter: Fullmakt[];
 }
 
 const StyledMottakerBoks = styled.div`
@@ -32,13 +33,15 @@ const Kolonner = styled.div`
 
 export const VergerOgFullmektigeFraRegister: FC<Props> = ({
     valgteMottakere,
+    personIdent,
     settValgteMottakere,
     verger,
-    fullmakter,
 }) => {
+    const { fullmektige, uthentingAvFullmektigeFeilet } = useHentFullmektige(personIdent);
+
     const muligeMottakere = [
+        ...fullmektige.map(fullmektigDtoTilBrevMottaker),
         ...verger.map(vergemålTilBrevmottaker),
-        ...fullmakter.map(fullmaktTilBrevMottaker),
     ];
 
     const settMottaker = (mottaker: IBrevmottaker) => () => {
@@ -50,7 +53,7 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
     return (
         <>
             <BodyLong size="large" spacing>
-                Verge/Fullmektig fra register
+                Verge/fullmektig fra register
             </BodyLong>
             {muligeMottakere.length ? (
                 muligeMottakere.map((mottaker, index) => {
@@ -81,6 +84,11 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
                 })
             ) : (
                 <BodyShort>Ingen verge/fullmektig i register</BodyShort>
+            )}
+            {uthentingAvFullmektigeFeilet && (
+                <ErrorMessage>
+                    Henting av fullmakter feilet: {uthentingAvFullmektigeFeilet}
+                </ErrorMessage>
             )}
         </>
     );

--- a/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
@@ -37,7 +37,7 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
     settValgteMottakere,
     verger,
 }) => {
-    const { fullmektige, uthentingAvFullmektigeFeilet } = useHentFullmektige(personIdent);
+    const { fullmektige, hentFullmektigeFeilet } = useHentFullmektige(personIdent);
 
     const muligeMottakere = [
         ...fullmektige.map(fullmektigDtoTilBrevMottaker),
@@ -85,10 +85,8 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
             ) : (
                 <BodyShort>Ingen verge/fullmektig i register</BodyShort>
             )}
-            {uthentingAvFullmektigeFeilet && (
-                <ErrorMessage>
-                    Henting av fullmakter feilet: {uthentingAvFullmektigeFeilet}
-                </ErrorMessage>
+            {hentFullmektigeFeilet && (
+                <ErrorMessage>Henting av fullmakter feilet: {hentFullmektigeFeilet}</ErrorMessage>
             )}
         </>
     );

--- a/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
+++ b/src/frontend/komponenter/Brevmottakere/VergerOgFullmektigeFraRegister.tsx
@@ -37,7 +37,7 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
     settValgteMottakere,
     verger,
 }) => {
-    const { fullmektige, hentFullmektigeFeil } = useHentFullmektige(personIdent);
+    const { fullmektige, feilmeldingFraHentFullmektige } = useHentFullmektige(personIdent);
 
     const muligeMottakere = [
         ...(fullmektige?.map(fullmektigDtoTilBrevMottaker) ?? []),
@@ -85,8 +85,10 @@ export const VergerOgFullmektigeFraRegister: FC<Props> = ({
             ) : (
                 <BodyShort>Ingen verge/fullmektig i register</BodyShort>
             )}
-            {hentFullmektigeFeil && (
-                <ErrorMessage>Henting av fullmakter feilet: {hentFullmektigeFeil}</ErrorMessage>
+            {feilmeldingFraHentFullmektige && (
+                <ErrorMessage>
+                    Henting av fullmakter feilet: {feilmeldingFraHentFullmektige}
+                </ErrorMessage>
             )}
         </>
     );

--- a/src/frontend/komponenter/Brevmottakere/brevmottakerUtils.ts
+++ b/src/frontend/komponenter/Brevmottakere/brevmottakerUtils.ts
@@ -15,5 +15,5 @@ export const fullmektigDtoTilBrevMottaker = (fullmektig: FullmektigDto): IBrevmo
     id: uuidv4(),
     navn: fullmektig.fullmektigNavn || '',
     personIdent: fullmektig.fullmektigIdent,
-    mottakerRolle: EBrevmottakerRolle.FULLMAKT,
+    mottakerRolle: EBrevmottakerRolle.FULLMEKTIG,
 });

--- a/src/frontend/komponenter/Brevmottakere/brevmottakerUtils.ts
+++ b/src/frontend/komponenter/Brevmottakere/brevmottakerUtils.ts
@@ -1,7 +1,8 @@
 import { v4 as uuidv4 } from 'uuid';
 
 import { EBrevmottakerRolle, IBrevmottaker } from './typer';
-import { Fullmakt, Vergemål } from '../../Sider/Klage/typer/personopplysningerFraKlage';
+import { Vergemål } from '../../Sider/Klage/typer/personopplysningerFraKlage';
+import { FullmektigDto } from '../../typer/fullmakt';
 
 export const vergemålTilBrevmottaker = (vergemål: Vergemål): IBrevmottaker => ({
     id: uuidv4(),
@@ -9,9 +10,10 @@ export const vergemålTilBrevmottaker = (vergemål: Vergemål): IBrevmottaker =>
     personIdent: vergemål.motpartsPersonident || '',
     mottakerRolle: EBrevmottakerRolle.VERGE,
 });
-export const fullmaktTilBrevMottaker = (fullmakt: Fullmakt): IBrevmottaker => ({
+
+export const fullmektigDtoTilBrevMottaker = (fullmektig: FullmektigDto): IBrevmottaker => ({
     id: uuidv4(),
-    navn: fullmakt.navn || '',
-    personIdent: fullmakt.motpartsPersonident,
+    navn: fullmektig.fullmektigNavn || '',
+    personIdent: fullmektig.fullmektigIdent,
     mottakerRolle: EBrevmottakerRolle.FULLMAKT,
 });

--- a/src/frontend/komponenter/Brevmottakere/typer.ts
+++ b/src/frontend/komponenter/Brevmottakere/typer.ts
@@ -20,7 +20,7 @@ export interface IOrganisasjonMottaker {
 export enum EBrevmottakerRolle {
     BRUKER = 'BRUKER',
     VERGE = 'VERGE',
-    FULLMAKT = 'FULLMAKT',
+    FULLMEKTIG = 'FULLMEKTIG',
 }
 
 export enum Applikasjonskontekst {

--- a/src/frontend/typer/fullmakt.ts
+++ b/src/frontend/typer/fullmakt.ts
@@ -1,7 +1,4 @@
 export interface FullmektigDto {
     fullmektigIdent: string;
     fullmektigNavn?: string;
-    gyldigFraOgMed: Date;
-    gyldigTilOgMed?: Date;
-    temaer: string[];
 }

--- a/src/frontend/typer/fullmakt.ts
+++ b/src/frontend/typer/fullmakt.ts
@@ -1,0 +1,7 @@
+export interface FullmektigDto {
+    fullmektigIdent: string;
+    fullmektigNavn?: string;
+    gyldigFraOgMed: Date;
+    gyldigTilOgMed?: Date;
+    temaer: string[];
+}

--- a/src/frontend/typer/personopplysninger.ts
+++ b/src/frontend/typer/personopplysninger.ts
@@ -4,7 +4,6 @@ export interface Personopplysninger {
     harVergemål: boolean;
     harFullmektig: boolean;
     adressebeskyttelse: Adressebeskyttelse;
-    fullmakt: Fullmakt[];
     vergemål: Vergemål[];
 }
 
@@ -28,12 +27,4 @@ export interface Vergemål {
     motpartsPersonident?: string;
     navn?: string;
     omfang?: string;
-}
-
-export interface Fullmakt {
-    gyldigFraOgMed: string;
-    gyldigTilOgMed: string;
-    motpartsPersonident: string;
-    navn?: string;
-    områder: string[];
 }

--- a/src/frontend/typer/ressurs.ts
+++ b/src/frontend/typer/ressurs.ts
@@ -65,6 +65,9 @@ export const byggFeiletRessurs = <T>(melding: string, error?: Error): Ressurs<T>
 export const pakkUtHvisSuksess = <T>(ressurs: Ressurs<T>) =>
     ressurs.status === RessursStatus.SUKSESS ? ressurs.data : undefined;
 
+export const feilmeldingVedFeil = <T>(response: Ressurs<T>) =>
+    erFeilressurs(response) ? response.frontendFeilmelding : undefined;
+
 export const byggRessursFeilet = (feilmelding: string): RessursFeilet => {
     return {
         status: RessursStatus.FEILET,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det var misledende, og en potensiell feilkilde, at fullmakter var en del av PDL-responsen, ettersom dissse dataene er utdaterte. Nå hentes i stedet brevmottakere i klage og i ts-sak fra et nytt endepunkt `/fullmektige`

Hvis alt funker:
![image](https://github.com/user-attachments/assets/7495b74d-6f61-4d4b-8be3-ded562de5491)

Hvis noe går galt ved uthentingen: 
![image](https://github.com/user-attachments/assets/b92dd508-f93e-4499-8d4c-af4f6b3de3ce)


