### PR TITLE
Fellesfelter målgruppe

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -161,10 +161,11 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
+                    typeOptions={aktivitetTypeOptions}
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}
-                    />
+                />
                 {form.type !== AktivitetType.INGEN_AKTIVITET && (
                     <FeilmeldingMaksBredde $maxWidth={140}>
                         <TextField

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { Button, HStack } from '@navikt/ds-react';
 
 import { AktivitetDelvilkårBarnetilsyn } from './Delvilkår/AktivitetDelvilkårBarnetilsyn';
-import { EndreFellesFelter } from './EndreFellesFelter';
 import { finnBegrunnelseGrunnerAktivitet, nyAktivitet, resettAktivitet } from './utilsBarnetilsyn';
 import { AktivitetValidering, validerAktivitet } from './valideringAktivitetBarnetilsyn';
 import { useApp } from '../../../../context/AppContext';
@@ -34,6 +33,7 @@ import {
     Vurdering,
 } from '../typer/vilkårperiode';
 import Begrunnelse from '../Vilkårperioder/Begrunnelse/Begrunnelse';
+import { EndreTypeOgDatoer } from '../Vilkårperioder/EndreTypeOgDatoer';
 import SlettVilkårperiode from '../Vilkårperioder/SlettVilkårperiodeModal';
 import VilkårperiodeKortBase from '../Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase';
 
@@ -157,7 +157,7 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
     return (
         <VilkårperiodeKortBase vilkårperiode={aktivitet} redigeres>
             <FeltContainer>
-                <EndreFellesFelter
+                <EndreTypeOgDatoer
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -24,6 +24,7 @@ import {
     Aktivitet,
     AktivitetLæremidler,
     AktivitetType,
+    aktivitetTypeOptions,
     DelvilkårAktivitetLæremidler,
 } from '../typer/aktivitet';
 import {
@@ -160,6 +161,7 @@ export const EndreAktivitetLæremidler: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
+                    typeOptions={aktivitetTypeOptions}
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { Button, HStack } from '@navikt/ds-react';
 
 import { AktivitetDelvilkårLæremidler } from './Delvilkår/AktivitetDelvilkårLæremidler';
-import { EndreFellesFelter } from './EndreFellesFelter';
 import { finnBegrunnelseGrunnerAktivitet, nyAktivitet, resettAktivitet } from './utilsLæremidler';
 import { AktivitetValidering, validerAktivitet } from './valideringAktivitetLæremidler';
 import { useApp } from '../../../../context/AppContext';
@@ -34,6 +33,7 @@ import {
     Vurdering,
 } from '../typer/vilkårperiode';
 import Begrunnelse from '../Vilkårperioder/Begrunnelse/Begrunnelse';
+import { EndreTypeOgDatoer } from '../Vilkårperioder/EndreTypeOgDatoer';
 import SlettVilkårperiode from '../Vilkårperioder/SlettVilkårperiodeModal';
 import VilkårperiodeKortBase from '../Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase';
 
@@ -157,7 +157,7 @@ export const EndreAktivitetLæremidler: React.FC<{
     return (
         <VilkårperiodeKortBase vilkårperiode={aktivitet} redigeres>
             <FeltContainer>
-                <EndreFellesFelter
+                <EndreTypeOgDatoer
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreFellesFelter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreFellesFelter.tsx
@@ -3,36 +3,43 @@ import React from 'react';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { useTriggRerendringAvDateInput } from '../../../../hooks/useTriggRerendringAvDateInput';
 import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
-import SelectMedOptions from '../../../../komponenter/Skjema/SelectMedOptions';
+import SelectMedOptions, { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { Periode } from '../../../../utils/periode';
-import { AktivitetType, aktivitetTypeOptions } from '../typer/aktivitet';
+import { AktivitetType } from '../typer/aktivitet';
+import { MålgruppeType } from '../typer/målgruppe';
+
+type MålgruppeEllerAktivitet = MålgruppeType | AktivitetType;
 
 export interface FellesFormFelter extends Periode {
-    type: AktivitetType | '';
+    type: MålgruppeEllerAktivitet | '';
 }
 
-export const EndreFellesFelter: React.FC<{
+interface Props<T extends MålgruppeEllerAktivitet> {
     form: FellesFormFelter;
-    oppdaterTypeIForm: (type: AktivitetType) => void;
+    oppdaterTypeIForm: (type: T) => void;
     oppdaterPeriode: (key: keyof Periode, nyVerdi: string) => void;
+    typeOptions: SelectOption[];
     formFeil?: FormErrors<FellesFormFelter>;
     alleFelterKanEndres: boolean;
     kanEndreType: boolean;
-}> = ({
+}
+
+export const EndreFellesFelter = <T extends MålgruppeEllerAktivitet>({
     form,
     oppdaterTypeIForm,
     oppdaterPeriode,
+    typeOptions,
     formFeil,
     alleFelterKanEndres,
     kanEndreType,
-}) => {
+}: Props<T>) => {
     const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
         useTriggRerendringAvDateInput();
     const { keyDato: tomKeyDato, oppdaterDatoKey: oppdaterTomDatoKey } =
         useTriggRerendringAvDateInput();
 
-    const oppdaterType = (type: AktivitetType) => {
+    const oppdaterType = (type: T) => {
         oppdaterTypeIForm(type);
 
         oppdaterFomDatoKey();
@@ -46,8 +53,8 @@ export const EndreFellesFelter: React.FC<{
                     label="Type"
                     readOnly={!kanEndreType}
                     value={form.type}
-                    valg={aktivitetTypeOptions}
-                    onChange={(e) => oppdaterType(e.target.value as AktivitetType)}
+                    valg={typeOptions}
+                    onChange={(e) => oppdaterType(e.target.value as T)}
                     size="small"
                     error={formFeil?.type}
                 />

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -12,11 +12,7 @@ import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
-import { useTriggRerendringAvDateInput } from '../../../../hooks/useTriggRerendringAvDateInput';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
-import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
-import SelectMedOptions from '../../../../komponenter/Skjema/SelectMedOptions';
-import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { PeriodeYtelseRegister } from '../../../../typer/registerytelser';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
@@ -27,12 +23,12 @@ import {
     målgruppeTypeOptions,
 } from '../typer/målgruppe';
 import {
-    KildeVilkårsperiode,
     LagreVilkårperiodeResponse,
     StønadsperiodeStatus,
     Vurdering,
 } from '../typer/vilkårperiode';
 import Begrunnelse from '../Vilkårperioder/Begrunnelse/Begrunnelse';
+import { EndreTypeOgDatoer } from '../Vilkårperioder/EndreTypeOgDatoer';
 import SlettVilkårperiode from '../Vilkårperioder/SlettVilkårperiodeModal';
 import VilkårperiodeKortBase from '../Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase';
 
@@ -72,10 +68,6 @@ const EndreMålgruppeRad: React.FC<{
     const { request } = useApp();
     const { behandling, behandlingFakta } = useBehandling();
     const { oppdaterMålgruppe, leggTilMålgruppe, settStønadsperiodeFeil } = useInngangsvilkår();
-    const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
-        useTriggRerendringAvDateInput();
-    const { keyDato: tomKeyDato, oppdaterDatoKey: oppdaterTomDatoKey } =
-        useTriggRerendringAvDateInput();
 
     const [form, settForm] = useState<EndreMålgruppeForm>(
         initaliserForm(behandling.id, målgruppe, registerYtelsePeriode)
@@ -143,8 +135,6 @@ const EndreMålgruppeRad: React.FC<{
         settForm((prevState) =>
             resettMålgruppe(type, prevState, behandlingFakta.søknadMottattTidspunkt)
         );
-        oppdaterFomDatoKey();
-        oppdaterTomDatoKey();
     };
 
     const { alleFelterKanEndres } = useRevurderingAvPerioder({
@@ -156,42 +146,15 @@ const EndreMålgruppeRad: React.FC<{
     return (
         <VilkårperiodeKortBase vilkårperiode={målgruppe} redigeres>
             <FeltContainer>
-                <FeilmeldingMaksBredde>
-                    <SelectMedOptions
-                        label="Ytelse/situasjon"
-                        readOnly={!kanEndreType}
-                        value={form.type}
-                        valg={målgruppeTypeOptions}
-                        onChange={(e) => oppdaterType(e.target.value as MålgruppeType)}
-                        size="small"
-                        error={vilkårsperiodeFeil?.type}
-                    />
-                </FeilmeldingMaksBredde>
-
-                <FeilmeldingMaksBredde>
-                    <DateInputMedLeservisning
-                        key={fomKeyDato}
-                        erLesevisning={målgruppe?.kilde === KildeVilkårsperiode.SYSTEM}
-                        readOnly={!alleFelterKanEndres}
-                        label={'Fra'}
-                        value={form?.fom}
-                        onChange={(dato) => oppdaterForm('fom', dato || '')}
-                        size="small"
-                        feil={vilkårsperiodeFeil?.fom}
-                    />
-                </FeilmeldingMaksBredde>
-
-                <FeilmeldingMaksBredde>
-                    <DateInputMedLeservisning
-                        key={tomKeyDato}
-                        erLesevisning={målgruppe?.kilde === KildeVilkårsperiode.SYSTEM}
-                        label={'Til'}
-                        value={form?.tom}
-                        onChange={(dato) => oppdaterForm('tom', dato || '')}
-                        size="small"
-                        feil={vilkårsperiodeFeil?.tom}
-                    />
-                </FeilmeldingMaksBredde>
+                <EndreTypeOgDatoer
+                    form={form}
+                    oppdaterTypeIForm={oppdaterType}
+                    oppdaterPeriode={oppdaterForm}
+                    typeOptions={målgruppeTypeOptions}
+                    formFeil={vilkårsperiodeFeil}
+                    alleFelterKanEndres={alleFelterKanEndres}
+                    kanEndreType={kanEndreType}
+                />
             </FeltContainer>
 
             <MålgruppeVilkår

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
@@ -25,7 +25,7 @@ interface Props<T extends MålgruppeEllerAktivitet> {
     kanEndreType: boolean;
 }
 
-export const EndreFellesFelter = <T extends MålgruppeEllerAktivitet>({
+export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
     form,
     oppdaterTypeIForm,
     oppdaterPeriode,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
@@ -11,16 +11,16 @@ import { MålgruppeType } from '../typer/målgruppe';
 
 type MålgruppeEllerAktivitet = MålgruppeType | AktivitetType;
 
-export interface FellesFormFelter extends Periode {
-    type: MålgruppeEllerAktivitet | '';
+interface TypeOgDatoFelter extends Periode {
+    type: MålgruppeType | AktivitetType | '';
 }
 
 interface Props<T extends MålgruppeEllerAktivitet> {
-    form: FellesFormFelter;
+    form: TypeOgDatoFelter;
     oppdaterTypeIForm: (type: T) => void;
     oppdaterPeriode: (key: keyof Periode, nyVerdi: string) => void;
     typeOptions: SelectOption[];
-    formFeil?: FormErrors<FellesFormFelter>;
+    formFeil?: FormErrors<TypeOgDatoFelter>;
     alleFelterKanEndres: boolean;
     kanEndreType: boolean;
 }

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
@@ -50,7 +50,7 @@ export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
         <>
             <FeilmeldingMaksBredde>
                 <SelectMedOptions
-                    label="Type"
+                    label={form.type in MålgruppeType ? 'Ytelse/situasjon' : 'Type'}
                     readOnly={!kanEndreType}
                     value={form.type}
                     valg={typeOptions}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Vi lagde EndreFellesFelter for å unngå duplikat mellom EndreAktivitetBarnetilsyn og EndreAktivitetLæremidler, men disse fellesfeltene finnes også på målgruppe. Så ved å gjøre filen litt mer generell kan den brukes av begge.

**OBS:** lukket #592 for å gjøre det litt ryddigere. Har gjort typen generisk så vi slipper casting ⭐ 