### PR TITLE
Brev validering valgfelt

### DIFF
--- a/src/frontend/context/BrevFeilContext.ts
+++ b/src/frontend/context/BrevFeilContext.ts
@@ -111,10 +111,46 @@ export const [BrevFeilContextProvider, useBrevFeilContext] = constate(() => {
     const manglerVerdi = (delmalId: string, komponentId: string) =>
         manglerPerDelmal[delmalId]?.has(komponentId);
 
+    const nullstillValgfelt = (delmalId: string, komponentId: string) => {
+        settManglendeValgfelt((prevState) =>
+            prevState
+                .map((feil) => {
+                    if (feil.delmalId === delmalId) {
+                        return {
+                            ...feil,
+                            mangler: feil.mangler.filter((mangel) => mangel._id !== komponentId),
+                        };
+                    } else {
+                        return feil;
+                    }
+                })
+                .filter((feil) => feil.mangler.length > 0)
+        );
+    };
+
+    const nullstillVariabel = (delmalId: string, komponentId: string) => {
+        settManglendeBrevVariabler((prevState) =>
+            prevState
+                .map((feil) => {
+                    if (feil.delmalId === delmalId) {
+                        return {
+                            ...feil,
+                            mangler: feil.mangler.filter((mangel) => mangel._id !== komponentId),
+                        };
+                    } else {
+                        return feil;
+                    }
+                })
+                .filter((feil) => feil.mangler.length > 0)
+        );
+    };
+
     return {
         manglendeBrevVariabler,
         manglendeValgfelt,
         oppdaterMangelIBrev,
         manglerVerdi,
+        nullstillValgfelt,
+        nullstillVariabel,
     };
 });

--- a/src/frontend/context/BrevFeilContext.ts
+++ b/src/frontend/context/BrevFeilContext.ts
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import constate from 'constate';
 
@@ -91,9 +91,30 @@ export const [BrevFeilContextProvider, useBrevFeilContext] = constate(() => {
             : 'HAR_IKKE_MANGEL';
     };
 
+    /**
+     * Grupperer mangler per delmal for å enklere kunne sjekke om en komponent i en delmal har mangel
+     */
+    const manglerPerDelmal = useMemo(() => {
+        return [...manglendeValgfelt, ...manglendeBrevVariabler].reduce(
+            (prev, current) => {
+                const previousValues = prev[current.delmalId] ?? [];
+                prev[current.delmalId] = new Set([
+                    ...previousValues,
+                    ...current.mangler.map((mangel) => mangel._id),
+                ]);
+                return prev;
+            },
+            {} as Record<string, Set<string>>
+        );
+    }, [manglendeValgfelt, manglendeBrevVariabler]);
+
+    const manglerVerdi = (delmalId: string, komponentId: string) =>
+        manglerPerDelmal[delmalId]?.has(komponentId);
+
     return {
         manglendeBrevVariabler,
         manglendeValgfelt,
         oppdaterMangelIBrev,
+        manglerVerdi,
     };
 });

--- a/src/frontend/context/BrevFeilContext.ts
+++ b/src/frontend/context/BrevFeilContext.ts
@@ -145,6 +145,15 @@ export const [BrevFeilContextProvider, useBrevFeilContext] = constate(() => {
         );
     };
 
+    const nullstillDelmal = (delmalId: string) => {
+        settManglendeBrevVariabler((prevState) =>
+            prevState.filter((feil) => feil.delmalId !== delmalId)
+        );
+        settManglendeBrevVariabler((prevState) =>
+            prevState.filter((feil) => feil.delmalId !== delmalId)
+        );
+    };
+
     return {
         manglendeBrevVariabler,
         manglendeValgfelt,
@@ -152,5 +161,6 @@ export const [BrevFeilContextProvider, useBrevFeilContext] = constate(() => {
         manglerVerdi,
         nullstillValgfelt,
         nullstillVariabel,
+        nullstillDelmal,
     };
 });

