### PR TITLE
Låsing av vedtaksperioder i innvilgelse i en revurdering av læremidler

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -4,6 +4,7 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
+import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
 
@@ -13,6 +14,7 @@ interface Props {
     vedtaksperiodeFeil: FormErrors<Periode> | undefined;
     oppdaterPeriode: (property: 'fom' | 'tom', value: string | undefined) => void;
     slettPeriode: () => void;
+    erNyRad: boolean;
 }
 
 export const VedtaksperiodeRad: React.FC<Props> = ({
@@ -21,13 +23,21 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
     vedtaksperiodeFeil,
     oppdaterPeriode,
     slettPeriode,
+    erNyRad,
 }) => {
+    const { alleFelterKanEndres, helePeriodenErLåstForEndring } = useRevurderingAvPerioder({
+        periodeFom: vedtaksperiode.fom,
+        periodeTom: vedtaksperiode.tom,
+        nyRadLeggesTil: erNyRad,
+    });
+
     return (
         <>
             <DateInputMedLeservisning
                 label="Fra"
                 hideLabel
                 erLesevisning={erLesevisning}
+                readOnly={!alleFelterKanEndres}
                 value={vedtaksperiode.fom}
                 onChange={(dato?: string) => oppdaterPeriode('fom', dato)}
                 feil={vedtaksperiodeFeil?.fom}
@@ -37,6 +47,7 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
                 label="Til"
                 hideLabel
                 erLesevisning={erLesevisning}
+                readOnly={helePeriodenErLåstForEndring}
                 value={vedtaksperiode.tom}
                 onChange={(dato?: string) => oppdaterPeriode('tom', dato)}
                 feil={vedtaksperiodeFeil?.tom}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { TrashIcon } from '@navikt/aksel-icons';
+import { Button } from '@navikt/ds-react';
+
+import { FormErrors } from '../../../../../hooks/felles/useFormState';
+import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
+import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
+
+interface Props {
+    vedtaksperiode: PeriodeMedEndretKey;
+    erLesevisning: boolean;
+    vedtaksperiodeFeil: FormErrors<Periode> | undefined;
+    oppdaterPeriode: (property: 'fom' | 'tom', value: string | undefined) => void;
+    slettPeriode: () => void;
+}
+
+export const VedtaksperiodeRad: React.FC<Props> = ({
+    vedtaksperiode,
+    erLesevisning,
+    vedtaksperiodeFeil,
+    oppdaterPeriode,
+    slettPeriode,
+}) => {
+    return (
+        <>
+            <DateInputMedLeservisning
+                label="Fra"
+                hideLabel
+                erLesevisning={erLesevisning}
+                value={vedtaksperiode.fom}
+                onChange={(dato?: string) => oppdaterPeriode('fom', dato)}
+                feil={vedtaksperiodeFeil?.fom}
+                size="small"
+            />
+            <DateInputMedLeservisning
+                label="Til"
+                hideLabel
+                erLesevisning={erLesevisning}
+                value={vedtaksperiode.tom}
+                onChange={(dato?: string) => oppdaterPeriode('tom', dato)}
+                feil={vedtaksperiodeFeil?.tom}
+                size="small"
+            />
+            {!erLesevisning ? (
+                <Button
+                    variant="tertiary"
+                    onClick={() => slettPeriode()}
+                    icon={<TrashIcon />}
+                    size="xsmall"
+                />
+            ) : (
+                <div />
+            )}
+        </>
+    );
+};

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -25,11 +25,12 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
     slettPeriode,
     erNyRad,
 }) => {
-    const { alleFelterKanEndres, helePeriodenErLåstForEndring } = useRevurderingAvPerioder({
-        periodeFom: vedtaksperiode.fom,
-        periodeTom: vedtaksperiode.tom,
-        nyRadLeggesTil: erNyRad,
-    });
+    const { alleFelterKanEndres, helePeriodenErLåstForEndring, kanSlettePeriode } =
+        useRevurderingAvPerioder({
+            periodeFom: vedtaksperiode.fom,
+            periodeTom: vedtaksperiode.tom,
+            nyRadLeggesTil: erNyRad,
+        });
 
     return (
         <>
@@ -53,7 +54,7 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
                 feil={vedtaksperiodeFeil?.tom}
                 size="small"
             />
-            {!erLesevisning ? (
+            {kanSlettePeriode ? (
                 <Button
                     variant="tertiary"
                     onClick={() => slettPeriode()}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -2,16 +2,16 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { PlusCircleIcon, TrashIcon } from '@navikt/aksel-icons';
+import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { BodyLong, Button, Heading, Label, ReadMore, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../../../context/AppContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { UlagretKomponent } from '../../../../../hooks/useUlagredeKomponenter';
-import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
 import { tomVedtaksperiode } from '../vedtakLæremidlerUtils';
+import { VedtaksperiodeRad } from './VedtaksperiodeRad';
 
 const Grid = styled.div`
     display: grid;
@@ -88,40 +88,16 @@ export const Vedtaksperioder: React.FC<Props> = ({
                     <Label size="small">Fra og med</Label>
                     <Label size="small">Til og med</Label>
                     {vedtaksperioder.map((vedtaksperiode, indeks) => (
-                        <React.Fragment key={vedtaksperiode.endretKey}>
-                            <DateInputMedLeservisning
-                                label="Fra"
-                                hideLabel
-                                erLesevisning={!erStegRedigerbart}
-                                value={vedtaksperiode.fom}
-                                onChange={(dato?: string) =>
-                                    oppdaterPeriodeFelt(indeks, 'fom', dato)
-                                }
-                                feil={vedtaksperioderFeil && vedtaksperioderFeil[indeks]?.fom}
-                                size="small"
-                            />
-                            <DateInputMedLeservisning
-                                label="Til"
-                                hideLabel
-                                erLesevisning={!erStegRedigerbart}
-                                value={vedtaksperiode.tom}
-                                onChange={(dato?: string) =>
-                                    oppdaterPeriodeFelt(indeks, 'tom', dato)
-                                }
-                                feil={vedtaksperioderFeil && vedtaksperioderFeil[indeks]?.tom}
-                                size="small"
-                            />
-                            {erStegRedigerbart ? (
-                                <Button
-                                    variant="tertiary"
-                                    onClick={() => slettPeriode(indeks)}
-                                    icon={<TrashIcon />}
-                                    size="xsmall"
-                                />
-                            ) : (
-                                <div />
-                            )}
-                        </React.Fragment>
+                        <VedtaksperiodeRad
+                            key={vedtaksperiode.endretKey}
+                            vedtaksperiode={vedtaksperiode}
+                            erLesevisning={!erStegRedigerbart}
+                            oppdaterPeriode={(property, value) => {
+                                oppdaterPeriodeFelt(indeks, property, value);
+                            }}
+                            slettPeriode={() => slettPeriode(indeks)}
+                            vedtaksperiodeFeil={vedtaksperioderFeil && vedtaksperioderFeil[indeks]}
+                        />
                     ))}
                 </Grid>
             )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -41,6 +41,8 @@ export const Vedtaksperioder: React.FC<Props> = ({
     const { erStegRedigerbart } = useSteg();
     const { settUlagretKomponent } = useApp();
 
+    const [endretKeyNyeRader, settEndretKeyNyeRader] = useState<Set<string>>(new Set());
+
     const oppdaterPeriodeFelt = (
         indeks: number,
         property: 'fom' | 'tom',
@@ -60,7 +62,9 @@ export const Vedtaksperioder: React.FC<Props> = ({
     };
 
     const leggTilPeriode = () => {
-        settVedtaksperioder([...vedtaksperioder, tomVedtaksperiode()]);
+        const nyVedtaksperiode = tomVedtaksperiode();
+        settEndretKeyNyeRader((prevState) => new Set([...prevState, nyVedtaksperiode.endretKey]));
+        settVedtaksperioder([...vedtaksperioder, nyVedtaksperiode]);
         settUlagretKomponent(UlagretKomponent.BEREGNING_INNVILGE);
     };
 
@@ -97,6 +101,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                             }}
                             slettPeriode={() => slettPeriode(indeks)}
                             vedtaksperiodeFeil={vedtaksperioderFeil && vedtaksperioderFeil[indeks]}
+                            erNyRad={endretKeyNyeRader.has(vedtaksperiode.endretKey)}
                         />
                     ))}
                 </Grid>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I en revurdering skal vi låse tidligere vedtaksperioder som man ikke skal kunne endre. 
På lik måte som andre perioder som blir låste.

![image](https://github.com/user-attachments/assets/5cf6fff7-2f33-443f-b6a4-953d96d6567d)

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a

Kan være fint å sjekke commit for commit. Første commit er oppsplitting av renderingen av hver rad for å sen kunne legge til `useRevurderingAvPerioder`
