### PR TITLE
Lagt til avslagsvedtak for læremidler

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/AvslåVedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/AvslåVedtak.tsx
@@ -1,0 +1,91 @@
+import React, { useState } from 'react';
+
+import { Checkbox, CheckboxGroup, Textarea, VStack } from '@navikt/ds-react';
+
+import { FeilmeldingVedtak, valider } from './validering';
+import { useApp } from '../../../../context/AppContext';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import { useSteg } from '../../../../context/StegContext';
+import { UlagretKomponent } from '../../../../hooks/useUlagredeKomponenter';
+import { StegKnapp } from '../../../../komponenter/Stegflyt/StegKnapp';
+import { Steg } from '../../../../typer/behandling/steg';
+import { erTomtObjekt } from '../../../../typer/typeUtils';
+import { TypeVedtak, ÅrsakAvslag, årsakAvslagTilTekst } from '../../../../typer/vedtak/vedtak';
+import {
+    AvslagLæremidler,
+    AvslåLæremidlerRequest,
+} from '../../../../typer/vedtak/vedtakLæremidler';
+import { FanePath } from '../../faner';
+
+const AvslåVedtak: React.FC<{ vedtak?: AvslagLæremidler }> = ({ vedtak }) => {
+    const { behandling } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
+    const { request, settUlagretKomponent } = useApp();
+
+    const [årsaker, settÅrsaker] = useState<ÅrsakAvslag[]>(vedtak?.årsakerAvslag || []);
+    const [begrunnelse, settBegrunnelse] = useState<string>(vedtak?.begrunnelse || '');
+    const [feilmeldinger, settFeilmeldinger] = useState<FeilmeldingVedtak>({});
+
+    const lagreVedtak = () => {
+        return request<null, AvslåLæremidlerRequest>(
+            `/api/sak/vedtak/laremidler/${behandling.id}/avslag`,
+            'POST',
+            { type: TypeVedtak.AVSLAG, årsakerAvslag: årsaker, begrunnelse: begrunnelse }
+        );
+    };
+
+    const validerOgLagreVedtak = () => {
+        const feil = valider(årsaker, begrunnelse);
+        settFeilmeldinger(feil);
+
+        if (erTomtObjekt(feil)) {
+            return lagreVedtak();
+        } else {
+            return Promise.reject();
+        }
+    };
+
+    return (
+        <VStack gap="4">
+            <CheckboxGroup
+                legend="Årsak til avslag"
+                value={årsaker}
+                onChange={(e) => {
+                    settÅrsaker(e);
+                    settUlagretKomponent(UlagretKomponent.BEREGNING_AVSLÅ);
+                }}
+                readOnly={!erStegRedigerbart}
+                size="small"
+                error={feilmeldinger.årsaker}
+            >
+                {Object.keys(ÅrsakAvslag).map((årsak) => (
+                    <Checkbox value={årsak} key={årsak}>
+                        {årsakAvslagTilTekst[årsak as ÅrsakAvslag]}
+                    </Checkbox>
+                ))}
+            </CheckboxGroup>
+            <Textarea
+                label="Begrunnelse for avslag (obligatorisk)"
+                value={begrunnelse}
+                onChange={(e) => {
+                    settBegrunnelse(e.target.value);
+                    settUlagretKomponent(UlagretKomponent.BEREGNING_AVSLÅ);
+                }}
+                error={feilmeldinger.begrunnelse}
+                readOnly={!erStegRedigerbart}
+                size="small"
+            />
+
+            <StegKnapp
+                steg={Steg.BEREGNE_YTELSE}
+                nesteFane={FanePath.SIMULERING}
+                onNesteSteg={validerOgLagreVedtak}
+                validerUlagedeKomponenter={false}
+            >
+                Lagre vedtak og gå videre
+            </StegKnapp>
+        </VStack>
+    );
+};
+
+export default AvslåVedtak;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
@@ -1,0 +1,66 @@
+import React, { FC, useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { HGrid } from '@navikt/ds-react';
+
+import AvslåVedtak from './AvslåVedtak';
+import { useVedtak } from '../../../../hooks/useVedtak';
+import DataViewer from '../../../../komponenter/DataViewer';
+import Panel from '../../../../komponenter/Panel/Panel';
+import { RessursStatus } from '../../../../typer/ressurs';
+import { TypeVedtak } from '../../../../typer/vedtak/vedtak';
+import { AvslagLæremidler, VedtakLæremidler } from '../../../../typer/vedtak/vedtakLæremidler';
+import VelgVedtakResultat from '../Felles/VelgVedtakResultat';
+
+const Container = styled.div`
+    padding: 2rem 2rem;
+    display: flex;
+    flex-direction: column;
+    gap: 1.5rem;
+`;
+
+const VedtakOgBeregningLæremidler: FC = () => {
+    const { vedtak } = useVedtak<VedtakLæremidler>();
+
+    const [typeVedtak, settTypeVedtak] = useState<TypeVedtak | undefined>();
+
+    useEffect(() => {
+        if (vedtak.status === RessursStatus.SUKSESS) {
+            settTypeVedtak(vedtak.data.type);
+        }
+    }, [vedtak]);
+
+    return (
+        <DataViewer response={{ vedtak }}>
+            {({ vedtak }) => (
+                <Container>
+                    <Panel tittel="Vedtak">
+                        <HGrid gap="16" columns={{ sm: 1, md: '5em auto' }}>
+                            {
+                                <VelgVedtakResultat
+                                    typeVedtak={typeVedtak}
+                                    settTypeVedtak={settTypeVedtak}
+                                />
+                            }
+                            {typeVedtak === TypeVedtak.AVSLAG && (
+                                <AvslåVedtak vedtak={vedtak as AvslagLæremidler} />
+                            )}
+                            {typeVedtak === TypeVedtak.OPPHØR && (
+                                <span>Har ikke støtte for opphør ennå</span>
+                                /*<OpphørVedtak vedtak={vedtak as OpphørBarnetilsyn} />*/
+                            )}
+                        </HGrid>
+                    </Panel>
+
+                    {typeVedtak === TypeVedtak.INNVILGELSE && (
+                        <span>Har ikke støtte for innvilgelse ennå</span>
+                        /*<InnvilgeBarnetilsyn lagretVedtak={vedtak as InnvilgelseBarnetilsyn} />*/
+                    )}
+                </Container>
+            )}
+        </DataViewer>
+    );
+};
+
+export default VedtakOgBeregningLæremidler;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
@@ -1,0 +1,24 @@
+import { ÅrsakAvslag, ÅrsakOpphør } from '../../../../typer/vedtak/vedtak';
+import { harIkkeVerdi } from '../../../../utils/utils';
+
+export interface FeilmeldingVedtak {
+    årsaker?: string;
+    begrunnelse?: string;
+}
+
+export const valider = (
+    årsaker: ÅrsakAvslag[] | ÅrsakOpphør[],
+    begrunnelse?: string
+): FeilmeldingVedtak => {
+    const feilmeldinger: FeilmeldingVedtak = {};
+
+    if (årsaker.length === 0) {
+        feilmeldinger.årsaker = 'Minst en årsak må velges';
+    }
+
+    if (harIkkeVerdi(begrunnelse)) {
+        feilmeldinger.begrunnelse = 'Begrunnelse må fylles ut';
+    }
+
+    return feilmeldinger;
+};

--- a/src/frontend/Sider/Behandling/faner.tsx
+++ b/src/frontend/Sider/Behandling/faner.tsx
@@ -15,9 +15,10 @@ import { RevurderFra } from './RevurderFra/RevurderFra';
 import Simulering from './Simulering/Simulering';
 import Stønadsvilkår from './Stønadsvilkår/Stønadsvilkår';
 import VedtakOgBeregningBarnetilsyn from './VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn';
+import VedtakOgBeregningLæremidler from './VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler';
 import { Behandling } from '../../typer/behandling/behandling';
 import { BehandlingResultat } from '../../typer/behandling/behandlingResultat';
-import { Stønadstype } from '../../typer/behandling/behandlingTema';
+import { Stønadstype, stønadstypeTilTekst } from '../../typer/behandling/behandlingTema';
 import { BehandlingType } from '../../typer/behandling/behandlingType';
 import { BehandlingÅrsak } from '../../typer/behandling/behandlingÅrsak';
 import { Steg, stegErLåstForBehandling } from '../../typer/behandling/steg';
@@ -137,6 +138,17 @@ const sendTilBeslutterUtenBrev = (behandling: Behandling): FanerMedRouter[] => {
     }
 };
 