--- a/src/frontend/context/BrevFeilContext.ts
+++ b/src/frontend/context/BrevFeilContext.ts
@@ -39,7 +39,7 @@ export const [BrevFeilContextProvider, useBrevFeilContext] = constate(() => {
         });
     };
 
-    const oppdaterManglendeBrevVariabler = (
+    const oppdaterMangelIBrev = (
         mal: MalStruktur,
         inkluderteDelmaler: Record<string, boolean>,
         valgfelt: Partial<Record<string, Record<Valgfelt['_id'], Valg>>>,
@@ -53,6 +53,6 @@ export const [BrevFeilContextProvider, useBrevFeilContext] = constate(() => {
 
     return {
         manglendeBrevVariabler,
-        oppdaterManglendeBrevVariabler,
+        oppdaterMangelIBrev,
     };
 });

--- a/src/frontend/context/BrevFeilContext.ts
+++ b/src/frontend/context/BrevFeilContext.ts
@@ -12,45 +12,63 @@ import { harIkkeVerdi } from '../utils/utils';
  */
 const htmlVariabler = new Set([variabelBeregningstabellId]);
 
+export type FeilIDelmalType = Variabel | Valgfelt;
+
+export interface FeilIDelmal<T extends FeilIDelmalType> {
+    delmalId: string;
+    mangler: T[];
+}
+
 export const [BrevFeilContextProvider, useBrevFeilContext] = constate(() => {
-    const [manglendeBrevVariabler, settManglendeBrevVariabler] = useState<Variabel[]>([]);
-    const [manglendeValgfelt, settManglendeValgfelt] = useState<Valgfelt[]>([]);
+    const [manglendeBrevVariabler, settManglendeBrevVariabler] = useState<FeilIDelmal<Variabel>[]>(
+        []
+    );
+    const [manglendeValgfelt, settManglendeValgfelt] = useState<FeilIDelmal<Valgfelt>[]>([]);
 
     const finnManglendeBrevVariabler = (
         delmaler: Delmal[],
         valgfelt: Partial<Record<string, Record<Valgfelt['_id'], Valg>>>,
         variabler: Partial<Record<string, string>>
-    ): Variabel[] => {
-        return delmaler.flatMap((delmal) => {
-            const valgForDelmal = Object.values(valgfelt[delmal._id] ?? {});
+    ): FeilIDelmal<Variabel>[] => {
+        return delmaler
+            .flatMap((delmal) => {
+                const valgForDelmal = Object.values(valgfelt[delmal._id] ?? {});
 
-            const variablerIValg = valgForDelmal
-                .filter((valg) => valg._type === 'tekst')
-                .flatMap((valg) => valg.variabler);
+                const variablerIValg = valgForDelmal
+                    .filter((valg) => valg._type === 'tekst')
+                    .flatMap((valg) => valg.variabler);
 
-            const variablerIDelmal = delmal.blocks
-                .filter((block) => block._type === 'block')
-                .flatMap((block) => block.markDefs)
-                .filter((mark) => mark._type === 'variabel')
-                .filter((mark) => !htmlVariabler.has(mark._id));
+                const variablerIDelmal = delmal.blocks
+                    .filter((block) => block._type === 'block')
+                    .flatMap((block) => block.markDefs)
+                    .filter((mark) => mark._type === 'variabel')
+                    .filter((mark) => !htmlVariabler.has(mark._id));
 
-            return [...variablerIValg, ...variablerIDelmal].filter((variabel) =>
-                harIkkeVerdi(variabler[variabel._id])
-            );
-        });
+                const alleManglerIDelmal = [...variablerIValg, ...variablerIDelmal].filter(
+                    (variabel) => harIkkeVerdi(variabler[variabel._id])
+                );
+                return { delmalId: delmal._id, mangler: alleManglerIDelmal };
+            })
+            .filter((feil) => feil.mangler.length > 0);
     };
 
     const finnManglendeValgfelt = (
         delmaler: Delmal[],
         valgfelt: Partial<Record<string, Record<Valgfelt['_id'], Valg>>>
-    ): Valgfelt[] => {
-        return delmaler.flatMap((delmal) => {
-            const valgfeltForDelmal = valgfelt[delmal._id] ?? {};
-            return delmal.blocks
-                .filter((block) => block._type === 'valgfelt')
-                .filter((block) => block.erPakrevd)
-                .filter((valg) => !valgfeltForDelmal[valg._id]);
-        });
+    ): FeilIDelmal<Valgfelt>[] => {
+        return delmaler
+            .flatMap((delmal) => {
+                const valgfeltForDelmal = valgfelt[delmal._id] ?? {};
+                const mangler = delmal.blocks
+                    .filter((block) => block._type === 'valgfelt')
+                    .filter((block) => block.erPakrevd)
+                    .filter((valg) => !valgfeltForDelmal[valg._id]);
+                return {
+                    delmalId: delmal._id,
+                    mangler: mangler,
+                };
+            })
+            .filter((feil) => feil.mangler.length > 0);
     };
 
     const oppdaterMangelIBrev = (

--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -33,17 +33,12 @@ export const Brevknapp = ({
 }: Props) => {
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
-    const { oppdaterManglendeBrevVariabler } = useBrevFeilContext();
+    const { oppdaterMangelIBrev } = useBrevFeilContext();
 
     const trykkPåKnapp = () => {
         settFeilmelding(undefined);
 
-        const harMangelResultat = oppdaterManglendeBrevVariabler(
-            mal,
-            inkluderteDelmaler,
-            valgfelt,
-            variabler
-        );
+        const harMangelResultat = oppdaterMangelIBrev(mal, inkluderteDelmaler, valgfelt, variabler);
 
         if (harMangelResultat === 'HAR_MANGEL') {
             settFeilmelding('Kan ikke gå videre, følgende felter mangler fra brev:');

--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { BodyShort, Button, List, VStack } from '@navikt/ds-react';
 
-import { MalStruktur, Valg, Valgfelt, Variabel } from './typer';
+import { MalStruktur, Valg, Valgfelt } from './typer';
 import { useBrevFeilContext } from '../../context/BrevFeilContext';
 import { Feilmelding } from '../Feil/Feilmelding';
 
@@ -65,7 +65,7 @@ export const Brevknapp = ({
 };
 
 const FeilmeldingBrev = ({ feilmelding }: { feilmelding: string | undefined }) => {
-    const { manglendeBrevVariabler } = useBrevFeilContext();
+    const { manglendeBrevVariabler, manglendeValgfelt } = useBrevFeilContext();
     return (
         feilmelding && (
             <Feilmelding variant="alert" size={'small'}>
@@ -74,12 +74,19 @@ const FeilmeldingBrev = ({ feilmelding }: { feilmelding: string | undefined }) =
                     tittel={'Felt som mangler verdi'}
                     mangler={manglendeBrevVariabler}
                 />
+                <ListeMedMangler tittel={'Valg som mangler verdi'} mangler={manglendeValgfelt} />
             </Feilmelding>
         )
     );
 };
 
-const ListeMedMangler = ({ tittel, mangler }: { tittel: string; mangler: Variabel[] }) => {
+const ListeMedMangler = ({
+    tittel,
+    mangler,
+}: {
+    tittel: string;
+    mangler: { _id: string; visningsnavn: string }[];
+}) => {
     return (
         mangler.length > 0 && (
             <List size={'small'}>

--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -6,7 +6,7 @@ import styled from 'styled-components';
 import { BodyShort, Button, List, VStack } from '@navikt/ds-react';
 
 import { MalStruktur, Valg, Valgfelt } from './typer';
-import { useBrevFeilContext } from '../../context/BrevFeilContext';
+import { FeilIDelmal, FeilIDelmalType, useBrevFeilContext } from '../../context/BrevFeilContext';
 import { Feilmelding } from '../Feil/Feilmelding';
 
 const Knapp = styled(Button)`
@@ -85,13 +85,14 @@ const ListeMedMangler = ({
     mangler,
 }: {
     tittel: string;
-    mangler: { _id: string; visningsnavn: string }[];
+    mangler: FeilIDelmal<FeilIDelmalType>[];
 }) => {
+    const alleMangler = mangler.flatMap((delmal) => delmal.mangler);
     return (
-        mangler.length > 0 && (
+        alleMangler.length > 0 && (
             <List size={'small'}>
                 <BodyShort size={'small'}>{tittel}</BodyShort>
-                {mangler.map((mangel, index) => (
+                {alleMangler.map((mangel, index) => (
                     <List.Item key={`${mangel._id}-${index}`}>{mangel.visningsnavn}</List.Item>
                 ))}
             </List>

--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -41,7 +41,6 @@ export const Brevknapp = ({
         const harMangelResultat = oppdaterMangelIBrev(mal, inkluderteDelmaler, valgfelt, variabler);
 
         if (harMangelResultat === 'HAR_MANGEL') {
-            settFeilmelding('Kan ikke gå videre, følgende felter mangler fra brev:');
             return;
         }
 
@@ -59,17 +58,18 @@ export const Brevknapp = ({
             <Knapp onClick={trykkPåKnapp} disabled={laster}>
                 {tittel}
             </Knapp>
-            <FeilmeldingBrev feilmelding={feilmelding} />
+            <Feilmelding>{feilmelding}</Feilmelding>
+            <FeilmeldingBrev />
         </VStack>
     );
 };
 
-const FeilmeldingBrev = ({ feilmelding }: { feilmelding: string | undefined }) => {
+const FeilmeldingBrev = () => {
     const { manglendeBrevVariabler, manglendeValgfelt } = useBrevFeilContext();
     return (
-        feilmelding && (
+        (manglendeBrevVariabler.length > 0 || manglendeValgfelt.length > 0) && (
             <Feilmelding variant="alert" size={'small'}>
-                {feilmelding}
+                Kan ikke gå videre, følgende felter mangler fra brev:
                 <ListeMedMangler
                     tittel={'Felt som mangler verdi'}
                     mangler={manglendeBrevVariabler}

--- a/src/frontend/komponenter/Brev/DelmalMeny.tsx
+++ b/src/frontend/komponenter/Brev/DelmalMeny.tsx
@@ -53,6 +53,7 @@ export const DelmalMeny: React.FC<Props> = ({
                     case 'valgfelt':
                         return (
                             <Valgfelt
+                                delmalId={delmal._id}
                                 valgtVerdi={idEllerFritekst(valgfelt[val._id])}
                                 valgfelt={val}
                                 settValgfelt={settValgfelt}
@@ -66,6 +67,7 @@ export const DelmalMeny: React.FC<Props> = ({
                     case 'block':
                         return (
                             <Variabler
+                                delmalId={delmal._id}
                                 variabler={val.markDefs}
                                 variablerState={variabler}
                                 settVariabler={settVariabler}

--- a/src/frontend/komponenter/Brev/DelmalMeny.tsx
+++ b/src/frontend/komponenter/Brev/DelmalMeny.tsx
@@ -9,6 +9,7 @@ import { Delmal as DelmalType, FritekstAvsnitt, Valg } from './typer';
 import Valgfelt from './Valgfelt';
 import { idEllerFritekst } from './valgUtil';
 import Variabler from './Variabler';
+import { useBrevFeilContext } from '../../context/BrevFeilContext';
 
 interface Props {
     delmal: DelmalType;
@@ -39,12 +40,18 @@ export const DelmalMeny: React.FC<Props> = ({
     inkluderIBrev,
     settInkluderIBrev,
 }) => {
+    const { nullstillDelmal } = useBrevFeilContext();
     return (
         <FlexColumn>
             <Checkbox
                 disabled={delmal.visningsdetaljer.skalAlltidMed}
                 checked={inkluderIBrev}
-                onChange={(e) => settInkluderIBrev(e.target.checked)}
+                onChange={(e) => {
+                    settInkluderIBrev(e.target.checked);
+                    if (!e.target.checked) {
+                        nullstillDelmal(delmal._id);
+                    }
+                }}
             >
                 Inkluder seksjon i brev
             </Checkbox>

--- a/src/frontend/komponenter/Brev/Valgfelt.tsx
+++ b/src/frontend/komponenter/Brev/Valgfelt.tsx
@@ -5,8 +5,10 @@ import { Select } from '@navikt/ds-react';
 import Fritekst, { lagTomtAvsnitt } from './Fritekst';
 import { FritekstAvsnitt, Valg, Valgfelt } from './typer';
 import Variabler from './Variabler';
+import { useBrevFeilContext } from '../../context/BrevFeilContext';
 
 interface Props {
+    delmalId: string;
     valgtVerdi: string | undefined;
     valgfelt: Valgfelt;
     settValgfelt: React.Dispatch<SetStateAction<Record<string, Valg>>>;
@@ -17,6 +19,7 @@ interface Props {
 }
 
 const Valgfelt: React.FC<Props> = ({
+    delmalId,
     valgtVerdi,
     valgfelt,
     settValgfelt,
@@ -25,6 +28,7 @@ const Valgfelt: React.FC<Props> = ({
     settFritekst,
     settVariabler,
 }) => {
+    const { manglerVerdi } = useBrevFeilContext();
     const finnValgtBlock = (id: string | undefined) =>
         valgfelt.valg.find(
             (valg) =>
@@ -57,6 +61,7 @@ const Valgfelt: React.FC<Props> = ({
                 value={valgtVerdi || ''}
                 onChange={(e) => oppdaterValgfelt(e.target.value)}
                 size="small"
+                error={manglerVerdi(delmalId, valgfelt._id) && 'Mangler verdi'}
             >
                 <option value={''}>Velg</option>
                 {valgfelt.valg.map((valg, index) =>
@@ -90,6 +95,7 @@ const Valgfelt: React.FC<Props> = ({
                     />
                 ) : (
                     <Variabler
+                        delmalId={delmalId}
                         variabler={valgtBlock.variabler}
                         variablerState={variabler}
                         settVariabler={settVariabler}

--- a/src/frontend/komponenter/Brev/Valgfelt.tsx
+++ b/src/frontend/komponenter/Brev/Valgfelt.tsx
@@ -28,7 +28,7 @@ const Valgfelt: React.FC<Props> = ({
     settFritekst,
     settVariabler,
 }) => {
-    const { manglerVerdi } = useBrevFeilContext();
+    const { manglerVerdi, nullstillValgfelt, nullstillVariabel } = useBrevFeilContext();
     const finnValgtBlock = (id: string | undefined) =>
         valgfelt.valg.find(
             (valg) =>
@@ -36,14 +36,21 @@ const Valgfelt: React.FC<Props> = ({
                 (valg._type === 'fritekst' && id === 'fritekst')
         );
 
+    const valgtBlock = finnValgtBlock(valgtVerdi);
+
     const oppdaterValgfelt = (id: string) => {
-        const valgtBlock = finnValgtBlock(id);
+        const nyttValgtBlock = finnValgtBlock(id);
+        if (nyttValgtBlock) {
+            nullstillValgfelt(delmalId, valgfelt._id);
+        } else if (valgtBlock?._type === 'tekst') {
+            valgtBlock.variabler.forEach((variabel) => nullstillVariabel(delmalId, variabel._id));
+        }
 
         settValgfelt((prevState) => {
             const oppdatertState = { ...prevState };
 
-            if (valgtBlock) {
-                oppdatertState[valgfelt._id] = valgtBlock;
+            if (nyttValgtBlock) {
+                oppdatertState[valgfelt._id] = nyttValgtBlock;
             } else {
                 delete oppdatertState[valgfelt._id];
             }
@@ -51,8 +58,6 @@ const Valgfelt: React.FC<Props> = ({
             return oppdatertState;
         });
     };
-
-    const valgtBlock = finnValgtBlock(valgtVerdi);
 
     return (
         <>

--- a/src/frontend/komponenter/Brev/Variabler.tsx
+++ b/src/frontend/komponenter/Brev/Variabler.tsx
@@ -13,16 +13,18 @@ interface Props {
 }
 
 const Variabler: React.FC<Props> = ({ delmalId, variabler, variablerState, settVariabler }) => {
-    const { manglerVerdi } = useBrevFeilContext();
+    const { manglerVerdi, nullstillVariabel } = useBrevFeilContext();
 
     return (
         <>
             {variabler.map((variabel) => {
-                const håndterInput = (e: React.ChangeEvent<HTMLInputElement>) =>
+                const håndterInput = (e: React.ChangeEvent<HTMLInputElement>) => {
                     settVariabler((prevState) => ({
                         ...prevState,
                         [variabel._id]: e.target.value,
                     }));
+                    nullstillVariabel(delmalId, variabel._id);
+                };
 
                 if (!variabel.erHtml) {
                     return (

--- a/src/frontend/komponenter/Brev/Variabler.tsx
+++ b/src/frontend/komponenter/Brev/Variabler.tsx
@@ -3,14 +3,18 @@ import React, { SetStateAction } from 'react';
 import { TextField } from '@navikt/ds-react';
 
 import { Variabel } from './typer';
+import { useBrevFeilContext } from '../../context/BrevFeilContext';
 
 interface Props {
+    delmalId: string;
     variabler: Variabel[];
     variablerState: Partial<Record<string, string>>;
     settVariabler: React.Dispatch<SetStateAction<Partial<Record<string, string>>>>;
 }
 
-const Variabler: React.FC<Props> = ({ variabler, variablerState, settVariabler }) => {
+const Variabler: React.FC<Props> = ({ delmalId, variabler, variablerState, settVariabler }) => {
+    const { manglerVerdi } = useBrevFeilContext();
+
     return (
         <>
             {variabler.map((variabel) => {
@@ -30,6 +34,7 @@ const Variabler: React.FC<Props> = ({ variabler, variablerState, settVariabler }
                                 onChange={håndterInput}
                                 autoComplete="off"
                                 size="small"
+                                error={manglerVerdi(delmalId, variabel._id) && 'Mangler verdi'}
                             />
                         </div>
                     );

--- a/src/frontend/komponenter/Brev/typer.ts
+++ b/src/frontend/komponenter/Brev/typer.ts
@@ -36,6 +36,7 @@ export interface Valgfelt {
     _id: string;
     valg: Valg[];
     visningsnavn: string;
+    erPakrevd?: boolean;
 }
 
 interface Blockcontent {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønskelig å validere valgfelt

Har også lagt inn at felt som mangler verdi får error.
<img width="405" alt="image" src="https://github.com/user-attachments/assets/c1760b1b-0268-4cbc-aa66-439e6b448198" />
<img width="418" alt="image" src="https://github.com/user-attachments/assets/7e3cc7e9-64ad-4b4c-a7a9-5a795ac6ca98" />


Fortsettelse på 
* https://github.com/navikt/tilleggsstonader-sak-frontend/pull/676

Avhengig av
* https://github.com/navikt/tilleggsstonader-brev-sanity/pull/68

Et alternativ er å bruke map i stedet for liste
* https://github.com/navikt/tilleggsstonader-sak-frontend/commit/f10ca1caf541f044eac820295335f5596dc09e53