### PR TITLE
✅ Ingen steg er redigerbare i revurdering med mindre revurder fra-datoen er satt

### DIFF
--- a/src/frontend/context/StegContext.ts
+++ b/src/frontend/context/StegContext.ts
@@ -2,6 +2,7 @@ import constate from 'constate';
 
 import { FanePath, faneTilSteg } from '../Sider/Behandling/faner';
 import { Behandling } from '../typer/behandling/behandling';
+import { BehandlingType } from '../typer/behandling/behandlingType';
 
 interface Props {
     fane: FanePath | undefined;
@@ -12,7 +13,11 @@ interface Props {
 export const [StegProvider, useSteg] = constate(
     ({ fane, behandling, behandlingErRedigerbar }: Props) => {
         const erISteg = fane && behandling.steg === faneTilSteg[fane];
-        const erStegRedigerbart = erISteg && behandlingErRedigerbar;
+
+        const revurderFraDatoMangler =
+            behandling.type === BehandlingType.REVURDERING && !behandling.revurderFra;
+
+        const erStegRedigerbart = erISteg && behandlingErRedigerbar && !revurderFraDatoMangler;
 
         return {
             erStegRedigerbart,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Alle faner låses for redigering i revurderinger som ikke har satt revurder fra-dato. 

Slik ser inngangsvilkårene ut dersom revurder fra ikke er satt:
![image](https://github.com/user-attachments/assets/8440df9d-d3cc-4eef-9b27-4e86e53814cd)


Når https://github.com/navikt/tilleggsstonader-sak/pull/523 er merget vil det i tillegg komme feilmelding fra backend dersom SB forsøker å endre steg. 

![image](https://github.com/user-attachments/assets/3ec6f8d3-b401-44e5-a0ac-4d051b30055d)