+export const vedtakForBehandling = (behandling: Behandling): React.ReactNode => {
+    switch (behandling.stønadstype) {
+        case Stønadstype.BARNETILSYN:
+            return <VedtakOgBeregningBarnetilsyn />;
+        case Stønadstype.LÆREMIDLER:
+            return <VedtakOgBeregningLæremidler />;
+        default:
+            return <span>Har ikke vedtak for {stønadstypeTilTekst[behandling.stønadstype]}</span>;
+    }
+};
+
 export const hentBehandlingfaner = (behandling: Behandling): FanerMedRouter[] => {
     return [
         ...revurderingFraFane(behandling),
@@ -155,7 +167,7 @@ export const hentBehandlingfaner = (behandling: Behandling): FanerMedRouter[] =>
         {
             navn: FaneNavn.VEDTAK_OG_BEREGNING,
             path: FanePath.VEDTAK_OG_BEREGNING,
-            komponent: () => <VedtakOgBeregningBarnetilsyn />,
+            komponent: () => vedtakForBehandling(behandling),
             ikon: <CalculatorIcon />,
             erLåst: faneErLåst(behandling, FanePath.VEDTAK_OG_BEREGNING),
         },

--- a/src/frontend/typer/vedtak/vedtakLæremidler.ts
+++ b/src/frontend/typer/vedtak/vedtakLæremidler.ts
@@ -1,0 +1,11 @@
+import { TypeVedtak, ÅrsakAvslag } from './vedtak';
+
+export type VedtakLæremidler = AvslagLæremidler;
+
+export type AvslåLæremidlerRequest = {
+    type: TypeVedtak.AVSLAG;
+    årsakerAvslag: ÅrsakAvslag[];
+    begrunnelse: string;
+};
+
+export type AvslagLæremidler = AvslåLæremidlerRequest;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skall for vedtak for læremidler. Foreløpig kun avslag.
- Har kopiert komponenter fra tilsyn barn. Mulig eks avslag kan lages som en felleskomponent senere. 

<img width="1022" alt="image" src="https://github.com/user-attachments/assets/7de4d1dd-896e-41db-8512-6a9e622cf87e">