### PR TITLE
Skal kunne overstyre datoet som brukes for henting av grunnlag i en førstegangsbehandling

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -6,6 +6,7 @@ import styled from 'styled-components';
 import { Alert, Button, Tabs } from '@navikt/ds-react';
 import { ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 
+import { HamburgermenyBehandling } from './Fanemeny/HamburgermenyBehandling';
 import { faneErLåst, FanePath, hentBehandlingfaner, isFanePath } from './faner';
 import SettPåVentContainer from './SettPåVent/SettPåVentContainer';
 import { useApp } from '../../context/AppContext';
@@ -113,6 +114,7 @@ const BehandlingTabsInnhold = () => {
                                 </Button>
                             </Tabsknapp>
                         )}
+                        {behandlingErRedigerbar && <HamburgermenyBehandling />}
                     </TabsList>
                 </StickyTablistContainer>
 

--- a/src/frontend/Sider/Behandling/Fanemeny/HamburgermenyBehandling.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/HamburgermenyBehandling.tsx
@@ -1,0 +1,24 @@
+import React from 'react';
+
+import { useBehandling } from '../../../context/BehandlingContext';
+import { Hamburgermeny, MenyItem } from '../../../komponenter/Hamburgermeny/Hamburgermeny';
+import { BehandlingType } from '../../../typer/behandling/behandlingType';
+import { Steg } from '../../../typer/behandling/steg';
+
+export const HamburgermenyBehandling = () => {
+    const { behandling, settVisRedigerGrunnlagFomAdmin } = useBehandling();
+
+    const items: MenyItem[] = [
+        ...(behandling.type === BehandlingType.FØRSTEGANGSBEHANDLING &&
+        behandling.steg === Steg.INNGANGSVILKÅR
+            ? [
+                  {
+                      tekst: 'Rediger dato saksopplysninger hentes fra',
+                      onClick: () => settVisRedigerGrunnlagFomAdmin(true),
+                  },
+              ]
+            : []),
+    ];
+
+    return <Hamburgermeny items={items} />;
+};

--- a/src/frontend/Sider/Behandling/Fanemeny/HamburgermenyBehandling.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/HamburgermenyBehandling.tsx
@@ -1,16 +1,21 @@
 import React from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
+
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Hamburgermeny, MenyItem } from '../../../komponenter/Hamburgermeny/Hamburgermeny';
 import { BehandlingType } from '../../../typer/behandling/behandlingType';
 import { Steg } from '../../../typer/behandling/steg';
