### PR TITLE
Legg til opphørstag

### DIFF
--- a/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { CopyButton, HStack, Popover, Table } from '@navikt/ds-react';
+import { CopyButton, HStack, Popover, Table, Tag } from '@navikt/ds-react';
 
 import Oppgaveknapp from './Oppgaveknapp';
 import { utledetFolkeregisterIdent } from './Oppgavetabell';
@@ -37,9 +37,12 @@ const Oppgaverad: React.FC<{ oppgave: Oppgave }> = ({ oppgave }) => {
     return (
         <Table.Row key={oppgave.id}>
             <Table.DataCell>
-                {oppgave.oppgavetype
-                    ? oppgaveTypeTilTekst[oppgave.oppgavetype]
-                    : 'Mangler oppgavetype'}
+                <HStack gap={'2'} align={'center'}>
+                    {oppgave.oppgavetype
+                        ? oppgaveTypeTilTekst[oppgave.oppgavetype]
+                        : 'Mangler oppgavetype'}
+                    {oppgave.erOpphør && <Tag variant={'error'}>Opphør</Tag>}
+                </HStack>
             </Table.DataCell>
             <Table.DataCell>
                 {utledTypeBehandling(oppgave.behandlingstype, oppgave.behandlingstema)}

--- a/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgaverad.tsx
@@ -41,7 +41,11 @@ const Oppgaverad: React.FC<{ oppgave: Oppgave }> = ({ oppgave }) => {
                     {oppgave.oppgavetype
                         ? oppgaveTypeTilTekst[oppgave.oppgavetype]
                         : 'Mangler oppgavetype'}
-                    {oppgave.erOpphør && <Tag variant={'error'}>Opphør</Tag>}
+                    {oppgave.erOpphør && (
+                        <Tag variant={'error'} size={'small'}>
+                            Opphør
+                        </Tag>
+                    )}
                 </HStack>
             </Table.DataCell>
             <Table.DataCell>

--- a/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavetabell.tsx
@@ -23,7 +23,7 @@ import { useOppgave } from '../../context/OppgaveContext';
 import { PartialRecord } from '../../typer/common';
 
 const Tabell = styled(Table)`
-    width: 1250px;
+    width: 1400px;
 `;
 interface Props {
     oppgaverResponse: OppgaverResponse;

--- a/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
+++ b/src/frontend/Sider/Oppgavebenk/typer/oppgave.ts
@@ -72,6 +72,7 @@ export interface Oppgave {
     navn?: string;
     behandlingId?: string;
     sendtTilTotrinnskontrollAv?: string;
+    erOpphør: boolean;
 }
 
 export interface IOppgaveIdent {


### PR DESCRIPTION
Det er ønskelig at saksbehandlere velger opphørsoppgaver først derfor ønsker vi å tagge disse før å gjøre det tydelig at det er et opphør. Dette gjelder kun godkjenn vedtak oppgaver.

![image](https://github.com/user-attachments/assets/568107d9-f83d-448d-9ab0-74d8b7a815a0)

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-23450