### PR TITLE
Legg til støtte for ingen utdanning som svar på læremidelvilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
@@ -33,6 +33,6 @@ export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype
             ];
 
         case Stønadstype.LÆREMIDLER:
-            return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_AKTIVITET];
+            return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_UTDANNING];
     }
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
@@ -110,7 +110,7 @@ const resetPeriode = (
         return { fom: førsteDagIMånedTreMånederForut(søknadMottattTidspunkt), tom: dagensDato() };
     }
 
-    if (eksisterendeForm.type === AktivitetType.INGEN_AKTIVITET) {
+    if (eksisterendeForm.type === AktivitetType.INGEN_UTDANNING) {
         // Resetter datoer om de forrige var satt automatisk
         return { fom: '', tom: '' };
     }
@@ -134,6 +134,10 @@ export const finnBegrunnelseGrunnerAktivitet = (
 
     if (type === AktivitetType.INGEN_AKTIVITET) {
         delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.INGEN_AKTIVITET);
+    }
+
+    if (type === AktivitetType.INGEN_UTDANNING) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.INGEN_UTDANNING);
     }
 
     return delvilkårSomMåBegrunnes;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetLæremidler.tsx
@@ -40,7 +40,7 @@ export const validerAktivitet = (
         };
     }
 
-    if (endretAktivitet.type !== AktivitetType.INGEN_AKTIVITET) {
+    if (endretAktivitet.type !== AktivitetType.INGEN_UTDANNING) {
         if (!prosentErGyldigTall(endretAktivitet.prosent)) {
             return { ...feil, prosent: 'Prosent må være et tall mellom 1 og 100' };
         }

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/Begrunnelse/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/Begrunnelse/utils.ts
@@ -6,15 +6,14 @@ export enum BegrunnelseGrunner {
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
     INGEN_MÅLGRUPPE = 'INGEN_MÅLGRUPPE',
 
-    // Aktivitet felles
-    INGEN_AKTIVITET = 'INGEN_AKTIVITET',
-
     // Barnetilsyn
     LØNNET = 'LØNNET',
+    INGEN_AKTIVITET = 'INGEN_AKTIVITET',
 
     // Læremidler
     HAR_UTGIFTER = 'HAR_UTGIFTER',
     HAR_RETT_TIL_UTSTYRSSTIPEND = 'HAR_RETT_TIL_UTSTYRSSTIPEND',
+    INGEN_UTDANNING = 'INGEN_UTDANNING',
 }
 
 export const begrunnelseTilTekst: Record<BegrunnelseGrunner, string> = {
@@ -27,4 +26,5 @@ export const begrunnelseTilTekst: Record<BegrunnelseGrunner, string> = {
     INGEN_MÅLGRUPPE: 'Ingen målgruppe',
     HAR_UTGIFTER: 'Hvorfor bruker ikke har utgifter',
     HAR_RETT_TIL_UTSTYRSSTIPEND: 'Hvorfor bruker har rett til utstyrsstipend',
+    INGEN_UTDANNING: 'Ingen utdanning eller opplæringstiltak',
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
@@ -16,6 +16,7 @@ export enum AktivitetType {
     UTDANNING = 'UTDANNING',
     REELL_ARBEIDSSØKER = 'REELL_ARBEIDSSØKER',
     INGEN_AKTIVITET = 'INGEN_AKTIVITET',
+    INGEN_UTDANNING = 'INGEN_UTDANNING',
 }
 
 export const AktivitetTypeTilTekst: Record<AktivitetType, string> = {
@@ -23,6 +24,7 @@ export const AktivitetTypeTilTekst: Record<AktivitetType, string> = {
     UTDANNING: 'Utdanning',
     REELL_ARBEIDSSØKER: 'Reell arbeidssøker',
     INGEN_AKTIVITET: 'Ingen aktivitet',
+    INGEN_UTDANNING: 'Ingen utdanning/opplæringstiltak',
 };
 
 export type AktivitetFaktaOgVurderinger =

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler.ts
@@ -11,7 +11,7 @@ export interface AktivitetLæremidler extends VilkårPeriode {
 export type AktivitetTypeLæremidler =
     | AktivitetType.TILTAK
     | AktivitetType.UTDANNING
-    | AktivitetType.INGEN_AKTIVITET;
+    | AktivitetType.INGEN_UTDANNING;
 
 export interface AktivitetLæremidlerFaktaOgVurderinger {
     '@type': 'AKTIVITET_LÆREMIDLER';


### PR DESCRIPTION
Valgte å utvide eksisterende enum med ny aktivitet siden det var enklere for meg å lage en ny flyt enn å finne ta høyde for alle effekter ved å redigere en eksisterende flyt. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23719

![Screenshot 2024-12-17 at 15 00 32](https://github.com/user-attachments/assets/db6424a1-3e1b-4027-ae6e-c7ca6c375b04)

![Screenshot 2024-12-17 at 15 55 49](https://github.com/user-attachments/assets/ecccd217-dd8d-4daa-b08e-71a13d9878d3)

### Hvorfor er denne endringen nødvendig? ✨
