### PR TITLE
Hundre prosent sykepenger fjernes som maalgruppe for laremidler

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -27,8 +27,7 @@ import { Periode } from '../../../../utils/periode';
 import {
     Målgruppe,
     MålgruppeType,
-    målgruppeTypeOptionsForStønadBarnestilsyn,
-    målgruppeTypeOptionsForStønadLæremidler,
+    målgruppeTypeOptionsForStønad,
     SvarMålgruppe,
 } from '../typer/vilkårperiode/målgruppe';
 import { StønadsperiodeStatus, SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
@@ -151,10 +150,10 @@ const EndreMålgruppeRad: React.FC<{
     const målgruppeSwitch = (stønadstype: Stønadstype): SelectOption[] => {
         switch (stønadstype) {
             case Stønadstype.BARNETILSYN: {
-                return målgruppeTypeOptionsForStønadBarnestilsyn;
+                return målgruppeTypeOptionsForStønad(stønadstype);
             }
             case Stønadstype.LÆREMIDLER: {
-                return målgruppeTypeOptionsForStønadLæremidler;
+                return målgruppeTypeOptionsForStønad(stønadstype);
             }
         }
     };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -19,14 +19,16 @@ import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useLagreVilkårperiode } from '../../../../hooks/useLagreVilkårperiode';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { PeriodeYtelseRegister } from '../../../../typer/registerytelser';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import {
     Målgruppe,
-    målgrupperForStønad,
     MålgruppeType,
+    målgruppeTypeOptionsForStønadBarnestilsyn,
+    målgruppeTypeOptionsForStønadLæremidler,
     SvarMålgruppe,
 } from '../typer/vilkårperiode/målgruppe';
 import { StønadsperiodeStatus, SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
@@ -146,13 +148,13 @@ const EndreMålgruppeRad: React.FC<{
         nyRadLeggesTil: !målgruppe,
     });
 
-    const målgruppeSwitch = (stønadstype: Stønadstype) => {
+    const målgruppeSwitch = (stønadstype: Stønadstype): SelectOption[] => {
         switch (stønadstype) {
             case Stønadstype.BARNETILSYN: {
-                return målgrupperForStønad[Stønadstype.BARNETILSYN];
+                return målgruppeTypeOptionsForStønadBarnestilsyn;
             }
             case Stønadstype.LÆREMIDLER: {
-                return målgrupperForStønad[Stønadstype.LÆREMIDLER];
+                return målgruppeTypeOptionsForStønadLæremidler;
             }
         }
     };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -19,6 +19,7 @@ import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useLagreVilkårperiode } from '../../../../hooks/useLagreVilkårperiode';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { PeriodeYtelseRegister } from '../../../../typer/registerytelser';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
@@ -26,6 +27,7 @@ import {
     Målgruppe,
     MålgruppeType,
     målgruppeTypeOptions,
+    målgruppeTypeOptionsForLæremidler,
     SvarMålgruppe,
 } from '../typer/vilkårperiode/målgruppe';
 import { StønadsperiodeStatus, SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
@@ -152,7 +154,11 @@ const EndreMålgruppeRad: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
-                    typeOptions={målgruppeTypeOptions}
+                    typeOptions={
+                        behandling.stønadstype === Stønadstype.LÆREMIDLER
+                            ? målgruppeTypeOptionsForLæremidler
+                            : målgruppeTypeOptions
+                    }
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={kanEndreType}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -25,9 +25,8 @@ import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import {
     Målgruppe,
+    målgrupperForStønad,
     MålgruppeType,
-    målgruppeTypeOptions,
-    målgruppeTypeOptionsForLæremidler,
     SvarMålgruppe,
 } from '../typer/vilkårperiode/målgruppe';
 import { StønadsperiodeStatus, SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
@@ -147,6 +146,17 @@ const EndreMålgruppeRad: React.FC<{
         nyRadLeggesTil: !målgruppe,
     });
 
+    const målgruppeSwitch = (stønadstype: Stønadstype) => {
+        switch (stønadstype) {
+            case Stønadstype.BARNETILSYN: {
+                return målgrupperForStønad[Stønadstype.BARNETILSYN];
+            }
+            case Stønadstype.LÆREMIDLER: {
+                return målgrupperForStønad[Stønadstype.LÆREMIDLER];
+            }
+        }
+    };
+
     return (
         <VilkårperiodeKortBase vilkårperiode={målgruppe} redigeres>
             <FeltContainer>
@@ -154,11 +164,7 @@ const EndreMålgruppeRad: React.FC<{
                     form={form}
                     oppdaterTypeIForm={oppdaterType}
                     oppdaterPeriode={oppdaterForm}
-                    typeOptions={
-                        behandling.stønadstype === Stønadstype.LÆREMIDLER
-                            ? målgruppeTypeOptionsForLæremidler
-                            : målgruppeTypeOptions
-                    }
+                    typeOptions={målgruppeSwitch(behandling.stønadstype)}
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={kanEndreType}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
@@ -2,7 +2,10 @@ import React from 'react';
 
 import { BodyLong, ReadMore } from '@navikt/ds-react';
 
-export const MålgruppeHjelpetekst = () => (
+import { useBehandling } from '../../../../context/BehandlingContext';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
+
+const BarnetilsynHjelpetekst = () => (
     <ReadMore header={'Slik gjør du vurderingen'} size="small">
         <BodyLong size={'small'} spacing>
             Dersom søker oppgir å ha <strong>overgangsstønad</strong>, men ikke mottar stønaden, må
@@ -30,3 +33,38 @@ export const MålgruppeHjelpetekst = () => (
         </BodyLong>
     </ReadMore>
 );
+
+const LæremidlerHjelpetekst = () => (
+    <ReadMore header={'Slik gjør du vurderingen'} size="small">
+        <BodyLong size={'small'} spacing>
+            Dersom søker oppgir å ha <strong>overgangsstønad</strong>, men ikke mottar stønaden, må
+            du be NAY enslig forsørger (kontornummer 4489) vurdere om søker har rett til
+            overgangsstønad. Dersom søker har rett, settes målgruppe overgangsstønad til oppfylt.
+        </BodyLong>
+        <BodyLong size={'small'} spacing>
+            Dersom søker oppgir å ha <strong>omstillingsstønad</strong>, men ikke mottar stønaden,
+            må du be Nav Familie- og Pensjonsytelser vurdere om søker har rett til
+            omstillingsstønad. Dersom søker har rett, settes målgruppe omstillingsstønad til
+            oppfylt. Dersom søker ikke har eller har rett til omstillingsstønad, må du kontrollere
+            om det utbetales gjenlevendepensjon. Dersom søker har gjenlevendepensjon, settes
+            målgruppe omstillingsstønad til oppfylt. Dersom søker heller ikke har
+            gjenlevendepensjon, må du be Nav Familie- og Pensjonsytelser vurdere om inngangsvilkår
+            for tilleggsstønad etter kapittel 17 slik det lød før 01.01.24, er oppfylt.
+        </BodyLong>
+        <BodyLong size={'small'} spacing>
+            Dersom søker oppgir <strong>nedsatt arbeidsevne</strong>, men ikke mottar AAP eller
+            uføretrygd, må du be Nav- kontoret vurdere om vilkårene for nedsatt arbeidsevne i § 11
+            A-3 er oppfylt.
+        </BodyLong>
+        <BodyLong size={'small'}>
+            Hvis søker mottar <strong>sykepenger</strong> , men ikke har AAP eller uføretrygd, skal
+            du sjekke om søker har nedsatt arbeidsevne etter §11 A-3.
+        </BodyLong>
+    </ReadMore>
+);
+
+export const MålgruppeHjelpetekst = () => {
+    const { behandling } = useBehandling();
+    if (behandling.stønadstype === Stønadstype.LÆREMIDLER) return <LæremidlerHjelpetekst />;
+    return <BarnetilsynHjelpetekst />;
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
@@ -16,9 +16,9 @@ const BarnetilsynHjelpetekst = () => (
             Dersom søker oppgir å ha <strong>omstillingsstønad</strong>, men ikke mottar stønaden,
             må du be Nav Familie- og Pensjonsytelser vurdere om søker har rett til
             omstillingsstønad. Dersom søker har rett, settes målgruppe omstillingsstønad til
-            oppfylt. Dersom søker ikke har eller har rett til omstillingsstønad, må du kontrollere
-            om det utbetales gjenlevendepensjon. Dersom søker har gjenlevendepensjon, settes
-            målgruppe omstillingsstønad til oppfylt. Dersom søker heller ikke har
+            oppfylt. Dersom søker ikke mottar eller har rett til omstillingsstønad, må du
+            kontrollere om det utbetales gjenlevendepensjon. Dersom søker har gjenlevendepensjon,
+            settes målgruppe omstillingsstønad til oppfylt. Dersom søker heller ikke har
             gjenlevendepensjon, må du be Nav Familie- og Pensjonsytelser vurdere om inngangsvilkår
             for tilleggsstønad etter kapittel 17 slik det lød før 01.01.24, er oppfylt.
         </BodyLong>
@@ -45,9 +45,9 @@ const LæremidlerHjelpetekst = () => (
             Dersom søker oppgir å ha <strong>omstillingsstønad</strong>, men ikke mottar stønaden,
             må du be Nav Familie- og Pensjonsytelser vurdere om søker har rett til
             omstillingsstønad. Dersom søker har rett, settes målgruppe omstillingsstønad til
-            oppfylt. Dersom søker ikke mottar eller har rett til omstillingsstønad, må du kontrollere
-            om det utbetales gjenlevendepensjon. Dersom søker har gjenlevendepensjon, settes
-            målgruppe omstillingsstønad til oppfylt. Dersom søker heller ikke har
+            oppfylt. Dersom søker ikke mottar eller har rett til omstillingsstønad, må du
+            kontrollere om det utbetales gjenlevendepensjon. Dersom søker har gjenlevendepensjon,
+            settes målgruppe omstillingsstønad til oppfylt. Dersom søker heller ikke har
             gjenlevendepensjon, må du be Nav Familie- og Pensjonsytelser vurdere om inngangsvilkår
             for tilleggsstønad etter kapittel 17 slik det lød før 01.01.24, er oppfylt.
         </BodyLong>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
@@ -57,7 +57,7 @@ const LæremidlerHjelpetekst = () => (
             A-3 er oppfylt.
         </BodyLong>
         <BodyLong size={'small'}>
-            Hvis søker mottar <strong>sykepenger</strong> , men ikke har AAP eller uføretrygd, skal
+            Hvis søker mottar <strong>sykepenger</strong>, men ikke har AAP eller uføretrygd, skal
             du sjekke om søker har nedsatt arbeidsevne etter §11 A-3.
         </BodyLong>
     </ReadMore>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
@@ -24,8 +24,8 @@ const BarnetilsynHjelpetekst = () => (
         </BodyLong>
         <BodyLong size={'small'} spacing>
             Dersom søker oppgir <strong>nedsatt arbeidsevne</strong>, men ikke mottar AAP eller
-            uføretrygd, må du be Nav- kontoret vurdere om vilkårene for nedsatt arbeidsevne i § 11
-            A-3 er oppfylt.
+            uføretrygd, må du be Nav-kontoret vurdere om vilkårene for nedsatt arbeidsevne i §11 A-3
+            er oppfylt.
         </BodyLong>
         <BodyLong size={'small'}>
             Velg <strong>100% sykepenger</strong> hvis søker mottar sykepenger fra en
@@ -53,8 +53,8 @@ const LæremidlerHjelpetekst = () => (
         </BodyLong>
         <BodyLong size={'small'} spacing>
             Dersom søker oppgir <strong>nedsatt arbeidsevne</strong>, men ikke mottar AAP eller
-            uføretrygd, må du be Nav-kontoret vurdere om vilkårene for nedsatt arbeidsevne i § 11
-            A-3 er oppfylt.
+            uføretrygd, må du be Nav-kontoret vurdere om vilkårene for nedsatt arbeidsevne i §11 A-3
+            er oppfylt.
         </BodyLong>
         <BodyLong size={'small'}>
             Hvis søker mottar <strong>sykepenger</strong>, men ikke har AAP eller uføretrygd, skal

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
@@ -53,7 +53,7 @@ const LæremidlerHjelpetekst = () => (
         </BodyLong>
         <BodyLong size={'small'} spacing>
             Dersom søker oppgir <strong>nedsatt arbeidsevne</strong>, men ikke mottar AAP eller
-            uføretrygd, må du be Nav- kontoret vurdere om vilkårene for nedsatt arbeidsevne i § 11
+            uføretrygd, må du be Nav-kontoret vurdere om vilkårene for nedsatt arbeidsevne i § 11
             A-3 er oppfylt.
         </BodyLong>
         <BodyLong size={'small'}>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeHjelpetekst.tsx
@@ -45,7 +45,7 @@ const LæremidlerHjelpetekst = () => (
             Dersom søker oppgir å ha <strong>omstillingsstønad</strong>, men ikke mottar stønaden,
             må du be Nav Familie- og Pensjonsytelser vurdere om søker har rett til
             omstillingsstønad. Dersom søker har rett, settes målgruppe omstillingsstønad til
-            oppfylt. Dersom søker ikke har eller har rett til omstillingsstønad, må du kontrollere
+            oppfylt. Dersom søker ikke mottar eller har rett til omstillingsstønad, må du kontrollere
             om det utbetales gjenlevendepensjon. Dersom søker har gjenlevendepensjon, settes
             målgruppe omstillingsstønad til oppfylt. Dersom søker heller ikke har
             gjenlevendepensjon, må du be Nav Familie- og Pensjonsytelser vurdere om inngangsvilkår

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -67,20 +67,12 @@ export const målgruppeTypeTilTekst = (type: MålgruppeType | '') => {
     return MålgruppeTypeTilTekst[type];
 };
 
-export const målgruppeTypeOptionsForStønadBarnestilsyn: SelectOption[] = Object.entries(
-    målgrupperForStønad[Stønadstype.BARNETILSYN]
-).map(([value, label]) => ({
-    value: value,
-    label: målgruppeTypeTilTekst(label),
-}));
-
-export const målgruppeTypeOptionsForStønadLæremidler: SelectOption[] = Object.entries(
-    målgrupperForStønad[Stønadstype.LÆREMIDLER]
-).map(([value, label]) => ({
-    value: value,
-    label: målgruppeTypeTilTekst(label),
-}));
-
+export const målgruppeTypeOptionsForStønad = (stønadstype: Stønadstype): SelectOption[] => {
+    return Object.entries(målgrupperForStønad[stønadstype]).map(([value, label]) => ({
+        value: value,
+        label: målgruppeTypeTilTekst(label),
+    }));
+};
 export const målgruppeTypeOptions: SelectOption[] = Object.entries(MålgruppeTypeTilTekst).map(
     ([value, label]) => ({
         value: value,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -52,14 +52,28 @@ const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
 export const målgrupperForStønad: Record<Stønadstype, MålgruppeType[]> = Object.entries(
     målgrupper
 ).reduce(
-    (prev, [stønadstype, årsaker]) => {
-        prev[stønadstype as Stønadstype] = Object.entries(årsaker)
+    (prev, [stønadstype, målgruppe]) => {
+        prev[stønadstype as Stønadstype] = Object.entries(målgruppe)
             .filter(([, skalMed]) => skalMed)
             .map(([målgruppe]) => målgruppe) as MålgruppeType[];
         return prev;
     },
     {} as Record<Stønadstype, MålgruppeType[]>
 );
+
+export const målgruppeTypeOptionsForStønadBarnestilsyn: SelectOption[] = Object.entries(
+    målgrupperForStønad[Stønadstype.BARNETILSYN]
+).map(([value, label]) => ({
+    value: value,
+    label: label,
+}));
+
+export const målgruppeTypeOptionsForStønadLæremidler: SelectOption[] = Object.entries(
+    målgrupperForStønad[Stønadstype.LÆREMIDLER]
+).map(([value, label]) => ({
+    value: value,
+    label: label,
+}));
 
 export const målgruppeTypeTilTekst = (type: MålgruppeType | '') => {
     if (type === '') return type;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -1,5 +1,6 @@
 import { SvarJaNei, VilkårPeriode, Vurdering } from './vilkårperiode';
 import { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
+import { Stønadstype } from '../../../../../typer/behandling/behandlingTema';
 
 export interface Målgruppe extends VilkårPeriode {
     id: string;
@@ -27,6 +28,39 @@ export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
     INGEN_MÅLGRUPPE: 'Ingen målgruppe',
 };
 
+const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
+    [Stønadstype.BARNETILSYN]: {
+        AAP: true,
+        UFØRETRYGD: true,
+        OMSTILLINGSSTØNAD: true,
+        OVERGANGSSTØNAD: true,
+        NEDSATT_ARBEIDSEVNE: true,
+        SYKEPENGER_100_PROSENT: true,
+        INGEN_MÅLGRUPPE: true,
+    },
+    [Stønadstype.LÆREMIDLER]: {
+        AAP: true,
+        UFØRETRYGD: true,
+        OMSTILLINGSSTØNAD: true,
+        OVERGANGSSTØNAD: true,
+        NEDSATT_ARBEIDSEVNE: true,
+        SYKEPENGER_100_PROSENT: false,
+        INGEN_MÅLGRUPPE: true,
+    },
+};
+
+export const målgrupperForStønad: Record<Stønadstype, MålgruppeType[]> = Object.entries(
+    målgrupper
+).reduce(
+    (prev, [stønadstype, årsaker]) => {
+        prev[stønadstype as Stønadstype] = Object.entries(årsaker)
+            .filter(([, skalMed]) => skalMed)
+            .map(([målgruppe]) => målgruppe) as MålgruppeType[];
+        return prev;
+    },
+    {} as Record<Stønadstype, MålgruppeType[]>
+);
+
 export const målgruppeTypeTilTekst = (type: MålgruppeType | '') => {
     if (type === '') return type;
 
@@ -44,10 +78,6 @@ export const målgruppeTypeOptionsForStønadsperiode = målgruppeTypeOptions.fil
     (option) =>
         option.value !== MålgruppeType.INGEN_MÅLGRUPPE &&
         option.value !== MålgruppeType.SYKEPENGER_100_PROSENT
-);
-
-export const målgruppeTypeOptionsForLæremidler = målgruppeTypeOptions.filter(
-    (option) => option.value !== MålgruppeType.SYKEPENGER_100_PROSENT
 );
 
 // TODO: Endre navn på enum

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -61,25 +61,25 @@ export const målgrupperForStønad: Record<Stønadstype, MålgruppeType[]> = Obj
     {} as Record<Stønadstype, MålgruppeType[]>
 );
 
+export const målgruppeTypeTilTekst = (type: MålgruppeType | '') => {
+    if (type === '') return type;
+
+    return MålgruppeTypeTilTekst[type];
+};
+
 export const målgruppeTypeOptionsForStønadBarnestilsyn: SelectOption[] = Object.entries(
     målgrupperForStønad[Stønadstype.BARNETILSYN]
 ).map(([value, label]) => ({
     value: value,
-    label: label,
+    label: målgruppeTypeTilTekst(label),
 }));
 
 export const målgruppeTypeOptionsForStønadLæremidler: SelectOption[] = Object.entries(
     målgrupperForStønad[Stønadstype.LÆREMIDLER]
 ).map(([value, label]) => ({
     value: value,
-    label: label,
+    label: målgruppeTypeTilTekst(label),
 }));
-
-export const målgruppeTypeTilTekst = (type: MålgruppeType | '') => {
-    if (type === '') return type;
-
-    return MålgruppeTypeTilTekst[type];
-};
 
 export const målgruppeTypeOptions: SelectOption[] = Object.entries(MålgruppeTypeTilTekst).map(
     ([value, label]) => ({

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -46,6 +46,10 @@ export const målgruppeTypeOptionsForStønadsperiode = målgruppeTypeOptions.fil
         option.value !== MålgruppeType.SYKEPENGER_100_PROSENT
 );
 
+export const målgruppeTypeOptionsForLæremidler = målgruppeTypeOptions.filter(
+    (option) => option.value !== MålgruppeType.SYKEPENGER_100_PROSENT
+);
+
 // TODO: Endre navn på enum
 // FaktiskMålgruppe brukes som navn foreløpig
 // Disse verdiene er faktiske målgrupper, mens målgruppetype burde hete noe ala hovedytelse eller liknende


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
FAVRO: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23603

Skal ikke vise "100% sykepenger" som mulig valg i dropdown dersom behandlingen gjelder Læremidler

Skal vise alternativ tekst dersom behandling gjelder Læremidler

*******
ETTER:
![Skjermbilde 2024-12-09 kl  16 03 27](https://github.com/user-attachments/assets/9e1d5db1-0ef6-4580-aa7d-5b5d1188cf99)
********
FØR:
![Skjermbilde 2024-12-09 kl  16 05 49](https://github.com/user-attachments/assets/534e051e-d826-4fdd-a90e-6c072570eea5)

