### PR TITLE
Toggle kan saksbehandle/revurdere stønader - læremidler

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -42,7 +42,7 @@ const DisabledTab = styled(Tabs.Tab)`
 const BehandlingTabsInnhold = () => {
     const navigate = useNavigate();
     const { settToast } = useApp();
-    const { behandling, behandlingErRedigerbar, kanBehandleRevurdering, kanSetteBehandlingPåVent } =
+    const { behandling, behandlingErRedigerbar, toggleKanSaksbehandle, kanSetteBehandlingPåVent } =
         useBehandling();
 
     const path = useLocation().pathname.split('/')[3];
@@ -112,7 +112,7 @@ const BehandlingTabsInnhold = () => {
                     </TabsList>
                 </StickyTablistContainer>
 
-                {!kanBehandleRevurdering && (
+                {!toggleKanSaksbehandle && (
                     <Alert variant={'error'}>Mulighet for å saksbehandle er skrudd av</Alert>
                 )}
                 <SettPåVentContainer

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -78,7 +78,7 @@ const skalHenteTotrinnskontroll = (
 };
 const Totrinnskontroll: FC = () => {
     const navigate = useNavigate();
-    const { behandling, kanBehandleRevurdering } = useBehandling();
+    const { behandling } = useBehandling();
     const prevBehandling = usePrevious(behandling);
 
     const [visGodkjentModal, settVisGodkjentModal] = useState(false);
@@ -95,10 +95,6 @@ const Totrinnskontroll: FC = () => {
     const skalViseTotrinnskontrollSwitch =
         totrinnskontroll.status === RessursStatus.SUKSESS &&
         totrinnskontroll.data.status !== TotrinnskontrollStatus.UAKTUELT;
-
-    if (!kanBehandleRevurdering) {
-        return null;
-    }
 
     return (
         <>

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -6,6 +6,7 @@ import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
 import { Behandling } from '../typer/behandling/behandling';
 import { BehandlingFakta } from '../typer/behandling/behandlingFakta/behandlingFakta';
 import { erBehandlingRedigerbar } from '../typer/behandling/behandlingStatus';
+import { Stønadstype } from '../typer/behandling/behandlingTema';
 import { Toggle } from '../utils/toggles';
 
 interface Props {
@@ -14,22 +15,64 @@ interface Props {
     behandlingFakta: BehandlingFakta;
 }
 
+/**
+ * @param behandlingErRedigerbar er redigerbar dersom behandling er i riktig state, og toggles for å behandle er enabled
+ * @param toggleKanSaksbehandle viser alert hvis funksjonalitet for saksbehandling er skrudd av.
+ * @param kanSetteBehandlingPåVent skal kunne sette en behandling på vent selv om toggle er skrudd av, men behandlingen må være i riktig state for å kunne settes på vent
+ *
+ */
+interface BehandlingContext {
+    behandling: Behandling;
+    behandlingErRedigerbar: boolean;
+    hentBehandling: RerrunnableEffect;
+    behandlingFakta: BehandlingFakta;
+    toggleKanSaksbehandle: boolean;
+    kanSetteBehandlingPåVent: boolean;
+}
+
+const useKanSaksbehandle = (stønadstype: Stønadstype) => {
+    const kanSaksbehandleLæremidler = useFlag(Toggle.KAN_SAKSBEHANDLE_LÆREMIDLER);
+    switch (stønadstype) {
+        case Stønadstype.BARNETILSYN:
+            return true;
+        case Stønadstype.LÆREMIDLER:
+            return kanSaksbehandleLæremidler;
+        default:
+            return false;
+    }
+};
+
+const useKanRevurdere = (stønadstype: Stønadstype) => {
+    const kanRevurdereLæremidler = useFlag(Toggle.KAN_REVURDERE_LÆREMIDLER);
+    switch (stønadstype) {
+        case Stønadstype.BARNETILSYN:
+            return true;
+        case Stønadstype.LÆREMIDLER:
+            return kanRevurdereLæremidler;
+        default:
+            return false;
+    }
+};
+
 export const [BehandlingProvider, useBehandling] = constate(
-    ({ behandling, hentBehandling, behandlingFakta }: Props) => {
+    ({ behandling, hentBehandling, behandlingFakta }: Props): BehandlingContext => {
         const { erSaksbehandler } = useApp();
 
-        const kanSaksbehandle = useFlag(Toggle.KAN_SAKSBEHANDLE);
+        const kanSaksbehandle = useKanSaksbehandle(behandling.stønadstype);
+        const kanRevurdere = useKanRevurdere(behandling.stønadstype);
 
-        // kanSetteBehandlingPåVent er temporær kan fjernes og erstattes med behandlingErRedigerbar når KAN_SAKSBEHANDLE fjernes
-        const kanBehandleRevurdering = !behandling.forrigeBehandlingId || kanSaksbehandle;
         const behandlingErRedigerbar = erBehandlingRedigerbar(behandling.status) && erSaksbehandler;
+
+        const toggleKanSaksbehandleEllerRevurdere = behandling.forrigeBehandlingId
+            ? kanRevurdere
+            : kanSaksbehandle;
 
         return {
             behandling,
-            behandlingErRedigerbar: kanBehandleRevurdering && behandlingErRedigerbar,
+            behandlingErRedigerbar: behandlingErRedigerbar && toggleKanSaksbehandleEllerRevurdere,
             hentBehandling,
             behandlingFakta,
-            toggleKanSaksbehandle: kanSaksbehandle,
+            toggleKanSaksbehandle: toggleKanSaksbehandleEllerRevurdere,
             kanSetteBehandlingPåVent: behandlingErRedigerbar,
         };
     }

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -29,7 +29,7 @@ export const [BehandlingProvider, useBehandling] = constate(
             behandlingErRedigerbar: kanBehandleRevurdering && behandlingErRedigerbar,
             hentBehandling,
             behandlingFakta,
-            kanBehandleRevurdering,
+            toggleKanSaksbehandle: kanSaksbehandle,
             kanSetteBehandlingPåVent: behandlingErRedigerbar,
         };
     }

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -5,7 +5,8 @@ export enum Toggle {
 
     ADMIN_KAN_OPPRETTE_BEHANDLING = 'sak.admin-kan-opprette-behandling',
 
-    KAN_SAKSBEHANDLE = 'sak.frontend.kan-saksbehandle',
+    KAN_SAKSBEHANDLE_LÆREMIDLER = 'sak.frontend.kan-saksbehandle.laremidler',
+    KAN_REVURDERE_LÆREMIDLER = 'sak.frontend.kan-revurdere.laremidler',
 
     SKAL_VISE_STATUS_PERIODER = 'sak.frontend.skal-vise-status-perioder',
 

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -8,12 +8,11 @@ import { Toggle } from './toggles';
  */
 const featureFlags: Partial<Record<Toggle, boolean>> = {
     [Toggle.KAN_OPPRETTE_REVURDERING]: true,
-    [Toggle.KAN_SAKSBEHANDLE]: true,
+    [Toggle.KAN_SAKSBEHANDLE_LÆREMIDLER]: true,
 };
 
 export const mockFlags: IToggle[] = Object.values(Toggle).map((toggle) => {
     const enabled = featureFlags[toggle] ?? true;
-
     return {
         name: toggle,
         enabled: enabled,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Skal kunne toggle behandling og revurdering av spesifike stønadstyper
- Behandling er redigerbar dersom behandling er i riktig state og toggle er enabled, som er avhengig av om det er en revurdering eller vanlig behandling
- Skal alltid kunne sette en behandling på vent

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23509
https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23476