### PR TITLE
Nye endepunkter for å opprette og oppdatere vilkårperioder

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårBarnetilsyn.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import JaNeiVurdering from '../../../Vilkårvurdering/JaNeiVurdering';
-import { DelvilkårAktivitetBarnetilsyn } from '../../typer/aktivitet';
-import { Vurdering } from '../../typer/vilkårperiode';
+import { JaNeiVurdering } from '../../../Vilkårvurdering/JaNeiVurdering';
+import { SvarJaNei } from '../../typer/vilkårperiode';
 import { EndreAktivitetFormBarnetilsyn } from '../EndreAktivitetBarnetilsyn';
 import { skalVurdereLønnet } from '../utilsBarnetilsyn';
 
@@ -15,9 +14,9 @@ const Container = styled.div`
 
 export const AktivitetDelvilkårBarnetilsyn: React.FC<{
     aktivitetForm: EndreAktivitetFormBarnetilsyn;
-    oppdaterDelvilkår: (key: keyof DelvilkårAktivitetBarnetilsyn, vurdering: Vurdering) => void;
+    oppdaterLønnet: (svar: SvarJaNei) => void;
     readOnly: boolean;
-}> = ({ aktivitetForm, oppdaterDelvilkår, readOnly }) => {
+}> = ({ aktivitetForm, oppdaterLønnet, readOnly }) => {
     if (aktivitetForm.type === '') return null;
 
     if (!skalVurdereLønnet(aktivitetForm.type)) return null;
@@ -27,8 +26,8 @@ export const AktivitetDelvilkårBarnetilsyn: React.FC<{
             <JaNeiVurdering
                 label="Mottar bruker ordinær lønn i tiltaket?"
                 readOnly={readOnly}
-                vurdering={aktivitetForm.delvilkår.lønnet}
-                oppdaterVurdering={(vurdering: Vurdering) => oppdaterDelvilkår('lønnet', vurdering)}
+                svar={aktivitetForm.svarLønnet}
+                oppdaterSvar={oppdaterLønnet}
             />
         </Container>
     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårLæremidler.tsx
@@ -2,9 +2,8 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import JaNeiVurdering from '../../../Vilkårvurdering/JaNeiVurdering';
-import { DelvilkårAktivitetLæremidler } from '../../typer/aktivitet';
-import { Vurdering } from '../../typer/vilkårperiode';
+import { JaNeiVurdering } from '../../../Vilkårvurdering/JaNeiVurdering';
+import { SvarJaNei } from '../../typer/vilkårperiode';
 import { EndreAktivitetFormLæremidler } from '../EndreAktivitetLæremidler';
 import { skalVurdereHarUtgifter } from '../utilsLæremidler';
 
@@ -15,9 +14,9 @@ const Container = styled.div`
 
 export const AktivitetDelvilkårLæremidler: React.FC<{
     aktivitetForm: EndreAktivitetFormLæremidler;
-    oppdaterDelvilkår: (key: keyof DelvilkårAktivitetLæremidler, vurdering: Vurdering) => void;
+    oppdaterHarUtgifter: (svar: SvarJaNei) => void;
     readOnly: boolean;
-}> = ({ aktivitetForm, oppdaterDelvilkår, readOnly }) => {
+}> = ({ aktivitetForm, oppdaterHarUtgifter, readOnly }) => {
     if (aktivitetForm.type === '') return null;
 
     if (!skalVurdereHarUtgifter(aktivitetForm.type)) return null;
@@ -27,10 +26,8 @@ export const AktivitetDelvilkårLæremidler: React.FC<{
             <JaNeiVurdering
                 label="Har bruker utgifter til læremidler?"
                 readOnly={readOnly}
-                vurdering={aktivitetForm.delvilkår.harUtgifter}
-                oppdaterVurdering={(vurdering: Vurdering) =>
-                    oppdaterDelvilkår('harUtgifter', vurdering)
-                }
+                svar={aktivitetForm.svarHarUtgifter}
+                oppdaterSvar={oppdaterHarUtgifter}
             />
         </Container>
     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetBarnetilsyn.tsx
@@ -47,7 +47,7 @@ export const validerAktivitet = (
 
     const obligatoriskeBegrunnelser = finnBegrunnelseGrunnerAktivitet(
         endretAktivitet.type,
-        endretAktivitet.delvilkår
+        endretAktivitet.svarLønnet
     );
 
     if (obligatoriskeBegrunnelser.length > 0 && harIkkeVerdi(endretAktivitet.begrunnelse))

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetLæremidler.tsx
@@ -47,7 +47,7 @@ export const validerAktivitet = (
 
     const obligatoriskeBegrunnelser = finnBegrunnelseGrunnerAktivitet(
         endretAktivitet.type,
-        endretAktivitet.delvilkår
+        endretAktivitet.svarHarUtgifter
     );
 
     if (obligatoriskeBegrunnelser.length > 0 && harIkkeVerdi(endretAktivitet.begrunnelse))

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -5,9 +5,9 @@ import styled from 'styled-components';
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import { målgruppeTilMedlemskapHjelpetekst } from './hjelpetekstVurdereMålgruppe';
 import { målgrupperHvorMedlemskapMåVurderes, skalVurdereDekkesAvAnnetRegelverk } from './utils';
-import JaNeiVurdering from '../../Vilkårvurdering/JaNeiVurdering';
-import { DelvilkårMålgruppe } from '../typer/målgruppe';
-import { Vurdering } from '../typer/vilkårperiode';
+import { JaNeiVurdering } from '../../Vilkårvurdering/JaNeiVurdering';
+import { VurderingerMålgruppe } from '../typer/målgruppe';
+import { SvarJaNei } from '../typer/vilkårperiode';
 
 const Container = styled.div`
     display: flex;
@@ -18,9 +18,9 @@ const Container = styled.div`
 // TODO: Rename til MålgruppeDelvilkår
 const MålgruppeVilkår: React.FC<{
     målgruppeForm: EndreMålgruppeForm;
-    oppdaterDelvilkår: (key: keyof DelvilkårMålgruppe, vurdering: Vurdering) => void;
+    oppdaterVurderinger: (key: keyof VurderingerMålgruppe, nyttSvar: SvarJaNei) => void;
     readOnly: boolean;
-}> = ({ målgruppeForm, oppdaterDelvilkår, readOnly }) => {
+}> = ({ målgruppeForm, oppdaterVurderinger, readOnly }) => {
     if (målgruppeForm.type === '') return null;
 
     const skalVurdereMedlemskap = målgrupperHvorMedlemskapMåVurderes.includes(målgruppeForm.type);
@@ -36,9 +36,9 @@ const MålgruppeVilkår: React.FC<{
                 <JaNeiVurdering
                     label="Medlemskap i folketrygden?"
                     readOnly={readOnly}
-                    vurdering={målgruppeForm.delvilkår.medlemskap}
-                    oppdaterVurdering={(vurdering: Vurdering) =>
-                        oppdaterDelvilkår('medlemskap', vurdering)
+                    svar={målgruppeForm.vurderinger.svarMedlemskap}
+                    oppdaterSvar={(nyttSvar: SvarJaNei) =>
+                        oppdaterVurderinger('svarMedlemskap', nyttSvar)
                     }
                     hjelpetekst={målgruppeTilMedlemskapHjelpetekst(målgruppeForm.type)}
                 />
@@ -47,9 +47,9 @@ const MålgruppeVilkår: React.FC<{
                 <JaNeiVurdering
                     label="Dekkes utgiftene av annet regelverk?"
                     readOnly={readOnly}
-                    vurdering={målgruppeForm.delvilkår.dekketAvAnnetRegelverk}
-                    oppdaterVurdering={(vurdering: Vurdering) =>
-                        oppdaterDelvilkår('dekketAvAnnetRegelverk', vurdering)
+                    svar={målgruppeForm.vurderinger.svarUtgifterDekketAvAnnetRegelverk}
+                    oppdaterSvar={(nyttSvar: SvarJaNei) =>
+                        oppdaterVurderinger('svarUtgifterDekketAvAnnetRegelverk', nyttSvar)
                     }
                 />
             )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/valideringMålgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/valideringMålgruppe.tsx
@@ -37,7 +37,7 @@ export const validerMålgruppe = (
 
     const obligatoriskeBegrunnelser = finnBegrunnelseGrunnerMålgruppe(
         endretMålgruppe.type,
-        endretMålgruppe.delvilkår
+        endretMålgruppe.vurderinger
     );
 
     if (obligatoriskeBegrunnelser.length > 0 && harIkkeVerdi(endretMålgruppe.begrunnelse))

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
@@ -67,3 +67,9 @@ export interface FaktaOgVurderingerAktivitetBarnetilsyn {
     aktivitetsdager: number | undefined;
     svarLønnet: SvarJaNei | undefined;
 }
+
+export interface FaktaOgVurderingerAktivitetLæremidler {
+    '@type': 'AKTIVITET_LÆREMIDLER';
+    prosent: number | undefined;
+    svarHarUtgifter: SvarJaNei | undefined;
+}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/aktivitet.ts
@@ -1,4 +1,4 @@
-import { VilkårPeriode, Vurdering } from './vilkårperiode';
+import { SvarJaNei, VilkårPeriode, Vurdering } from './vilkårperiode';
 import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 
 export type Aktivitet = AktivitetBarnetilsyn | AktivitetLæremidler;
@@ -61,3 +61,9 @@ export const aktivitetTypeOptions: SelectOption[] = Object.entries(AktivitetType
 export const aktivitetTypeOptionsForStønadsperiode = aktivitetTypeOptions.filter(
     (option) => option.value !== AktivitetType.INGEN_AKTIVITET
 );
+
+export interface FaktaOgVurderingerAktivitetBarnetilsyn {
+    '@type': 'AKTIVITET_BARNETILSYN';
+    aktivitetsdager: number | undefined;
+    svarLønnet: SvarJaNei | undefined;
+}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/målgruppe.ts
@@ -1,4 +1,4 @@
-import { VilkårPeriode, Vurdering } from './vilkårperiode';
+import { SvarJaNei, VilkårPeriode, Vurdering } from './vilkårperiode';
 import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 
 export interface Målgruppe extends VilkårPeriode {
@@ -72,3 +72,12 @@ export const MålgruppeTypeTilFaktiskMålgruppe: Record<MålgruppeType, FaktiskM
     SYKEPENGER_100_PROSENT: FaktiskMålgruppe.SYKEPENGER_100_PROSENT,
     INGEN_MÅLGRUPPE: FaktiskMålgruppe.INGEN_MÅLGRUPPE,
 };
+
+export interface VurderingerMålgruppe {
+    svarMedlemskap: SvarJaNei | undefined;
+    svarUtgifterDekketAvAnnetRegelverk: SvarJaNei | undefined;
+}
+
+export interface FaktaOgVurderingerMålgruppe extends VurderingerMålgruppe {
+    '@type': 'MÅLGRUPPE';
+}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
@@ -4,23 +4,23 @@ import styled from 'styled-components';
 
 import { HStack, Radio, RadioGroup, ReadMore } from '@navikt/ds-react';
 
-import { SvarJaNei, svarJaNeiMapping, Vurdering } from '../Inngangsvilkår/typer/vilkårperiode';
+import { SvarJaNei, svarJaNeiMapping } from '../Inngangsvilkår/typer/vilkårperiode';
 
 const LesMerTekst = styled(ReadMore)`
     max-width: 30rem;
 `;
 
-const JaNeiVurdering: React.FC<{
+export const JaNeiVurdering: React.FC<{
     label: string;
-    vurdering?: Vurdering;
-    oppdaterVurdering: (vurdering: Vurdering) => void;
+    svar: SvarJaNei | undefined;
+    oppdaterSvar: (svar: SvarJaNei) => void;
     svarJa?: string;
     svarNei?: string;
     hjelpetekst?: string;
     readOnly?: boolean;
 }> = ({
-    vurdering,
-    oppdaterVurdering,
+    svar,
+    oppdaterSvar,
     label,
     svarJa = svarJaNeiMapping[SvarJaNei.JA],
     svarNei = svarJaNeiMapping[SvarJaNei.NEI],
@@ -29,10 +29,10 @@ const JaNeiVurdering: React.FC<{
 }) => {
     return (
         <RadioGroup
-            value={vurdering?.svar || ''}
+            value={svar || ''}
             legend={label}
             readOnly={readOnly}
-            onChange={(e) => oppdaterVurdering({ ...vurdering, svar: e })}
+            onChange={oppdaterSvar}
             size="small"
         >
             {hjelpetekst && (
@@ -47,5 +47,3 @@ const JaNeiVurdering: React.FC<{
         </RadioGroup>
     );
 };
-
-export default JaNeiVurdering;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ta i bruk de nye endepunktene laget i [PR 495 i sak](https://github.com/navikt/tilleggsstonader-sak/pull/495)

Har splittet det opp i en commit per type/stønadstype, kan være fint å se på tilhørende util-fil samtidig.

PS: Fungerer ikke på lagremidler fordi mappingen av fakta og vurderinger ikke er implementer for læremidler enda. 