### PR TITLE
🐛 Ikke send med hent fra for revurdering

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
@@ -26,9 +26,7 @@ const OppdaterGrunnlagKnapp: React.FC<{
     const { visRedigerGrunnlagFomAdmin, settVisRedigerGrunnlagFomAdmin } = useBehandling();
     const { erStegRedigerbart } = useSteg();
     const { oppdaterGrunnlag, laster, feilmelding } = useOppdaterGrunnlag(hentVilkårperioder);
-    const [grunnlagHentFom, settGrunnlagHentFom] = useState<string | undefined>(
-        vilkårperioder.grunnlag?.hentetInformasjon?.fom
-    );
+    const [grunnlagHentFom, settGrunnlagHentFom] = useState<string | undefined>();
 
     if (!erStegRedigerbart || !vilkårperioder.grunnlag) {
         return null;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Denne er allerede satt i backend til å være revurderFra datoen. Hent fra feltet skal kun brukes når man skal hente grunnlag lengere tilbake i tid i en førstegangsbehandling. 

