### PR TITLE
Valider vedtaksperioder før de sendes til backend

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -63,9 +63,7 @@ export const InnvilgeLæremidler: React.FC<{
         const vedtaksperiodeFeil = validerVedtaksperioder(vedtaksperioder);
         settVedtaksperiodeFeil(vedtaksperiodeFeil);
 
-        return vedtaksperiodeFeil.every(
-            (vedtaksperiode) => vedtaksperiode === undefined || isValid(vedtaksperiode)
-        );
+        return isValid(vedtaksperiodeFeil);
     };
 
     const beregnLæremidler = () => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -7,13 +7,14 @@ import { Vedtaksperioder } from './Vedtaksperioder';
 import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { useSteg } from '../../../../../context/StegContext';
+import { FormErrors, isValid } from '../../../../../hooks/felles/useFormState';
 import { useStønadsperioder } from '../../../../../hooks/useStønadsperioder';
 import DataViewer from '../../../../../komponenter/DataViewer';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
 import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
 import { Steg } from '../../../../../typer/behandling/steg';
-import { byggTomRessurs, byggHenterRessurs, RessursStatus } from '../../../../../typer/ressurs';
+import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '../../../../../typer/ressurs';
 import { TypeVedtak } from '../../../../../typer/vedtak/vedtak';
 import {
     BeregningsresultatLæremidler,
@@ -23,6 +24,7 @@ import {
 import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
 import { FanePath } from '../../../faner';
 import { StønadsperiodeListe } from '../../../Stønadsvilkår/OppsummeringStønadsperioder';
+import { validerVedtaksperioder } from '../validering';
 import { initialiserVedtaksperioder } from '../vedtakLæremidlerUtils';
 
 export const InnvilgeLæremidler: React.FC<{
@@ -42,6 +44,8 @@ export const InnvilgeLæremidler: React.FC<{
     const [beregningsresultat, settBeregningsresultat] =
         useState(byggTomRessurs<BeregningsresultatLæremidler>());
 
+    const [vedtaksperiodeFeil, settVedtaksperiodeFeil] = useState<FormErrors<Periode>[]>();
+
     const lagreVedtak = () => {
         if (beregningsresultat.status === RessursStatus.SUKSESS) {
             return request<null, InnvilgelseLæremidlerRequest>(
@@ -55,15 +59,29 @@ export const InnvilgeLæremidler: React.FC<{
         }
     };
 
+    const validerForm = (): boolean => {
+        const vedtaksperiodeFeil = validerVedtaksperioder(vedtaksperioder);
+        settVedtaksperiodeFeil(vedtaksperiodeFeil);
+
+        return vedtaksperiodeFeil.every(
+            (vedtaksperiode) => vedtaksperiode === undefined || isValid(vedtaksperiode)
+        );
+    };
+
     const beregnLæremidler = () => {
         settVisHarIkkeBeregnetFeilmelding(false);
-        settBeregningsresultat(byggHenterRessurs());
 
-        request<BeregningsresultatLæremidler, Periode[]>(
-            `/api/sak/vedtak/laremidler/${behandling.id}/beregn`,
-            'POST',
-            vedtaksperioder
-        ).then(settBeregningsresultat);
+        const kanSendeInn = validerForm();
+
+        if (kanSendeInn) {
+            settBeregningsresultat(byggHenterRessurs());
+
+            request<BeregningsresultatLæremidler, Periode[]>(
+                `/api/sak/vedtak/laremidler/${behandling.id}/beregn`,
+                'POST',
+                vedtaksperioder
+            ).then(settBeregningsresultat);
+        }
     };
 
     return (
@@ -80,6 +98,8 @@ export const InnvilgeLæremidler: React.FC<{
                 <Vedtaksperioder
                     vedtaksperioder={vedtaksperioder}
                     settVedtaksperioder={settVedtaksperioder}
+                    vedtaksperioderFeil={vedtaksperiodeFeil}
+                    settVedtaksperioderFeil={settVedtaksperiodeFeil}
                 />
                 {erStegRedigerbart && <SmallButton onClick={beregnLæremidler}>Beregn</SmallButton>}
                 <VStack gap="8">

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -7,16 +7,17 @@ import { BodyLong, Button, Heading, Label, ReadMore, VStack } from '@navikt/ds-r
 
 import { useApp } from '../../../../../context/AppContext';
 import { useSteg } from '../../../../../context/StegContext';
+import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { UlagretKomponent } from '../../../../../hooks/useUlagredeKomponenter';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
-import { PeriodeMedEndretKey } from '../../../../../utils/periode';
+import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
 import { tomVedtaksperiode } from '../vedtakLæremidlerUtils';
 
 const Grid = styled.div`
     display: grid;
     grid-template-columns: repeat(3, max-content);
     grid-gap: 0.5rem 1rem;
-    align-items: center;
+    align-items: start;
     > :nth-child(3n) {
         grid-column: 1;
     }
@@ -25,9 +26,18 @@ const Grid = styled.div`
 interface Props {
     vedtaksperioder: PeriodeMedEndretKey[];
     settVedtaksperioder: React.Dispatch<React.SetStateAction<PeriodeMedEndretKey[]>>;
+    vedtaksperioderFeil?: FormErrors<Periode>[];
+    settVedtaksperioderFeil: React.Dispatch<
+        React.SetStateAction<FormErrors<Periode>[] | undefined>
+    >;
 }
 
-export const Vedtaksperioder: React.FC<Props> = ({ vedtaksperioder, settVedtaksperioder }) => {
+export const Vedtaksperioder: React.FC<Props> = ({
+    vedtaksperioder,
+    settVedtaksperioder,
+    vedtaksperioderFeil,
+    settVedtaksperioderFeil,
+}) => {
     const { erStegRedigerbart } = useSteg();
     const { settUlagretKomponent } = useApp();
 
@@ -42,6 +52,10 @@ export const Vedtaksperioder: React.FC<Props> = ({ vedtaksperioder, settVedtaksp
             return prevState.map((periode, i) => (i === indeks ? oppdatertPeriode : periode));
         });
 
+        settVedtaksperioderFeil((prevState: FormErrors<Periode>[] | undefined) =>
+            prevState?.filter((_, i) => i !== indeks)
+        );
+
         settUlagretKomponent(UlagretKomponent.BEREGNING_INNVILGE);
     };
 
@@ -53,13 +67,11 @@ export const Vedtaksperioder: React.FC<Props> = ({ vedtaksperioder, settVedtaksp
     const slettPeriode = (indeks: number) => {
         const oppdatertePerioder = vedtaksperioder.filter((_, i) => i != indeks);
         settVedtaksperioder(oppdatertePerioder);
-        // settValideringsFeil((prevState: FormErrors<InnvilgeVedtakForm>) => {
-        //     const utgiftsperioder = (
-        //         (prevState.utgifter && prevState.utgifter[barnId]) ??
-        //         []
-        //     ).splice(utgiftIndex, 1);
-        //     return { ...prevState, utgiftsperioder };
-        // });
+
+        settVedtaksperioderFeil((prevState: FormErrors<Periode>[] | undefined) =>
+            prevState?.filter((_, i) => i !== indeks)
+        );
+
         settUlagretKomponent(UlagretKomponent.BEREGNING_INNVILGE);
     };
 
@@ -85,7 +97,7 @@ export const Vedtaksperioder: React.FC<Props> = ({ vedtaksperioder, settVedtaksp
                                 onChange={(dato?: string) =>
                                     oppdaterPeriodeFelt(indeks, 'fom', dato)
                                 }
-                                // feil={errorState && errorState[indeks]?.fom}
+                                feil={vedtaksperioderFeil && vedtaksperioderFeil[indeks]?.fom}
                                 size="small"
                             />
                             <DateInputMedLeservisning
@@ -96,7 +108,7 @@ export const Vedtaksperioder: React.FC<Props> = ({ vedtaksperioder, settVedtaksp
                                 onChange={(dato?: string) =>
                                     oppdaterPeriodeFelt(indeks, 'tom', dato)
                                 }
-                                // feil={errorState && errorState[indeks]?.tom}
+                                feil={vedtaksperioderFeil && vedtaksperioderFeil[indeks]?.tom}
                                 size="small"
                             />
                             {erStegRedigerbart ? (

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
@@ -1,4 +1,6 @@
+import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { ÅrsakAvslag, ÅrsakOpphør } from '../../../../typer/vedtak/vedtak';
+import { Periode, PeriodeMedEndretKey, validerPeriode } from '../../../../utils/periode';
 import { harIkkeVerdi } from '../../../../utils/utils';
 
 export interface FeilmeldingVedtak {
@@ -22,3 +24,6 @@ export const valider = (
 
     return feilmeldinger;
 };
+
+export const validerVedtaksperioder = (vedtaksperioder: PeriodeMedEndretKey[]) =>
+    vedtaksperioder.map((periode) => validerPeriode(periode) as FormErrors<Periode>);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å gi tydligere melding til bruker på hva som er galt.

Før: 
![Screenshot 2025-01-10 at 14 56 34](https://github.com/user-attachments/assets/86bebd40-d733-4bad-ba83-e0f1ee63886e)


Nå:
![Screenshot 2025-01-10 at 14 56 17](https://github.com/user-attachments/assets/ff1daaad-f090-425f-bf18-9624520d668f)
