### PR TITLE
Småfiks fakta og vurdering læremidler

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårLæremidler.tsx
@@ -10,7 +10,7 @@ import {
     EndreAktivitetFormLæremidler,
     VurderingerAktivitetLæremidler,
 } from '../EndreAktivitetLæremidler';
-import { skalVurdereHarUtgifter } from '../utilsLæremidler';
+import { erUtdanningEllerTiltak, skalVurdereHarUtgifter } from '../utilsLæremidler';
 
 const Container = styled.div`
     display: flex;
@@ -43,7 +43,7 @@ export const AktivitetDelvilkårLæremidler: React.FC<{
     oppdaterVurderinger: (key: keyof VurderingerAktivitetLæremidler, nyttSvar: SvarJaNei) => void;
     readOnly: boolean;
 }> = ({ aktivitetForm, oppdaterVurderinger, readOnly }) => {
-    if (aktivitetForm.type === '') return null;
+    if (!erUtdanningEllerTiltak(aktivitetForm.type)) return null;
 
     return (
         <Container>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -8,6 +8,7 @@ import { AktivitetDelvilkårLæremidler } from './Delvilkår/AktivitetDelvilkår
 import { EndreStudienivå } from './EndreStudinivå';
 import { valgbareAktivitetTyper } from './utilsAktivitet';
 import {
+    erUtdanningEllerTiltak,
     finnBegrunnelseGrunnerAktivitet,
     mapEksisterendeAktivitet,
     mapFaktaOgSvarTilRequest,
@@ -28,7 +29,7 @@ import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
-import { Aktivitet, AktivitetType } from '../typer/vilkårperiode/aktivitet';
+import { Aktivitet } from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetLæremidler,
     AktivitetTypeLæremidler,
@@ -166,9 +167,6 @@ export const EndreAktivitetLæremidler: React.FC<{
 
     const aktivitetErBruktFraSystem = form.kildeId !== undefined;
 
-    const erUtdanningEllerTiltak =
-        form.type === AktivitetType.TILTAK || form.type === AktivitetType.UTDANNING;
-
     return (
         <VilkårperiodeKortBase vilkårperiode={aktivitet} redigeres>
             <FeltContainer>
@@ -181,7 +179,7 @@ export const EndreAktivitetLæremidler: React.FC<{
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}
                 />
-                {erUtdanningEllerTiltak && (
+                {erUtdanningEllerTiltak(form.type) && (
                     <FeilmeldingMaksBredde $maxWidth={140}>
                         <TextField
                             erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
@@ -202,16 +200,14 @@ export const EndreAktivitetLæremidler: React.FC<{
                 )}
             </FeltContainer>
 
-            {erUtdanningEllerTiltak && (
-                <EndreStudienivå
-                    form={form}
-                    settStudienivå={(studienivå: Studienivå) =>
-                        settForm((prevState) => ({ ...prevState, studienivå: studienivå }))
-                    }
-                    alleFelterKanEndres={alleFelterKanEndres}
-                    feil={vilkårsperiodeFeil}
-                />
-            )}
+            <EndreStudienivå
+                form={form}
+                settStudienivå={(studienivå: Studienivå) =>
+                    settForm((prevState) => ({ ...prevState, studienivå: studienivå }))
+                }
+                alleFelterKanEndres={alleFelterKanEndres}
+                feil={vilkårsperiodeFeil}
+            />
 
             <AktivitetDelvilkårLæremidler
                 aktivitetForm={form}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreStudinivå.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreStudinivå.tsx
@@ -3,9 +3,9 @@ import React from 'react';
 import { RadioGroup, HStack, Radio } from '@navikt/ds-react';
 
 import { EndreAktivitetFormLæremidler } from './EndreAktivitetLæremidler';
+import { erUtdanningEllerTiltak } from './utilsLæremidler';
 import { AktivitetValidering } from './valideringAktivitetLæremidler';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
-import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import { Studienivå, studienivåTilTekst } from '../typer/vilkårperiode/aktivitetLæremidler';
 
 export const EndreStudienivå: React.FC<{
@@ -14,27 +14,27 @@ export const EndreStudienivå: React.FC<{
     alleFelterKanEndres: boolean;
     feil?: FormErrors<AktivitetValidering>;
 }> = ({ form, settStudienivå, alleFelterKanEndres, feil }) => {
+    if (!erUtdanningEllerTiltak(form.type)) {
+        return null;
+    }
+
     return (
-        <>
-            {form.type !== AktivitetType.INGEN_AKTIVITET && (
-                <RadioGroup
-                    value={form.studienivå || ''}
-                    legend="Studienivå"
-                    readOnly={!alleFelterKanEndres}
-                    onChange={(e) => settStudienivå(e)}
-                    size="small"
-                    error={feil?.studienivå}
-                >
-                    <HStack gap="4">
-                        <Radio value={Studienivå.HØYERE_UTDANNING}>
-                            {studienivåTilTekst[Studienivå.HØYERE_UTDANNING]}
-                        </Radio>
-                        <Radio value={Studienivå.VIDEREGÅENDE}>
-                            {studienivåTilTekst[Studienivå.VIDEREGÅENDE]}
-                        </Radio>
-                    </HStack>
-                </RadioGroup>
-            )}
-        </>
+        <RadioGroup
+            value={form.studienivå || ''}
+            legend="Studienivå"
+            readOnly={!alleFelterKanEndres}
+            onChange={(e) => settStudienivå(e)}
+            size="small"
+            error={feil?.studienivå}
+        >
+            <HStack gap="4">
+                <Radio value={Studienivå.HØYERE_UTDANNING}>
+                    {studienivåTilTekst[Studienivå.HØYERE_UTDANNING]}
+                </Radio>
+                <Radio value={Studienivå.VIDEREGÅENDE}>
+                    {studienivåTilTekst[Studienivå.VIDEREGÅENDE]}
+                </Radio>
+            </HStack>
+        </RadioGroup>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
@@ -81,21 +81,20 @@ export const resettAktivitet = (
 ): EndreAktivitetFormLæremidler => {
     const { fom, tom } = resetPeriode(nyType, eksisterendeAktivitetForm, søknadMottattTidspunkt);
 
-    const erUtdanningEllerTiltak =
-        nyType === AktivitetType.TILTAK || nyType === AktivitetType.UTDANNING;
+    const utdanningEllerTiltak = erUtdanningEllerTiltak(nyType);
 
     return {
         ...eksisterendeAktivitetForm,
         type: nyType,
         fom: fom,
         tom: tom,
-        studienivå: erUtdanningEllerTiltak ? eksisterendeAktivitetForm.studienivå : undefined,
-        prosent: erUtdanningEllerTiltak ? eksisterendeAktivitetForm.prosent : undefined,
+        studienivå: utdanningEllerTiltak ? eksisterendeAktivitetForm.studienivå : undefined,
+        prosent: utdanningEllerTiltak ? eksisterendeAktivitetForm.prosent : undefined,
         vurderinger: {
             svarHarUtgifter: skalVurdereHarUtgifter(nyType)
                 ? eksisterendeAktivitetForm.vurderinger.svarHarUtgifter
                 : undefined,
-            svarHarRettTilUtstyrsstipend: erUtdanningEllerTiltak
+            svarHarRettTilUtstyrsstipend: utdanningEllerTiltak
                 ? eksisterendeAktivitetForm.vurderinger.svarHarRettTilUtstyrsstipend
                 : undefined,
         },

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
@@ -78,15 +78,23 @@ export const resettAktivitet = (
 ): EndreAktivitetFormLæremidler => {
     const { fom, tom } = resetPeriode(nyType, eksisterendeAktivitetForm, søknadMottattTidspunkt);
 
+    const erUtdanningEllerTiltak =
+        nyType === AktivitetType.TILTAK || nyType === AktivitetType.UTDANNING;
+
     return {
         ...eksisterendeAktivitetForm,
         type: nyType,
         fom: fom,
         tom: tom,
-        prosent: undefined, //todo: finn ut om den skal resettes
+        studienivå: erUtdanningEllerTiltak ? eksisterendeAktivitetForm.studienivå : undefined,
+        prosent: erUtdanningEllerTiltak ? eksisterendeAktivitetForm.prosent : undefined,
         vurderinger: {
-            svarHarUtgifter: undefined,
-            svarHarRettTilUtstyrsstipend: undefined,
+            svarHarUtgifter: skalVurdereHarUtgifter(nyType)
+                ? eksisterendeAktivitetForm.vurderinger.svarHarUtgifter
+                : undefined,
+            svarHarRettTilUtstyrsstipend: erUtdanningEllerTiltak
+                ? eksisterendeAktivitetForm.vurderinger.svarHarRettTilUtstyrsstipend
+                : undefined,
         },
     };
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
@@ -69,6 +69,9 @@ function nyTomAktivitet(): EndreAktivitetFormLæremidler {
 const lagBegrunnelseForAktivitet = (aktivitetFraRegister: Registeraktivitet) =>
     `Aktivitet: ${aktivitetFraRegister.typeNavn}\nStatus: ${aktivitetFraRegister.status}`;
 
+export const erUtdanningEllerTiltak = (type: AktivitetType | '') =>
+    type === AktivitetType.UTDANNING || type === AktivitetType.TILTAK;
+
 export const skalVurdereHarUtgifter = (type: AktivitetType | '') => type === AktivitetType.TILTAK;
 
 export const resettAktivitet = (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
* Resetter felter dersom de ikke skal tas stilling til
* Skal ikke ta stilling til utstyrsstipend hvis "ingen aktivitet". Ikke noe vits å vurdere hvis brukeren ikke har aktivitet
* Har også trukket inn `erUtdanningEllerTiltak` i komponentene for å unngå at man sjekker type både utenfor komponenten, i `EndreAktivitetLæremidler` og inne i sub-komponentener

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23693

Denne mappes heller ikke i backend
`AktivitetType.INGEN_AKTIVITET -> IngenAktivitetLæremidler`

Denne endringen blir vel delvis fikset i https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23580 men får også endret sjekker