+import { Toggle } from '../../../utils/toggles';
 
 export const HamburgermenyBehandling = () => {
-    const { behandling, settVisRedigerGrunnlagFomAdmin } = useBehandling();
+    const { behandling, settVisRedigerGrunnlagFomAdmin, behandlingErRedigerbar } = useBehandling();
+    const kanRedigereGrunnlagFom = useFlag(Toggle.KAN_REDIGERE_GRUNNLAG_FOM);
 
     const items: MenyItem[] = [
         ...(behandling.type === BehandlingType.FØRSTEGANGSBEHANDLING &&
-        behandling.steg === Steg.INNGANGSVILKÅR
+        behandling.steg === Steg.INNGANGSVILKÅR &&
+        kanRedigereGrunnlagFom
             ? [
                   {
                       tekst: 'Rediger dato saksopplysninger hentes fra',
@@ -19,6 +24,10 @@ export const HamburgermenyBehandling = () => {
               ]
             : []),
     ];
+
+    if (!behandlingErRedigerbar) {
+        return null;
+    }
 
     return <Hamburgermeny items={items} />;
 };

--- a/src/frontend/Sider/Behandling/Fanemeny/HamburgermenyBehandling.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/HamburgermenyBehandling.tsx
@@ -12,18 +12,17 @@ export const HamburgermenyBehandling = () => {
     const { behandling, settVisRedigerGrunnlagFomAdmin, behandlingErRedigerbar } = useBehandling();
     const kanRedigereGrunnlagFom = useFlag(Toggle.KAN_REDIGERE_GRUNNLAG_FOM);
 
-    const items: MenyItem[] = [
-        ...(behandling.type === BehandlingType.FØRSTEGANGSBEHANDLING &&
+    const items: MenyItem[] = [];
+    if (
+        behandling.type === BehandlingType.FØRSTEGANGSBEHANDLING &&
         behandling.steg === Steg.INNGANGSVILKÅR &&
         kanRedigereGrunnlagFom
-            ? [
-                  {
-                      tekst: 'Rediger dato saksopplysninger hentes fra',
-                      onClick: () => settVisRedigerGrunnlagFomAdmin(true),
-                  },
-              ]
-            : []),
-    ];
+    ) {
+        items.push({
+            tekst: 'Rediger dato saksopplysninger hentes fra',
+            onClick: () => settVisRedigerGrunnlagFomAdmin(true),
+        });
+    }
 
     if (!behandlingErRedigerbar) {
         return null;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteter.tsx
@@ -1,15 +1,16 @@
 import React from 'react';
 
-import { Alert, Detail, HStack, HelpText, VStack, Link } from '@navikt/ds-react';
+import { Alert, BodyShort, Detail, HelpText, HStack, Link, VStack } from '@navikt/ds-react';
 
 import RegisterAktiviteterTabell from './RegisterAktivteterTabell';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import ExpansionCard from '../../../../komponenter/ExpansionCard';
+import { Behandling } from '../../../../typer/behandling/behandling';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../../utils/dato';
 import { VilkårperioderGrunnlag } from '../typer/vilkårperiode/vilkårperiode';
 
-const RegisterAktiviteter: React.FC<{
+export const RegisterAktiviteter: React.FC<{
     grunnlag: VilkårperioderGrunnlag | undefined;
     leggTilAktivitetFraRegister: (aktivitet: Registeraktivitet) => void;
 }> = ({ grunnlag, leggTilAktivitetFraRegister }) => {
@@ -26,17 +27,17 @@ const RegisterAktiviteter: React.FC<{
     const aktiviteter = grunnlag.aktivitet.aktiviteter;
     const hentetInformasjon = grunnlag.hentetInformasjon;
 
-    const opplysningerHentetTekst = `Hentet fra Arena: ${formaterNullableIsoDatoTid(hentetInformasjon.tidspunktHentet)}`;
-
     if (aktiviteter.length === 0) {
         return (
             <Alert variant={'info'} inline size="small">
                 Vi fant ingen stønadsberettigede aktiviteteter registrert på bruker.
-                <Detail>{opplysningerHentetTekst}</Detail>
+                <Hjelpetekst
+                    behandling={behandling}
+                    tidspunktHentet={hentetInformasjon.tidspunktHentet}
+                />
             </Alert>
         );
     }
-
     return (
         <VStack>
             <ExpansionCard
@@ -48,28 +49,52 @@ const RegisterAktiviteter: React.FC<{
                         registerAktivitet={aktiviteter}
                         leggTilAktivitetFraRegister={leggTilAktivitetFraRegister}
                     />
-                    <VStack>
-                        <HStack gap="2" align="center">
-                            <Detail>
-                                <strong>{opplysningerHentetTekst}</strong>
-                            </Detail>
-                            <HelpText>
-                                Vi henter kun stønadsberettigede aktiviteter fra Arena. Du finner
-                                alle aktiviteter i{' '}
-                                <Link
-                                    href={`/person/${behandling.fagsakPersonId}/aktiviteter`}
-                                    target="_blank"
-                                    variant={'neutral'}
-                                >
-                                    personoversikten.
-                                </Link>{' '}
-                            </HelpText>
-                        </HStack>
-                    </VStack>
+                    <Hjelpetekst
+                        behandling={behandling}
+                        tidspunktHentet={hentetInformasjon.tidspunktHentet}
+                    />
                 </VStack>
             </ExpansionCard>
         </VStack>
     );
 };
+
+function Hjelpetekst({
+    behandling,
+    tidspunktHentet,
+}: {
+    behandling: Behandling;
+    tidspunktHentet: string;
+}) {
+    return (
+        <HStack gap="2" align="center">
+            <Detail>
+                <strong>Hentet fra Arena: {formaterNullableIsoDatoTid(tidspunktHentet)}</strong>
+            </Detail>
+            <HelpText>
+                <BodyShort spacing>
+                    Vi henter kun stønadsberettigede aktiviteter fra Arena. Du finner alle
+                    aktiviteter i{' '}
+                    <Link
+                        href={`/person/${behandling.fagsakPersonId}/aktiviteter`}
+                        target="_blank"
+                        variant={'neutral'}
+                    >
+                        personoversikten
+                    </Link>
+                    .
+                </BodyShort>
+                <BodyShort spacing>
+                    Datoet som brukes i en førstegangsbehandling er mottatt tidspunkt minus X
+                    måneder (3 for tilsyn barn, 6 for læremidler). I en revurdering hentes grunnlag
+                    fra og med revurder-fra datoet.
+                </BodyShort>
+                <BodyShort spacing>
+                    I en førstegangsbehandling kan man overstyre datoet man henter grunnlaget fra.
+                </BodyShort>
+            </HelpText>
+        </HStack>
+    );
+}
 
 export default RegisterAktiviteter;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -1,10 +1,11 @@
 import React from 'react';
 
-import { Alert, Detail, HelpText, HStack, Link, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, Detail, HelpText, HStack, Link, VStack } from '@navikt/ds-react';
 
 import RegisterYtelserTabell from './RegisterYtelserTabell';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import ExpansionCard from '../../../../komponenter/ExpansionCard';
+import { Behandling } from '../../../../typer/behandling/behandling';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../../utils/dato';
 import {
     VilkårperioderGrunnlag,
@@ -27,15 +28,16 @@ const RegisterYtelser: React.FC<{
     const perioderMedYtelse = grunnlag.ytelse.perioder;
     const hentetInformasjon = grunnlag.hentetInformasjon;
 
-    const opplysningerHentetTekst = `Hentet fra Arena: ${formaterNullableIsoDatoTid(hentetInformasjon.tidspunktHentet)}`;
-
     if (perioderMedYtelse.length === 0) {
         return (
             <Alert variant={'info'} inline size="small">
                 Vi finner ingen relevante ytelser registrert på bruker fra og med{' '}
                 {formaterNullableIsoDato(hentetInformasjon.fom)} til og med{' '}
                 {formaterNullableIsoDato(hentetInformasjon.tom)}
-                <Detail>{opplysningerHentetTekst}</Detail>
+                <Hjelpetekst
+                    behandling={behandling}
+                    tidspunktHentet={hentetInformasjon.tidspunktHentet}
+                />
             </Alert>
         );
     }
@@ -51,30 +53,53 @@ const RegisterYtelser: React.FC<{
                         perioderMedYtelse={perioderMedYtelse}
                         lagRadForPeriode={lagRadForPeriode}
                     />
-                    <VStack>
-                        <HStack gap="2" align="center">
-                            <Detail>
-                                <strong>{opplysningerHentetTekst}</strong>
-                            </Detail>
-                            <HelpText>
-                                Vi henter kun perioder med arbeidsavklaringspenger, rett til
-                                overgangsstønad og omstillingsstønad.{' '}
-                                <Link
-                                    href={`/person/${behandling.fagsakPersonId}/ytelser`}
-                                    target="_blank"
-                                    variant="neutral"
-                                    style={{ display: 'inline' }}
-                                >
-                                    Se flere ytelser bruker mottar
-                                </Link>{' '}
-                                i personoversikten.
-                            </HelpText>
-                        </HStack>
-                    </VStack>
+                    <Hjelpetekst
+                        behandling={behandling}
+                        tidspunktHentet={hentetInformasjon.tidspunktHentet}
+                    />
                 </VStack>
             </ExpansionCard>
         </VStack>
     );
 };
+
+function Hjelpetekst({
+    behandling,
+    tidspunktHentet,
+}: {
+    behandling: Behandling;
+    tidspunktHentet: string;
+}) {
+    return (
+        <HStack gap="2" align="center">
+            <Detail>
+                <strong>Hentet fra Arena: {formaterNullableIsoDatoTid(tidspunktHentet)}</strong>
+            </Detail>
+            <HelpText>
+                <BodyShort spacing>
+                    Vi henter kun perioder med arbeidsavklaringspenger, rett til overgangsstønad og
+                    omstillingsstønad.
+                    <Link
+                        href={`/person/${behandling.fagsakPersonId}/ytelser`}
+                        target="_blank"
+                        variant="neutral"
+                        style={{ display: 'inline' }}
+                    >
+                        Se flere ytelser bruker mottar
+                    </Link>{' '}
+                    i personoversikten.
+                </BodyShort>
+                <BodyShort spacing>
+                    Datoet som brukes i en førstegangsbehandling er mottatt tidspunkt minus X
+                    måneder (3 for tilsyn barn, 6 for læremidler). I en revurdering hentes grunnlag
+                    fra og med revurder-fra datoet.
+                </BodyShort>
+                <BodyShort spacing>
+                    I en førstegangsbehandling kan man overstyre datoet man henter grunnlaget fra.
+                </BodyShort>
+            </HelpText>
+        </HStack>
+    );
+}
 
 export default RegisterYtelser;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -26,6 +26,9 @@ const OppdaterGrunnlagKnapp: React.FC<{
     const { visRedigerGrunnlagFomAdmin, settVisRedigerGrunnlagFomAdmin } = useBehandling();
     const { erStegRedigerbart } = useSteg();
     const { oppdaterGrunnlag, laster, feilmelding } = useOppdaterGrunnlag(hentVilkårperioder);
+    const [grunnlagHenteFom, settGrunnlagHenteFom] = useState<string | undefined>(
+        vilkårperioder.grunnlag?.hentetInformasjon?.fom
+    );
 
     if (!erStegRedigerbart || !vilkårperioder.grunnlag) {
         return null;
@@ -38,7 +41,7 @@ const OppdaterGrunnlagKnapp: React.FC<{
                 icon={<ArrowsCirclepathIcon />}
                 variant={'tertiary'}
                 onClick={() => {
-                    oppdaterGrunnlag();
+                    oppdaterGrunnlag(grunnlagHenteFom);
                     settVisRedigerGrunnlagFomAdmin(false);
                 }}
                 disabled={laster}
@@ -52,10 +55,7 @@ const OppdaterGrunnlagKnapp: React.FC<{
                         label={'Dato saksopplysninger hentes fra og med'}
                         size={'small'}
                         value={vilkårperioder.grunnlag?.hentetInformasjon?.fom}
-                        onChange={(dato) => {
-                            oppdaterGrunnlag(dato);
-                            settVisRedigerGrunnlagFomAdmin(false);
-                        }}
+                        onChange={settGrunnlagHenteFom}
                     />
                 </AdminEndreHenteGrunnlagFra>
             )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
@@ -26,7 +26,7 @@ const OppdaterGrunnlagKnapp: React.FC<{
     const { visRedigerGrunnlagFomAdmin, settVisRedigerGrunnlagFomAdmin } = useBehandling();
     const { erStegRedigerbart } = useSteg();
     const { oppdaterGrunnlag, laster, feilmelding } = useOppdaterGrunnlag(hentVilkårperioder);
-    const [grunnlagHenteFom, settGrunnlagHenteFom] = useState<string | undefined>(
+    const [grunnlagHentFom, settGrunnlagHentFom] = useState<string | undefined>(
         vilkårperioder.grunnlag?.hentetInformasjon?.fom
     );
 
@@ -41,7 +41,7 @@ const OppdaterGrunnlagKnapp: React.FC<{
                 icon={<ArrowsCirclepathIcon />}
                 variant={'tertiary'}
                 onClick={() => {
-                    oppdaterGrunnlag(grunnlagHenteFom);
+                    oppdaterGrunnlag(grunnlagHentFom);
                     settVisRedigerGrunnlagFomAdmin(false);
                 }}
                 disabled={laster}
@@ -55,7 +55,7 @@ const OppdaterGrunnlagKnapp: React.FC<{
                         label={'Dato saksopplysninger hentes fra og med'}
                         size={'small'}
                         value={vilkårperioder.grunnlag?.hentetInformasjon?.fom}
-                        onChange={settGrunnlagHenteFom}
+                        onChange={settGrunnlagHentFom}
                     />
                     <Detail>
                         Trykk på Hent-knappen for å hente grunnlag fra og med valgt dato

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
@@ -3,7 +3,7 @@ import React, { useState } from 'react';
 import styled from 'styled-components';
 
 import { ArrowsCirclepathIcon } from '@navikt/aksel-icons';
-import { Alert, Button, Heading, HStack } from '@navikt/ds-react';
+import { Alert, Button, Detail, Heading, HStack } from '@navikt/ds-react';
 import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 
 import { useOppdaterGrunnlag } from './useOppdaterGrunnlag';
@@ -57,6 +57,9 @@ const OppdaterGrunnlagKnapp: React.FC<{
                         value={vilkårperioder.grunnlag?.hentetInformasjon?.fom}
                         onChange={settGrunnlagHenteFom}
                     />
+                    <Detail>
+                        Trykk på Hent-knappen for å hente grunnlag fra og med valgt dato
+                    </Detail>
                 </AdminEndreHenteGrunnlagFra>
             )}
         </>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
@@ -1,18 +1,29 @@
 import React from 'react';
 
+import styled from 'styled-components';
+
 import { ArrowsCirclepathIcon } from '@navikt/aksel-icons';
 import { Alert, Button, Heading, HStack } from '@navikt/ds-react';
+import { AGray50 } from '@navikt/ds-tokens/dist/tokens';
 
 import { useOppdaterGrunnlag } from './useOppdaterGrunnlag';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import { useSteg } from '../../../../context/StegContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import DateInput from '../../../../komponenter/Skjema/DateInput';
 import { dagerSiden } from '../../../../utils/dato';
 import { VilkårperioderResponse } from '../typer/vilkårperiode/vilkårperiode';
+
+const AdminEndreHenteGrunnlagFra = styled.div`
+    background: ${AGray50};
+    padding: 0.5rem;
+`;
 
 const OppdaterGrunnlagKnapp: React.FC<{
     vilkårperioder: VilkårperioderResponse;
     hentVilkårperioder: () => void;
 }> = ({ vilkårperioder, hentVilkårperioder }) => {
+    const { visRedigerGrunnlagFomAdmin, settVisRedigerGrunnlagFomAdmin } = useBehandling();
     const { erStegRedigerbart } = useSteg();
     const { oppdaterGrunnlag, laster, feilmelding } = useOppdaterGrunnlag(hentVilkårperioder);
 
@@ -26,12 +37,28 @@ const OppdaterGrunnlagKnapp: React.FC<{
                 size={'xsmall'}
                 icon={<ArrowsCirclepathIcon />}
                 variant={'tertiary'}
-                onClick={oppdaterGrunnlag}
+                onClick={() => {
+                    oppdaterGrunnlag();
+                    settVisRedigerGrunnlagFomAdmin(false);
+                }}
                 disabled={laster}
             >
                 {tekst}
             </Button>
             <Feilmelding size={'small'}>{feilmelding}</Feilmelding>
+            {visRedigerGrunnlagFomAdmin && (
+                <AdminEndreHenteGrunnlagFra>
+                    <DateInput
+                        label={'Dato saksopplysninger hentes fra og med'}
+                        size={'small'}
+                        value={vilkårperioder.grunnlag?.hentetInformasjon?.fom}
+                        onChange={(dato) => {
+                            oppdaterGrunnlag(dato);
+                            settVisRedigerGrunnlagFomAdmin(false);
+                        }}
+                    />
+                </AdminEndreHenteGrunnlagFra>
+            )}
         </>
     );
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
@@ -17,17 +17,17 @@ export const useOppdaterGrunnlag = (hentVilkårperioder: () => void): OppdaterGr
     const [laster, settLaster] = useState(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const oppdaterGrunnlag = (henteFom?: string) => {
+    const oppdaterGrunnlag = (hentFom?: string) => {
         if (laster) {
             return;
         }
         settFeilmelding(undefined);
         settLaster(true);
-        request<null, { henteFom: string | undefined }>(
+        request<null, { hentFom: string | undefined }>(
             `/api/sak/vilkarperiode/behandling/${behandling.id}/oppdater-grunnlag`,
             'POST',
             {
-                henteFom,
+                hentFom,
             }
         )
             .then((response) => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
@@ -6,7 +6,7 @@ import { RessursStatus } from '../../../../typer/ressurs';
 import { Toast } from '../../../../typer/toast';
 
 interface OppdaterGrunnlag {
-    oppdaterGrunnlag: () => void;
+    oppdaterGrunnlag: (henteFom?: string) => void;
     laster: boolean;
     feilmelding: string | undefined;
 }
@@ -17,15 +17,18 @@ export const useOppdaterGrunnlag = (hentVilkårperioder: () => void): OppdaterGr
     const [laster, settLaster] = useState(false);
     const [feilmelding, settFeilmelding] = useState<string>();
 
-    const oppdaterGrunnlag = () => {
+    const oppdaterGrunnlag = (henteFom?: string) => {
         if (laster) {
             return;
         }
         settFeilmelding(undefined);
         settLaster(true);
-        request<null, null>(
+        request<null, { henteFom: string | undefined }>(
             `/api/sak/vilkarperiode/behandling/${behandling.id}/oppdater-grunnlag`,
-            'POST'
+            'POST',
+            {
+                henteFom,
+            }
         )
             .then((response) => {
                 if (response.status === RessursStatus.SUKSESS) {

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -1,3 +1,5 @@
+import React, { useState } from 'react';
+
 import { useFlag } from '@unleash/proxy-client-react';
 import constate from 'constate';
 
@@ -28,6 +30,9 @@ interface BehandlingContext {
     behandlingFakta: BehandlingFakta;
     toggleKanSaksbehandle: boolean;
     kanSetteBehandlingPåVent: boolean;
+
+    visRedigerGrunnlagFomAdmin: boolean;
+    settVisRedigerGrunnlagFomAdmin: React.Dispatch<React.SetStateAction<boolean>>;
 }
 
 const useKanSaksbehandle = (stønadstype: Stønadstype) => {
@@ -58,6 +63,9 @@ export const [BehandlingProvider, useBehandling] = constate(
     ({ behandling, hentBehandling, behandlingFakta }: Props): BehandlingContext => {
         const { erSaksbehandler } = useApp();
 
+        const [visRedigerGrunnlagFomAdmin, settVisRedigerGrunnlagFomAdmin] =
+            useState<boolean>(false);
+
         const kanSaksbehandle = useKanSaksbehandle(behandling.stønadstype);
         const kanRevurdere = useKanRevurdere(behandling.stønadstype);
 
@@ -74,6 +82,8 @@ export const [BehandlingProvider, useBehandling] = constate(
             behandlingFakta,
             toggleKanSaksbehandle: toggleKanSaksbehandleEllerRevurdere,
             kanSetteBehandlingPåVent: behandlingErRedigerbar,
+            visRedigerGrunnlagFomAdmin,
+            settVisRedigerGrunnlagFomAdmin,
         };
     }
 );

--- a/src/frontend/komponenter/Hamburgermeny/Hamburgermeny.tsx
+++ b/src/frontend/komponenter/Hamburgermeny/Hamburgermeny.tsx
@@ -104,6 +104,7 @@ export const Hamburgermeny: FC<Props> = ({ className, items }) => {
             />
             <HamburgerMenyInnhold $åpen={åpenHamburgerMeny}>
                 <ul>
+                    {items.length === 0 && <li>Ingen valg</li>}
                     {items.map((p) => (
                         <li key={p.tekst}>
                             <Knapp

--- a/src/frontend/komponenter/Hamburgermeny/Hamburgermeny.tsx
+++ b/src/frontend/komponenter/Hamburgermeny/Hamburgermeny.tsx
@@ -23,7 +23,7 @@ const HamburgerWrapper = styled.div`
 const HamburgerMenyInnhold = styled.div<HamburgerMenyInnholdProps>`
     display: ${(props) => (props.$åpen ? 'block' : 'none')};
 
-    position: absolute;
+    position: fixed;
 
     background-color: white;
 

--- a/src/frontend/komponenter/Hamburgermeny/Hamburgermeny.tsx
+++ b/src/frontend/komponenter/Hamburgermeny/Hamburgermeny.tsx
@@ -51,7 +51,6 @@ const HamburgerMenyInnhold = styled.div<HamburgerMenyInnholdProps>`
 
     li:hover {
         background-color: #0166c5;
-        color: white;
         cursor: pointer;
     }
 `;

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -10,4 +10,6 @@ export enum Toggle {
      */
     BEHANDLING_ÅRSAK_UTEN_BREV = 'sak.behandling-arsak-uten-brev',
     ADMIN_KAN_OPPRETTE_BEHANDLING = 'sak.admin-kan-opprette-behandling',
+
+    KAN_REDIGERE_GRUNNLAG_FOM = 'sak.frontend.kan-redigere-grunnlag-fom',
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å kunne overstyre dato vedlegg hentes fra i en førstegangsbehandling då vi skal innvilge noen behandlinger fra og med 2020.
For revurdering brukes revurder-fra datoet.

Ikke peneste hamburgermenyn, er kopi fra klage. Men den virker. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23910

Koblet til
* https://github.com/navikt/tilleggsstonader-sak/commit/0162a42c1d65c56853c116497f62170fc996f545


https://github.com/user-attachments/assets/079cf69c-6be3-4dfe-835e-52685dbcc99d



