### PR TITLE
Behold 'på-vent' filteringen ved refresh

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
+++ b/src/frontend/Sider/Oppgavebenk/filter/oppgavefilterStorage.ts
@@ -53,9 +53,9 @@ export const hentLagretOppgaveRequest = (
         ...fraLocalStorage,
         limit: fraLocalStorage.limit ?? defaultSortering.limit,
         offset: fraLocalStorage.offset ?? defaultSortering.offset,
+        oppgaverPåVent: fraLocalStorage.oppgaverPåVent ?? defaultOppgaveRequest.oppgaverPåVent,
         order: defaultSortering.order,
         orderBy: defaultSortering.orderBy,
-        oppgaverPåVent: defaultOppgaveRequest.oppgaverPåVent,
     };
 
     return oppgaveRequestMedDefaultEnhet(


### PR DESCRIPTION
Saksbehandlerne er gjerne på 'Ventebenk'-vakt og skal gå gjennom alle saker på vent. Når man har behandlet en sak på vent ønsker saksbehandler å komme tilbake til oppgavebenk, og filteret for 'Benk - På vent' er fortsatt på.
