### PR TITLE
🐛 Skal ikke validere aktivitetsdager hvis type er ingen aktivitet

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitet.tsx
@@ -39,7 +39,10 @@ export const validerAktivitet = (
         };
     }
 
-    if (!aktivitetsdagerErGyldigTall(endretAktivitet.aktivitetsdager)) {
+    if (
+        endretAktivitet.type !== AktivitetType.INGEN_AKTIVITET &&
+        !aktivitetsdagerErGyldigTall(endretAktivitet.aktivitetsdager)
+    ) {
         return { ...feil, aktivitetsdager: 'Aktivitetsdager må være et tall mellom 1 og 5' };
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gikk ikke å lagre "ingen aktivitet" fordi det var en feilmelding som ikke gikk å lagre