### PR TITLE
Kun vis opphørsbrevmal hvis vedtaket er et opphør

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/brevUtils.ts
+++ b/src/frontend/Sider/Behandling/Brev/brevUtils.ts
@@ -16,6 +16,7 @@ enum SanityMappe {
     INNVILGET = 'INNVILGET',
     AVSLAG = 'AVSLAG',
     REVURDERING = 'REVURDERING',
+    OPPHØR = 'OPPHOR',
 }
 
 /**
@@ -29,6 +30,9 @@ export const finnSanityMappe = (
     if (vedtakType === TypeVedtak.AVSLAG) {
         return [SanityMappe.AVSLAG];
     }
+    if (vedtakType === TypeVedtak.OPPHØR) {
+        return [SanityMappe.OPPHØR];
+    }
 
     if (behandlingstype === BehandlingType.REVURDERING) {
         return [SanityMappe.REVURDERING, SanityMappe.INNVILGET];
@@ -36,10 +40,6 @@ export const finnSanityMappe = (
 
     if (vedtakType === TypeVedtak.INNVILGELSE) {
         return [SanityMappe.INNVILGET];
-    }
-
-    if (vedtakType === TypeVedtak.OPPHØR) {
-        return [SanityMappe.REVURDERING]; //TODO Legg til egen mappe for opphør
     }
 
     return vedtakType;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gjøre det enklere for saksbehandler å finne rett brevmal ved opphør

![Screenshot 2024-11-15 at 15 03 30](https://github.com/user-attachments/assets/ce0a6ab4-fff3-4085-8f35-eba3b30ebd3b)
