### PR TITLE
Ikke brekk layout når opphør feilmelding vises

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/OpphørVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/OpphørVedtak.tsx
@@ -76,6 +76,7 @@ const OpphørVedtak: React.FC<{ vedtak?: OpphørBarnetilsyn }> = ({ vedtak }) =>
                 error={feilmeldinger.begrunnelse}
                 readOnly={!erStegRedigerbart}
                 size="small"
+                style={{ maxWidth: '20em' }}
             />
 
             <StegKnapp

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -2,7 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import styled from 'styled-components';
 
-import { HStack } from '@navikt/ds-react';
+import { HGrid } from '@navikt/ds-react';
 
 import AvslåVedtak from './AvslåVedtak';
 import { InnvilgeBarnetilsyn } from './InnvilgeVedtak/InnvilgeBarnetilsyn';
@@ -43,7 +43,7 @@ const VedtakOgBeregningBarnetilsyn: FC = () => {
                 {({ vedtak }) => (
                     <Container>
                         <Panel tittel="Vedtak">
-                            <HStack gap="16">
+                            <HGrid gap="16" columns={{ sm: 1, md: '5em auto' }}>
                                 <VelgVedtakResultat
                                     typeVedtak={typeVedtak}
                                     settTypeVedtak={settTypeVedtak}
@@ -54,7 +54,7 @@ const VedtakOgBeregningBarnetilsyn: FC = () => {
                                 {typeVedtak === TypeVedtak.OPPHØR && (
                                     <OpphørVedtak vedtak={vedtak as OpphørBarnetilsyn} />
                                 )}
-                            </HStack>
+                            </HGrid>
                         </Panel>
 
                         {typeVedtak === TypeVedtak.INNVILGELSE && (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Før:
![Screenshot 2024-11-21 at 14 56 27](https://github.com/user-attachments/assets/5d26cf97-be57-422b-bfff-93d430921ffd)


Etter:
![Screenshot 2024-11-21 at 14 57 06](https://github.com/user-attachments/assets/a9c69ffe-929e-4b9a-af20-51768700205d)
