### PR TITLE
Fjern reell arbeidssøker som en valgmulighet for aktivitet på læremidler

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Button, HStack } from '@navikt/ds-react';
 
 import { AktivitetDelvilkårBarnetilsyn } from './Delvilkår/AktivitetDelvilkårBarnetilsyn';
-import { lagAktivitetTypeOptions } from './utilsAktivitet';
+import { valgbareAktivitetTyper } from './utilsAktivitet';
 import {
     finnBegrunnelseGrunnerAktivitet,
     mapEksisterendeAktivitet,
@@ -162,7 +162,7 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
-                    typeOptions={lagAktivitetTypeOptions(Stønadstype.BARNETILSYN)}
+                    typeOptions={valgbareAktivitetTyper(Stønadstype.BARNETILSYN)}
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -21,11 +21,16 @@ import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPeri
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import TextField from '../../../../komponenter/Skjema/TextField';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
-import { Aktivitet, AktivitetType, aktivitetTypeOptions } from '../typer/vilkårperiode/aktivitet';
+import {
+    Aktivitet,
+    AktivitetType,
+    lagAktivitetTypeOptions,
+} from '../typer/vilkårperiode/aktivitet';
 import { AktivitetBarnetilsyn } from '../typer/vilkårperiode/aktivitetBarnetilsyn';
 import {
     KildeVilkårsperiode,
@@ -160,7 +165,7 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
-                    typeOptions={aktivitetTypeOptions}
+                    typeOptions={lagAktivitetTypeOptions(Stønadstype.BARNETILSYN)}
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Button, HStack } from '@navikt/ds-react';
 
 import { AktivitetDelvilkårBarnetilsyn } from './Delvilkår/AktivitetDelvilkårBarnetilsyn';
+import { lagAktivitetTypeOptions } from './utilsAktivitet';
 import {
     finnBegrunnelseGrunnerAktivitet,
     mapEksisterendeAktivitet,
@@ -26,11 +27,7 @@ import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
-import {
-    Aktivitet,
-    AktivitetType,
-    lagAktivitetTypeOptions,
-} from '../typer/vilkårperiode/aktivitet';
+import { Aktivitet, AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import { AktivitetBarnetilsyn } from '../typer/vilkårperiode/aktivitetBarnetilsyn';
 import {
     KildeVilkårsperiode,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -5,6 +5,7 @@ import styled from 'styled-components';
 import { Button, HStack } from '@navikt/ds-react';
 
 import { AktivitetDelvilkårLæremidler } from './Delvilkår/AktivitetDelvilkårLæremidler';
+import { lagAktivitetTypeOptions } from './utilsAktivitet';
 import {
     finnBegrunnelseGrunnerAktivitet,
     mapEksisterendeAktivitet,
@@ -26,11 +27,7 @@ import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
-import {
-    Aktivitet,
-    AktivitetType,
-    lagAktivitetTypeOptions,
-} from '../typer/vilkårperiode/aktivitet';
+import { Aktivitet, AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetLæremidler,
     AktivitetTypeLæremidler,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -21,10 +21,16 @@ import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPeri
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
 import TextField from '../../../../komponenter/Skjema/TextField';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
+import {
+    Aktivitet,
+    AktivitetType,
+    lagAktivitetTypeOptions,
+} from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetLæremidler,
     AktivitetTypeLæremidler,
@@ -162,7 +168,7 @@ export const EndreAktivitetLæremidler: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
-                    typeOptions={aktivitetTypeOptions}
+                    typeOptions={lagAktivitetTypeOptions(Stønadstype.LÆREMIDLER)}
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { Button, HStack } from '@navikt/ds-react';
 
 import { AktivitetDelvilkårLæremidler } from './Delvilkår/AktivitetDelvilkårLæremidler';
-import { lagAktivitetTypeOptions } from './utilsAktivitet';
+import { valgbareAktivitetTyper } from './utilsAktivitet';
 import {
     finnBegrunnelseGrunnerAktivitet,
     mapEksisterendeAktivitet,
@@ -165,7 +165,7 @@ export const EndreAktivitetLæremidler: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
-                    typeOptions={lagAktivitetTypeOptions(Stønadstype.LÆREMIDLER)}
+                    typeOptions={valgbareAktivitetTyper(Stønadstype.LÆREMIDLER)}
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -25,8 +25,10 @@ import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
-import { Aktivitet, AktivitetType, aktivitetTypeOptions } from '../typer/vilkårperiode/aktivitet';
-import { AktivitetLæremidler } from '../typer/vilkårperiode/aktivitetLæremidler';
+import {
+    AktivitetLæremidler,
+    AktivitetTypeLæremidler,
+} from '../typer/vilkårperiode/aktivitetLæremidler';
 import {
     KildeVilkårsperiode,
     StønadsperiodeStatus,
@@ -48,7 +50,7 @@ const FeltContainer = styled.div`
 `;
 
 export interface EndreAktivitetFormLæremidler extends Periode {
-    type: AktivitetType | '';
+    type: AktivitetTypeLæremidler | '';
     prosent: number | undefined;
     svarHarUtgifter: SvarJaNei | undefined;
     begrunnelse?: string;
@@ -134,7 +136,7 @@ export const EndreAktivitetLæremidler: React.FC<{
         settForm((prevState) => ({ ...prevState, [key]: nyVerdi }));
     };
 
-    const oppdaterType = (type: AktivitetType) => {
+    const oppdaterType = (type: AktivitetTypeLæremidler) => {
         settForm((prevState) =>
             resettAktivitet(type, prevState, behandlingFakta.søknadMottattTidspunkt)
         );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
@@ -1,0 +1,38 @@
+import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
+import { AktivitetType, AktivitetTypeTilTekst } from '../typer/vilkårperiode/aktivitet';
+
+export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
+    if (type === '') return type;
+
+    return AktivitetTypeTilTekst[type];
+};
+
+export const lagAktivitetTypeOptions = (stønadstype: Stønadstype): SelectOption[] => {
+    const relevanteTyper = finnRelevanteAktivitetTyperForStønad(stønadstype);
+
+    return relevanteTyper.map((type) => ({
+        value: type,
+        label: AktivitetTypeTilTekst[type],
+    }));
+};
+
+export const lagAktivitetTypeOptionsForStønadsperiode = (stønadstype: Stønadstype) =>
+    lagAktivitetTypeOptions(stønadstype).filter(
+        (option) => option.value !== AktivitetType.INGEN_AKTIVITET
+    );
+
+export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype): AktivitetType[] => {
+    switch (stønadstype) {
+        case Stønadstype.BARNETILSYN:
+            return [
+                AktivitetType.TILTAK,
+                AktivitetType.UTDANNING,
+                AktivitetType.REELL_ARBEIDSSØKER,
+                AktivitetType.INGEN_AKTIVITET,
+            ];
+
+        case Stønadstype.LÆREMIDLER:
+            return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_AKTIVITET];
+    }
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
@@ -8,7 +8,7 @@ export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
     return AktivitetTypeTilTekst[type];
 };
 
-export const lagAktivitetTypeOptions = (stønadstype: Stønadstype): SelectOption[] => {
+export const valgbareAktivitetTyper = (stønadstype: Stønadstype): SelectOption[] => {
     const relevanteTyper = finnRelevanteAktivitetTyperForStønad(stønadstype);
 
     return relevanteTyper.map((type) => ({
@@ -17,8 +17,8 @@ export const lagAktivitetTypeOptions = (stønadstype: Stønadstype): SelectOptio
     }));
 };
 
-export const lagAktivitetTypeOptionsForStønadsperiode = (stønadstype: Stønadstype) =>
-    lagAktivitetTypeOptions(stønadstype).filter(
+export const valgbareAktivitetTyperForStønadsperiode = (stønadstype: Stønadstype) =>
+    valgbareAktivitetTyper(stønadstype).filter(
         (option) => option.value !== AktivitetType.INGEN_AKTIVITET
     );
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
@@ -6,6 +6,7 @@ import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetLæremidler,
     AktivitetLæremidlerFaktaOgSvar,
+    AktivitetTypeLæremidler,
 } from '../typer/vilkårperiode/aktivitetLæremidler';
 import { SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
 import { BegrunnelseGrunner } from '../Vilkårperioder/Begrunnelse/utils';
@@ -55,7 +56,7 @@ const lagBegrunnelseForAktivitet = (aktivitetFraRegister: Registeraktivitet) =>
 export const skalVurdereHarUtgifter = (type: AktivitetType | '') => type === AktivitetType.TILTAK;
 
 export const resettAktivitet = (
-    nyType: AktivitetType,
+    nyType: AktivitetTypeLæremidler,
     eksisterendeAktivitetForm: EndreAktivitetFormLæremidler,
     søknadMottattTidspunkt?: string
 ): EndreAktivitetFormLæremidler => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -11,7 +11,7 @@ import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponent
 import { BehandlingType } from '../../../../typer/behandling/behandlingType';
 import {
     aktivitetTypeTilTekst,
-    lagAktivitetTypeOptionsForStønadsperiode,
+    valgbareAktivitetTyperForStønadsperiode,
 } from '../Aktivitet/utilsAktivitet';
 import { Stønadsperiode } from '../typer/stønadsperiode';
 import {
@@ -47,7 +47,7 @@ const StønadsperiodeRad: React.FC<Props> = ({
     const finnFeilmelding = (property: keyof Stønadsperiode) =>
         feilmeldinger && feilmeldinger[property];
 
-    const aktivitetTypeOptionsForStønadsperiode = lagAktivitetTypeOptionsForStønadsperiode(
+    const aktivitetTypeOptionsForStønadsperiode = valgbareAktivitetTyperForStønadsperiode(
         behandling.stønadstype
     );
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -9,11 +9,11 @@ import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMe
 import SelectMedOptions from '../../../../komponenter/Skjema/SelectMedOptions';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { BehandlingType } from '../../../../typer/behandling/behandlingType';
-import { Stønadsperiode } from '../typer/stønadsperiode';
 import {
     aktivitetTypeTilTekst,
     lagAktivitetTypeOptionsForStønadsperiode,
-} from '../typer/vilkårperiode/aktivitet';
+} from '../Aktivitet/utilsAktivitet';
+import { Stønadsperiode } from '../typer/stønadsperiode';
 import {
     målgruppeTypeOptionsForStønadsperiode,
     målgruppeTypeTilTekst,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StønadsperiodeRad.tsx
@@ -11,8 +11,8 @@ import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponent
 import { BehandlingType } from '../../../../typer/behandling/behandlingType';
 import { Stønadsperiode } from '../typer/stønadsperiode';
 import {
-    aktivitetTypeOptionsForStønadsperiode,
     aktivitetTypeTilTekst,
+    lagAktivitetTypeOptionsForStønadsperiode,
 } from '../typer/vilkårperiode/aktivitet';
 import {
     målgruppeTypeOptionsForStønadsperiode,
@@ -46,6 +46,10 @@ const StønadsperiodeRad: React.FC<Props> = ({
 
     const finnFeilmelding = (property: keyof Stønadsperiode) =>
         feilmeldinger && feilmeldinger[property];
+
+    const aktivitetTypeOptionsForStønadsperiode = lagAktivitetTypeOptionsForStønadsperiode(
+        behandling.stønadstype
+    );
 
     return (
         <>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
@@ -8,8 +8,6 @@ import {
     AktivitetLæremidlerFaktaOgSvar,
     AktivitetLæremidlerFaktaOgVurderinger,
 } from './aktivitetLæremidler';
-import { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
-import { Stønadstype } from '../../../../../typer/behandling/behandlingTema';
 
 export type Aktivitet = AktivitetBarnetilsyn | AktivitetLæremidler;
 
@@ -25,41 +23,6 @@ export const AktivitetTypeTilTekst: Record<AktivitetType, string> = {
     UTDANNING: 'Utdanning',
     REELL_ARBEIDSSØKER: 'Reell arbeidssøker',
     INGEN_AKTIVITET: 'Ingen aktivitet',
-};
-
-export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
-    if (type === '') return type;
-
-    return AktivitetTypeTilTekst[type];
-};
-
-export const lagAktivitetTypeOptions = (stønadstype: Stønadstype): SelectOption[] => {
-    const relevanteTyper = finnRelevanteAktivitetTyperForStønad(stønadstype);
-
-    return relevanteTyper.map((type) => ({
-        value: type,
-        label: AktivitetTypeTilTekst[type],
-    }));
-};
-
-export const lagAktivitetTypeOptionsForStønadsperiode = (stønadstype: Stønadstype) =>
-    lagAktivitetTypeOptions(stønadstype).filter(
-        (option) => option.value !== AktivitetType.INGEN_AKTIVITET
-    );
-
-export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype): AktivitetType[] => {
-    switch (stønadstype) {
-        case Stønadstype.BARNETILSYN:
-            return [
-                AktivitetType.TILTAK,
-                AktivitetType.UTDANNING,
-                AktivitetType.REELL_ARBEIDSSØKER,
-                AktivitetType.INGEN_AKTIVITET,
-            ];
-
-        case Stønadstype.LÆREMIDLER:
-            return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_AKTIVITET];
-    }
 };
 
 export type AktivitetFaktaOgVurderinger =

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
@@ -9,6 +9,7 @@ import {
     AktivitetLæremidlerFaktaOgVurderinger,
 } from './aktivitetLæremidler';
 import { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
+import { Stønadstype } from '../../../../../typer/behandling/behandlingTema';
 
 export type Aktivitet = AktivitetBarnetilsyn | AktivitetLæremidler;
 
@@ -32,16 +33,34 @@ export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
     return AktivitetTypeTilTekst[type];
 };
 
-export const aktivitetTypeOptions: SelectOption[] = Object.entries(AktivitetTypeTilTekst).map(
-    ([value, label]) => ({
-        value: value,
-        label: label,
-    })
-);
+export const lagAktivitetTypeOptions = (stønadstype: Stønadstype): SelectOption[] => {
+    const relevanteTyper = finnRelevanteAktivitetTyperForStønad(stønadstype);
 
-export const aktivitetTypeOptionsForStønadsperiode = aktivitetTypeOptions.filter(
-    (option) => option.value !== AktivitetType.INGEN_AKTIVITET
-);
+    return relevanteTyper.map((type) => ({
+        value: type,
+        label: AktivitetTypeTilTekst[type],
+    }));
+};
+
+export const lagAktivitetTypeOptionsForStønadsperiode = (stønadstype: Stønadstype) =>
+    lagAktivitetTypeOptions(stønadstype).filter(
+        (option) => option.value !== AktivitetType.INGEN_AKTIVITET
+    );
+
+export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype): AktivitetType[] => {
+    switch (stønadstype) {
+        case Stønadstype.BARNETILSYN:
+            return [
+                AktivitetType.TILTAK,
+                AktivitetType.UTDANNING,
+                AktivitetType.REELL_ARBEIDSSØKER,
+                AktivitetType.INGEN_AKTIVITET,
+            ];
+
+        case Stønadstype.LÆREMIDLER:
+            return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_AKTIVITET];
+    }
+};
 
 export type AktivitetFaktaOgVurderinger =
     | AktivitetBarnetilsynFaktaOgVurderinger

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler.ts
@@ -3,10 +3,15 @@ import { SvarJaNei, VilkårPeriode, Vurdering } from './vilkårperiode';
 
 export interface AktivitetLæremidler extends VilkårPeriode {
     id: string;
-    type: AktivitetType.TILTAK | AktivitetType.UTDANNING | AktivitetType.INGEN_AKTIVITET;
+    type: AktivitetTypeLæremidler;
     kildeId?: string;
     faktaOgVurderinger: AktivitetLæremidlerFaktaOgVurderinger;
 }
+
+export type AktivitetTypeLæremidler =
+    | AktivitetType.TILTAK
+    | AktivitetType.UTDANNING
+    | AktivitetType.INGEN_AKTIVITET;
 
 export interface AktivitetLæremidlerFaktaOgVurderinger {
     '@type': 'AKTIVITET_LÆREMIDLER';

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/OppsummeringStønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/OppsummeringStønadsperioder.tsx
@@ -3,8 +3,8 @@ import React from 'react';
 import { Box, List } from '@navikt/ds-react';
 
 import { formaterTilTekstligDato } from '../../../utils/dato';
+import { aktivitetTypeTilTekst } from '../Inngangsvilkår/Aktivitet/utilsAktivitet';
 import { Stønadsperiode } from '../Inngangsvilkår/typer/stønadsperiode';
-import { aktivitetTypeTilTekst } from '../Inngangsvilkår/typer/vilkårperiode/aktivitet';
 import { målgruppeTypeTilTekst } from '../Inngangsvilkår/typer/vilkårperiode/målgruppe';
 
 const OppsummeringStønadsperioder: React.FC<{ stønadsperioder: Stønadsperiode[] }> = ({

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Beregningsresultat.tsx
@@ -8,7 +8,7 @@ import '@navikt/ds-css';
 
 import { BeregningsresultatTilsynBarn, Vedtaksperiode } from '../../../../../typer/vedtak';
 import { formaterIsoPeriode } from '../../../../../utils/dato';
-import { aktivitetTypeTilTekst } from '../../../Inngangsvilkår/typer/vilkårperiode/aktivitet';
+import { aktivitetTypeTilTekst } from '../../../Inngangsvilkår/Aktivitet/utilsAktivitet';
 import { målgruppeTypeTilTekst } from '../../../Inngangsvilkår/typer/vilkårperiode/målgruppe';
 
 const Container = styled.div`


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Reell arbeidssøker er ikke en gyldig aktivitet man skal kunne registrere på læremidler.

Løst ved å endre `aktivitetSelectOptions` til en funksjon som tar inn stønadstypen og finner alternativer basert på denne.

⚠️ Se commit for commit for å slippe litt kaos ved refaktor til ny fil i siste commit