### PR TITLE
Unngår henting av brevmottakere hver gang man endrer noe i brevet.

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -16,9 +16,9 @@ import useMellomlagrignBrev from './useMellomlagrignBrev';
 import VelgBrevmal from './VelgBrevmal';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { usePersonopplysninger } from '../../../context/PersonopplysningerContext';
+import { useContextBrevmottakereSak } from '../../../hooks/useBrevmottakere';
 import { useVedtak } from '../../../hooks/useVedtak';
 import BrevMottakere from '../../../komponenter/Brevmottakere/BrevMottakere';
-import { Applikasjonskontekst } from '../../../komponenter/Brevmottakere/typer';
 import DataViewer from '../../../komponenter/DataViewer';
 import PdfVisning from '../../../komponenter/PdfVisning';
 import { RessursStatus } from '../../../typer/ressurs';
@@ -40,6 +40,7 @@ const ToKolonner = styled.div`
 
 const Brev: React.FC = () => {
     const { behandling, behandlingErRedigerbar } = useBehandling();
+    const contextBrevmottakere = useContextBrevmottakereSak(behandling.id);
 
     const { personopplysninger } = usePersonopplysninger();
     const {
@@ -88,10 +89,7 @@ const Brev: React.FC = () => {
                         <ToKolonner>
                             <VStack gap="8" align="start">
                                 <BrevMottakere
-                                    context={{
-                                        type: Applikasjonskontekst.SAK,
-                                        behandlingId: behandling.id,
-                                    }}
+                                    context={contextBrevmottakere}
                                     kanEndreBrevmottakere={behandlingErRedigerbar}
                                     personopplysninger={mapPersonopplysningerTilPersonopplysningerIBrevmottakere(
                                         personopplysninger

--- a/src/frontend/Sider/Klage/Steg/Brev/Brev.tsx
+++ b/src/frontend/Sider/Klage/Steg/Brev/Brev.tsx
@@ -9,8 +9,8 @@ import { Alert, Button } from '@navikt/ds-react';
 import { OmgjørVedtak } from './OmgjørVedtak';
 import PdfVisning from './PdfVisning';
 import { useApp } from '../../../../context/AppContext';
+import { useContextBrevmottakereKlage } from '../../../../hooks/useBrevmottakere';
 import BrevMottakere from '../../../../komponenter/Brevmottakere/BrevMottakere';
-import { Applikasjonskontekst } from '../../../../komponenter/Brevmottakere/typer';
 import DataViewer from '../../../../komponenter/DataViewer';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import SystemetLaster from '../../../../komponenter/SystemetLaster/SystemetLaster';
@@ -61,7 +61,7 @@ interface IBrev {
 
 export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
     const [brevRessurs, settBrevRessurs] = useState<Ressurs<string>>(byggTomRessurs());
-
+    const contextBrevmottakere = useContextBrevmottakereKlage(behandlingId);
     const {
         hentBehandling,
         hentBehandlingshistorikk,
@@ -157,10 +157,7 @@ export const Brev: React.FC<IBrev> = ({ behandlingId }) => {
                             >
                                 {({ personopplysningerFraKlageResponse }) => (
                                     <BrevMottakere
-                                        context={{
-                                            type: Applikasjonskontekst.KLAGE,
-                                            behandlingId: behandlingId,
-                                        }}
+                                        context={contextBrevmottakere}
                                         kanEndreBrevmottakere={behandlingErRedigerbar}
                                         personopplysninger={mapPersonopplysningerFraKlageTilPersonopplysningenIBrevmottaker(
                                             personopplysningerFraKlageResponse

--- a/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
+++ b/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
@@ -7,6 +7,7 @@ import { ABreakpointLgDown } from '@navikt/ds-tokens/dist/tokens';
 
 import { useApp } from '../../../context/AppContext';
 import { usePersonopplysninger } from '../../../context/PersonopplysningerContext';
+import { useContextBrevmottakereFrittståendeBrev } from '../../../hooks/useBrevmottakere';
 import BrevMottakere from '../../../komponenter/Brevmottakere/BrevMottakere';
 import DataViewer from '../../../komponenter/DataViewer';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
@@ -34,6 +35,7 @@ const FrittståendeBrev: React.FC<{
     settBrevErSendt: () => void;
 }> = ({ valgtStønadstype, fagsakId, settBrevErSendt }) => {
     const { request } = useApp();
+    const contextBrevmottakere = useContextBrevmottakereFrittståendeBrev(fagsakId);
     const [senderBrev, settSenderBrev] = useState<boolean>(false);
 
     const { personopplysninger } = usePersonopplysninger();
@@ -106,10 +108,7 @@ const FrittståendeBrev: React.FC<{
                 <ToKolonner>
                     <VStack gap="8" align="start">
                         <BrevMottakere
-                            context={{
-                                type: 'frittstående-brev',
-                                fagsakId: fagsakId,
-                            }}
+                            context={contextBrevmottakere}
                             kanEndreBrevmottakere={true}
                             personopplysninger={mapPersonopplysningerTilPersonopplysningerIBrevmottakere(
                                 personopplysninger

--- a/src/frontend/hooks/useBrevmottakere.ts
+++ b/src/frontend/hooks/useBrevmottakere.ts
@@ -1,13 +1,30 @@
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { useApp } from '../context/AppContext';
 import { Applikasjonskontekst, IBrevmottakere } from '../komponenter/Brevmottakere/typer';
 import { byggTomRessurs, Ressurs } from '../typer/ressurs';
 
+type ContextBrevmottakereSak = { type: Applikasjonskontekst.SAK; behandlingId: string };
+type ContextBrevmottakereKlage = { type: Applikasjonskontekst.KLAGE; behandlingId: string };
+type ContextBrevmottakereFrittståendeBrev = { type: 'frittstående-brev'; fagsakId: string };
 export type ContextBrevmottakere =
-    | { type: Applikasjonskontekst.SAK; behandlingId: string }
-    | { type: Applikasjonskontekst.KLAGE; behandlingId: string }
-    | { type: 'frittstående-brev'; fagsakId: string };
+    | ContextBrevmottakereSak
+    | ContextBrevmottakereKlage
+    | ContextBrevmottakereFrittståendeBrev;
+
+export const useContextBrevmottakereSak = (behandlingId: string): ContextBrevmottakereSak =>
+    useMemo(() => ({ type: Applikasjonskontekst.SAK, behandlingId: behandlingId }), [behandlingId]);
+
+export const useContextBrevmottakereKlage = (behandlingId: string): ContextBrevmottakereKlage =>
+    useMemo(
+        () => ({ type: Applikasjonskontekst.KLAGE, behandlingId: behandlingId }),
+        [behandlingId]
+    );
+
+export const useContextBrevmottakereFrittståendeBrev = (
+    fagsakId: string
+): ContextBrevmottakereFrittståendeBrev =>
+    useMemo(() => ({ type: 'frittstående-brev', fagsakId: fagsakId }), [fagsakId]);
 
 export const useBrevmottakere = (context: ContextBrevmottakere) => {
     const [brevmottakere, settBrevmottakere] = useState<Ressurs<IBrevmottakere>>(byggTomRessurs());


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hver gang man utførte en endring i brevet så ble et kall trigget for å hente brevmottakere. Dette blir mange kall.

Tidligere ble objektet `context` opprettet på nytt hver gang man utførte en endring i brevet. Pga at `Brev` renderes på nytt.
Dette pga at `hentBrevmottakere` oppdateres hver gang `context` endrer seg, og dependency-list sjekker på objektpekere og ikke deep-check på objektet.

Hver context ligger nå i en memo, og trigger ev. endring av behandlingId/fagsakId.

## Alternativ til løsning:
Fjerne `context` fra `hentBrevmottakere` og `lagreBrevmottakere` sin `DependencyList`
Men på en måte føler jeg dette blir litt ryddigere