### PR TITLE
Læremidler revurdering vis perioder forrige behandling

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -29,7 +29,8 @@ import { initialiserVedtaksperioder } from '../vedtakLæremidlerUtils';
 
 export const InnvilgeLæremidler: React.FC<{
     lagretVedtak: InnvilgelseLæremidler | undefined;
-}> = ({ lagretVedtak }) => {
+    vedtaksperioderForrigeBehandling: Periode[] | undefined;
+}> = ({ lagretVedtak, vedtaksperioderForrigeBehandling }) => {
     const { request } = useApp();
     const { behandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
@@ -37,7 +38,9 @@ export const InnvilgeLæremidler: React.FC<{
     const { stønadsperioder } = useStønadsperioder(behandling.id);
 
     const [vedtaksperioder, settVedtaksperioder] = useState<PeriodeMedEndretKey[]>(
-        initialiserVedtaksperioder(lagretVedtak)
+        initialiserVedtaksperioder(
+            lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling
+        )
     );
     const [visHarIkkeBeregnetFeilmelding, settVisHarIkkeBeregnetFeilmelding] = useState<boolean>();
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
@@ -1,0 +1,77 @@
+import React, { useEffect } from 'react';
+
+import { InnvilgeLæremidler } from './InnvilgeLæremidler';
+import { useBehandling } from '../../../../../context/BehandlingContext';
+import { useSteg } from '../../../../../context/StegContext';
+import { useVedtakForrigeBehandling } from '../../../../../hooks/useVedtak';
+import DataViewer from '../../../../../komponenter/DataViewer';
+import { Stønadstype } from '../../../../../typer/behandling/behandlingTema';
+import { TypeVedtak } from '../../../../../typer/vedtak/vedtak';
+import {
+    InnvilgelseLæremidler,
+    VedtakLæremidler,
+} from '../../../../../typer/vedtak/vedtakLæremidler';
+import { Periode } from '../../../../../utils/periode';
+
+export const InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling: React.FC<{
+    lagretVedtak: InnvilgelseLæremidler | undefined;
+}> = ({ lagretVedtak }) => {
+    const { erStegRedigerbart } = useSteg();
+    const { behandling } = useBehandling();
+
+    if (lagretVedtak || !erStegRedigerbart || !behandling.forrigeBehandlingId) {
+        return (
+            <InnvilgeLæremidler
+                lagretVedtak={lagretVedtak}
+                vedtaksperioderForrigeBehandling={undefined}
+            />
+        );
+    } else {
+        return (
+            <InnvilgeLæremidlerMedPerioderFraForrigeBehandling
+                stønadstype={behandling.stønadstype}
+                forrigeBehandlingId={behandling.forrigeBehandlingId}
+            />
+        );
+    }
+};
+
+const InnvilgeLæremidlerMedPerioderFraForrigeBehandling = ({
+    stønadstype,
+    forrigeBehandlingId,
+}: {
+    stønadstype: Stønadstype;
+    forrigeBehandlingId: string;
+}) => {
+    const { forrigeVedtak, hentForrigeVedtak } = useVedtakForrigeBehandling<VedtakLæremidler>();
+
+    useEffect(() => {
+        hentForrigeVedtak(stønadstype, forrigeBehandlingId);
+    }, [hentForrigeVedtak, forrigeBehandlingId, stønadstype]);
+
+    return (
+        <DataViewer response={{ forrigeVedtak }}>
+            {({ forrigeVedtak }) => {
+                return (
+                    <InnvilgeLæremidler
+                        lagretVedtak={undefined}
+                        vedtaksperioderForrigeBehandling={vedtaksperioderForrigeVedtak(
+                            forrigeVedtak
+                        )}
+                    />
+                );
+            }}
+        </DataViewer>
+    );
+};
+
+const vedtaksperioderForrigeVedtak = (vedtak: VedtakLæremidler): Periode[] | undefined => {
+    switch (vedtak.type) {
+        case TypeVedtak.INNVILGELSE:
+            return vedtak.vedtaksperioder;
+        case TypeVedtak.OPPHØR:
+            return undefined; // TODO legg till når opphør inneholder vedtaksperioder?
+        case TypeVedtak.AVSLAG:
+            return undefined;
+    }
+};

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
@@ -60,7 +60,10 @@ const VedtakOgBeregningLæremidler: FC = () => {
                     </Panel>
 
                     {typeVedtak === TypeVedtak.INNVILGELSE && (
-                        <InnvilgeLæremidler lagretVedtak={vedtak as InnvilgelseLæremidler} />
+                        <InnvilgeLæremidler
+                            lagretVedtak={vedtak as InnvilgelseLæremidler}
+                            vedtaksperioderForrigeBehandling={undefined}
+                        />
                     )}
                 </Container>
             )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
@@ -17,8 +17,8 @@ import {
     VedtakLæremidler,
 } from '../../../../typer/vedtak/vedtakLæremidler';
 import VelgVedtakResultat from '../Felles/VelgVedtakResultat';
-import { InnvilgeLæremidler } from './InnvilgeVedtak/InnvilgeLæremidler';
 import OpphørVedtak from '../Læremidler/OpphørVedtak';
+import { InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling } from './InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling';
 
 const Container = styled.div`
     padding: 2rem 2rem;
@@ -60,9 +60,8 @@ const VedtakOgBeregningLæremidler: FC = () => {
                     </Panel>
 
                     {typeVedtak === TypeVedtak.INNVILGELSE && (
-                        <InnvilgeLæremidler
+                        <InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling
                             lagretVedtak={vedtak as InnvilgelseLæremidler}
-                            vedtaksperioderForrigeBehandling={undefined}
                         />
                     )}
                 </Container>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
@@ -1,13 +1,11 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { InnvilgelseLæremidler } from '../../../../typer/vedtak/vedtakLæremidler';
-import { tilPeriodeMedEndretKey, PeriodeMedEndretKey } from '../../../../utils/periode';
+import { tilPeriodeMedEndretKey, PeriodeMedEndretKey, Periode } from '../../../../utils/periode';
 
 export const initialiserVedtaksperioder = (
-    vedtak: InnvilgelseLæremidler | undefined
+    vedtaksperioder: Periode[] | undefined
 ): PeriodeMedEndretKey[] => {
-    const perioderMedEndretKey =
-        vedtak?.vedtaksperioder && tilPeriodeMedEndretKey(vedtak?.vedtaksperioder);
+    const perioderMedEndretKey = vedtaksperioder && tilPeriodeMedEndretKey(vedtaksperioder);
 
     return perioderMedEndretKey ?? [tomVedtaksperiode()];
 };

--- a/src/frontend/hooks/useVedtak.ts
+++ b/src/frontend/hooks/useVedtak.ts
@@ -7,7 +7,7 @@ import { Ressurs, byggTomRessurs } from '../typer/ressurs';
 import { VedtakResponse } from '../typer/vedtak/vedtak';
 
 interface Response<T extends VedtakResponse> {
-    hentVedtak: (behandlingId: string) => void;
+    hentVedtak: () => void;
     vedtak: Ressurs<T>;
 }
 
@@ -35,5 +35,28 @@ export const useVedtak = <T extends VedtakResponse>(): Response<T> => {
     return {
         hentVedtak,
         vedtak,
+    };
+};
+
+export const useVedtakForrigeBehandling = <T extends VedtakResponse>(): {
+    forrigeVedtak: Ressurs<T>;
+    hentForrigeVedtak: (stønadstype: Stønadstype, forrigeBehandlingId: string) => void;
+} => {
+    const { request } = useApp();
+
+    const [forrigeVedtak, settForrigeVedtak] = useState<Ressurs<T>>(byggTomRessurs());
+
+    const hentForrigeVedtak = useCallback(
+        (stønadstype: Stønadstype, forrigeBehandlingId: string) => {
+            request<T, null>(
+                `/api/sak/vedtak/${stønadstypeTilVedtakUrl[stønadstype]}/${forrigeBehandlingId}`
+            ).then(settForrigeVedtak);
+        },
+        [request]
+    );
+
+    return {
+        hentForrigeVedtak,
+        forrigeVedtak,
     };
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Når man skal innvilge en revurdering og forrige behandling er innvilgelse eller opphør trenger vi å vise vedtaksperiodene fra forrige behandling, og at de som er før revurder fra blir låste.

Fortsettelse på 
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/673

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23758