### PR TITLE
✨ Skjuler neste steg-knapp dersom steget er låst for redigering

### DIFF
--- a/src/frontend/Sider/Behandling/Felles/VarselRevurderFraDatoMangler.tsx
+++ b/src/frontend/Sider/Behandling/Felles/VarselRevurderFraDatoMangler.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+
+import { Alert } from '@navikt/ds-react';
+
+import { useBehandling } from '../../../context/BehandlingContext';
+import { BehandlingType } from '../../../typer/behandling/behandlingType';
+
+export const VarselRevurderFraDatoMangler = () => {
+    const { behandling } = useBehandling();
+
+    const erRevurdering = behandling.type === BehandlingType.REVURDERING;
+    const revurderFraDatoErSatt = !!behandling.revurderFra;
+
+    if (!erRevurdering || revurderFraDatoErSatt) {
+        return null;
+    }
+
+    return (
+        <Alert variant={'warning'} size={'small'}>
+            Du må sette revurder fra-dato før du kan gjøre endringer.
+        </Alert>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -17,6 +17,7 @@ import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Stønadstype } from '../../../typer/behandling/behandlingTema';
 import { Steg } from '../../../typer/behandling/steg';
 import { FanePath } from '../faner';
+import { VarselRevurderFraDatoMangler } from '../Felles/VarselRevurderFraDatoMangler';
 import { VarselVedtakIArena } from '../Felles/VarselVedtakIArena';
 
 const Container = styled.div`
@@ -44,6 +45,7 @@ const Inngangsvilkår = () => {
     return (
         <Container>
             <VarselVedtakIArena />
+            <VarselRevurderFraDatoMangler />
 
             <DataViewer
                 response={{

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -49,31 +49,29 @@ const Stønadsvilkår = () => {
     }, [hentRegler]);
 
     return (
-        <>
-            <Container>
-                <VarselRevurderFraDatoMangler />
-                <DataViewer
-                    response={{
-                        regler,
-                        vilkårsvurdering,
-                        vilkårsoppsummering,
-                    }}
-                >
-                    {({ regler, vilkårsvurdering, vilkårsoppsummering }) => (
-                        <VilkårProvider hentetVilkårsvurdering={vilkårsvurdering}>
-                            {vilkårsoppsummering.visVarselKontantstøtte && <VarselBarnUnder2År />}
-                            <OppsummeringStønadsperioder
-                                stønadsperioder={vilkårsoppsummering.stønadsperioder}
-                            />
-                            <PassBarn vilkårsregler={regler.vilkårsregler.PASS_BARN.regler} />
-                        </VilkårProvider>
-                    )}
-                </DataViewer>
-                <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
-                    Fullfør vilkårsvurdering og gå videre
-                </StegKnapp>
-            </Container>
-        </>
+        <Container>
+            <VarselRevurderFraDatoMangler />
+            <DataViewer
+                response={{
+                    regler,
+                    vilkårsvurdering,
+                    vilkårsoppsummering,
+                }}
+            >
+                {({ regler, vilkårsvurdering, vilkårsoppsummering }) => (
+                    <VilkårProvider hentetVilkårsvurdering={vilkårsvurdering}>
+                        {vilkårsoppsummering.visVarselKontantstøtte && <VarselBarnUnder2År />}
+                        <OppsummeringStønadsperioder
+                            stønadsperioder={vilkårsoppsummering.stønadsperioder}
+                        />
+                        <PassBarn vilkårsregler={regler.vilkårsregler.PASS_BARN.regler} />
+                    </VilkårProvider>
+                )}
+            </DataViewer>
+            <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
+                Fullfør vilkårsvurdering og gå videre
+            </StegKnapp>
+        </Container>
     );
 };
 

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -17,6 +17,7 @@ import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Steg } from '../../../typer/behandling/steg';
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
 import { FanePath } from '../faner';
+import { VarselRevurderFraDatoMangler } from '../Felles/VarselRevurderFraDatoMangler';
 import { Vilkårsvurdering } from '../vilkår';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
@@ -48,28 +49,31 @@ const Stønadsvilkår = () => {
     }, [hentRegler]);
 
     return (
-        <Container>
-            <DataViewer
-                response={{
-                    regler,
-                    vilkårsvurdering,
-                    vilkårsoppsummering,
-                }}
-            >
-                {({ regler, vilkårsvurdering, vilkårsoppsummering }) => (
-                    <VilkårProvider hentetVilkårsvurdering={vilkårsvurdering}>
-                        {vilkårsoppsummering.visVarselKontantstøtte && <VarselBarnUnder2År />}
-                        <OppsummeringStønadsperioder
-                            stønadsperioder={vilkårsoppsummering.stønadsperioder}
-                        />
-                        <PassBarn vilkårsregler={regler.vilkårsregler.PASS_BARN.regler} />
-                    </VilkårProvider>
-                )}
-            </DataViewer>
-            <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
-                Fullfør vilkårsvurdering og gå videre
-            </StegKnapp>
-        </Container>
+        <>
+            <Container>
+                <VarselRevurderFraDatoMangler />
+                <DataViewer
+                    response={{
+                        regler,
+                        vilkårsvurdering,
+                        vilkårsoppsummering,
+                    }}
+                >
+                    {({ regler, vilkårsvurdering, vilkårsoppsummering }) => (
+                        <VilkårProvider hentetVilkårsvurdering={vilkårsvurdering}>
+                            {vilkårsoppsummering.visVarselKontantstøtte && <VarselBarnUnder2År />}
+                            <OppsummeringStønadsperioder
+                                stønadsperioder={vilkårsoppsummering.stønadsperioder}
+                            />
+                            <PassBarn vilkårsregler={regler.vilkårsregler.PASS_BARN.regler} />
+                        </VilkårProvider>
+                    )}
+                </DataViewer>
+                <StegKnapp steg={Steg.VILKÅR} nesteFane={FanePath.VEDTAK_OG_BEREGNING}>
+                    Fullfør vilkårsvurdering og gå videre
+                </StegKnapp>
+            </Container>
+        </>
     );
 };
 

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -27,7 +27,7 @@ export const StegKnapp: FC<{
     const navigate = useNavigateUtenSjekkForUlagredeKomponenter();
     const { request, harUlagradeKomponenter } = useApp();
 
-    const { behandling, hentBehandling } = useBehandling();
+    const { behandling, behandlingErRedigerbar, hentBehandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
     const [feilmelding, settFeilmelding] = useState<string>();
 
@@ -76,13 +76,13 @@ export const StegKnapp: FC<{
         });
     };
 
-    if (!erStegRedigerbart) {
+    if (!behandlingErRedigerbar) {
         return null;
     }
 
     return (
         <VStack align={'start'}>
-            {behandling.steg === steg && (
+            {behandling.steg === steg && erStegRedigerbart && (
                 <Button variant="primary" size="small" onClick={gåTilNesteSteg}>
                     {children}
                 </Button>

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -4,6 +4,7 @@ import { Button, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
+import { useSteg } from '../../context/StegContext';
 import { useNavigateUtenSjekkForUlagredeKomponenter } from '../../hooks/useNavigateUtenSjekkForUlagredeKomponenter';
 import { FanePath } from '../../Sider/Behandling/faner';
 import { Steg, stegErEtterAnnetSteg } from '../../typer/behandling/steg';
@@ -26,7 +27,8 @@ export const StegKnapp: FC<{
     const navigate = useNavigateUtenSjekkForUlagredeKomponenter();
     const { request, harUlagradeKomponenter } = useApp();
 
-    const { behandling, behandlingErRedigerbar, hentBehandling } = useBehandling();
+    const { behandling, hentBehandling } = useBehandling();
+    const { erStegRedigerbart } = useSteg();
     const [feilmelding, settFeilmelding] = useState<string>();
 
     useEffect(() => {
@@ -74,7 +76,7 @@ export const StegKnapp: FC<{
         });
     };
 
-    if (!behandlingErRedigerbar) {
+    if (!erStegRedigerbart) {
         return null;
     }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Et forslag som spinner ut fra https://github.com/navikt/tilleggsstonader-sak-frontend/pull/639#pullrequestreview-2502270615

Forslaget var at "Neste steg"-knappen skjules i en revurdering dersom ikke revurder fra-datoen er satt. 

![image](https://github.com/user-attachments/assets/93d921f3-07e4-408e-b5da-82ccf7290aae)
