### PR TITLE
Skal kunne nullstille valg i valgfelt

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
@@ -36,15 +36,15 @@ const Valgfelt: React.FC<Props> = ({
         const valgtBlock = finnValgtBlock(id);
 
         settValgfelt((prevState) => {
-            const updatedState = { ...prevState };
+            const oppdatertState = { ...prevState };
 
             if (valgtBlock) {
-                updatedState[valgfelt._id] = valgtBlock;
+                oppdatertState[valgfelt._id] = valgtBlock;
             } else {
-                delete updatedState[valgfelt._id];
+                delete oppdatertState[valgfelt._id];
             }
 
-            return updatedState;
+            return oppdatertState;
         });
     };
 

--- a/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Valgfelt.tsx
@@ -32,6 +32,22 @@ const Valgfelt: React.FC<Props> = ({
                 (valg._type === 'fritekst' && id === 'fritekst')
         );
 
+    const oppdaterValgfelt = (id: string) => {
+        const valgtBlock = finnValgtBlock(id);
+
+        settValgfelt((prevState) => {
+            const updatedState = { ...prevState };
+
+            if (valgtBlock) {
+                updatedState[valgfelt._id] = valgtBlock;
+            } else {
+                delete updatedState[valgfelt._id];
+            }
+
+            return updatedState;
+        });
+    };
+
     const valgtBlock = finnValgtBlock(valgtVerdi);
 
     return (
@@ -39,15 +55,7 @@ const Valgfelt: React.FC<Props> = ({
             <Select
                 label={valgfelt.visningsnavn}
                 value={valgtVerdi || ''}
-                onChange={(e) => {
-                    settValgfelt((prevState) => {
-                        const valgtBlock = finnValgtBlock(e.target.value);
-
-                        return valgtBlock
-                            ? { ...prevState, [valgfelt._id]: valgtBlock }
-                            : prevState;
-                    });
-                }}
+                onChange={(e) => oppdaterValgfelt(e.target.value)}
                 size="small"
             >
                 <option value={''}>Velg</option>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis man har gjort et valg i et valgfelt så er det ikke mulig å gå tilbake til å "ikke ha valgt noe", som er uheldig de stedene valgfeltene brukes for å "huke av og på informasjon" og det å ta et valg er valgfritt. 

<img width="494" alt="image" src="https://github.com/user-attachments/assets/e860f247-79e7-43a4-a6c3-b4c2c857afb8">
