### PR TITLE
Erstatter "Revurdering" med "Ordinær Behandling" ved opprettelse av ny behandling

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -5,14 +5,14 @@ import { useFlag } from '@unleash/proxy-client-react';
 import { Button, Select, VStack } from '@navikt/ds-react';
 
 import OpprettKlageBehandling from './OpprettKlageBehandling';
+import {
+    OpprettNyBehandlingType,
+    opprettNyBehandlingTypeTilTekst,
+} from './OpprettNyBehandlingUtils';
 import OpprettRevurderingBehandling from './OpprettRevurderingBehandling';
 import { useApp } from '../../../../context/AppContext';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
-import {
-    BehandlingType,
-    behandlingTypeTilTekst,
-} from '../../../../typer/behandling/behandlingType';
 import { Toggle } from '../../../../utils/toggles';
 
 interface Props {
@@ -30,13 +30,14 @@ const OpprettNyBehandlingModal: FC<Props> = ({
 }) => {
     const { erSaksbehandler } = useApp();
     const [visModal, settVisModal] = useState(false);
-    const [behandlingtype, settBehandlingtype] = useState<BehandlingType>();
+    const [opprettNyBehandlingType, settOpprettNyBehandlingType] =
+        useState<OpprettNyBehandlingType>();
 
     const kanOppretteRevurdering = useFlag(Toggle.KAN_OPPRETTE_REVURDERING);
 
     const lukkModal = () => {
         settVisModal(false);
-        settBehandlingtype(undefined);
+        settOpprettNyBehandlingType(undefined);
     };
 
     if (!erSaksbehandler) {
@@ -54,30 +55,34 @@ const OpprettNyBehandlingModal: FC<Props> = ({
             <ModalWrapper visModal={visModal} onClose={lukkModal} tittel={'Opprett ny behandling'}>
                 <VStack gap="4">
                     <Select
-                        value={behandlingtype}
+                        value={opprettNyBehandlingType}
                         label="Behandlingstype"
                         onChange={(event) => {
-                            settBehandlingtype(event.target.value as BehandlingType);
+                            settOpprettNyBehandlingType(
+                                event.target.value as OpprettNyBehandlingType
+                            );
                         }}
                     >
                         <option value={''}>Velg</option>
                         {[
-                            ...(kanOppretteRevurdering ? [BehandlingType.REVURDERING] : []),
-                            ...[BehandlingType.KLAGE],
+                            ...(kanOppretteRevurdering
+                                ? [OpprettNyBehandlingType.ORDINAER_BEHANDLING]
+                                : []),
+                            ...[OpprettNyBehandlingType.KLAGE],
                         ].map((type) => (
                             <option key={type} value={type}>
-                                {behandlingTypeTilTekst[type]}
+                                {opprettNyBehandlingTypeTilTekst[type]}
                             </option>
                         ))}
                     </Select>
-                    {behandlingtype === BehandlingType.KLAGE && (
+                    {opprettNyBehandlingType === OpprettNyBehandlingType.KLAGE && (
                         <OpprettKlageBehandling
                             fagsakId={fagsakId}
                             lukkModal={lukkModal}
                             hentKlagebehandlinger={hentKlagebehandlinger}
                         />
                     )}
-                    {behandlingtype === BehandlingType.REVURDERING && (
+                    {opprettNyBehandlingType === OpprettNyBehandlingType.ORDINAER_BEHANDLING && (
                         <OpprettRevurderingBehandling
                             fagsakId={fagsakId}
                             stønadstype={stønadstype}

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -9,7 +9,7 @@ import {
     OpprettNyBehandlingType,
     opprettNyBehandlingTypeTilTekst,
 } from './OpprettNyBehandlingUtils';
-import OpprettRevurderingBehandling from './OpprettRevurderingBehandling';
+import OpprettOrdinærBehandling from './OpprettOrdinærBehandling';
 import { useApp } from '../../../../context/AppContext';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
@@ -83,7 +83,7 @@ const OpprettNyBehandlingModal: FC<Props> = ({
                         />
                     )}
                     {opprettNyBehandlingType === OpprettNyBehandlingType.ORDINAER_BEHANDLING && (
-                        <OpprettRevurderingBehandling
+                        <OpprettOrdinærBehandling
                             fagsakId={fagsakId}
                             stønadstype={stønadstype}
                             lukkModal={lukkModal}

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingUtils.ts
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingUtils.ts
@@ -1,0 +1,9 @@
+export enum OpprettNyBehandlingType {
+    ORDINAER_BEHANDLING = 'ORDINAER_BEHANDLING',
+    KLAGE = 'KLAGE',
+}
+
+export const opprettNyBehandlingTypeTilTekst: Record<OpprettNyBehandlingType, string> = {
+    ORDINAER_BEHANDLING: 'Ordinær behandling',
+    KLAGE: 'Klage',
+};

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingUtils.ts
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingUtils.ts
@@ -1,9 +1,11 @@
 export enum OpprettNyBehandlingType {
     ORDINAER_BEHANDLING = 'ORDINAER_BEHANDLING',
     KLAGE = 'KLAGE',
+    TILBAKEKREVING = 'TILBAKEKREVING',
 }
 
 export const opprettNyBehandlingTypeTilTekst: Record<OpprettNyBehandlingType, string> = {
     ORDINAER_BEHANDLING: 'Ordinær behandling',
     KLAGE: 'Klage',
+    TILBAKEKREVING: 'Tilbakekreving',
 };

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettOrdinærBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettOrdinærBehandling.tsx
@@ -39,7 +39,7 @@ const utledSkalViseBarnTilRevurdering = (
     ].indexOf(årsak) > -1;
 // TODO skal ikke kunne velge nye barn etter opprydding av de 2 sakene som trenger det
 
-const OpprettRevurderingBehandling: React.FC<Props> = ({
+const OpprettOrdinærBehandling: React.FC<Props> = ({
     fagsakId,
     stønadstype,
     lukkModal,
@@ -134,4 +134,4 @@ const OpprettRevurderingBehandling: React.FC<Props> = ({
     );
 };
 
-export default OpprettRevurderingBehandling;
+export default OpprettOrdinærBehandling;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ved opprettelse av ny behandling via saksoversikten har man i realiteten anledning til å opprette både revurderinger og førstegangsbehandlinger. Idag må saksbehandler allikevel velge "Revurdering", selv om det faktisk opprettes en førstegangsbehandling.

I denne PR erstattes "Revurdering" med "Ordinær behandling", som skal representere både revurderinger og førstegangsbehandlinger.

FAVRO: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23356

**ETTER:**
<img width="1271" alt="Skjermbilde 2024-11-26 kl  15 03 57" src="https://github.com/user-attachments/assets/1fec6517-e394-4a80-932c-8d00c4ff5580">

******
**FØR:**

<img width="1294" alt="Skjermbilde 2024-11-26 kl  15 04 13" src="https://github.com/user-attachments/assets/2fc4feca-db4b-4a42-ae44-c27876e73dd2">



