### PR TITLE
Setter width på knappen til fit-content for å ikke være like brev som…

### DIFF
--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -10,7 +10,7 @@ import { FeilIDelmal, FeilIDelmalType, useBrevFeilContext } from '../../context/
 import { Feilmelding } from '../Feil/Feilmelding';
 
 const Knapp = styled(Button)`
-    display: block;
+    width: fit-content;
 `;
 
 interface Props {


### PR DESCRIPTION
… hele kolonnen då den er i en flex-column

### Hvorfor er denne endringen nødvendig? ✨
Jeg tror jeg ødela denne når jeg flyttet rundt på knappen i forbindelse med å legge på validering av felter i brevmenyn. 
Tidligere var den smal.

Lager PR då jeg ble usikker på noen kanskje var uenig 👀 

Etter:
![image](https://github.com/user-attachments/assets/3a8e3e98-9a1a-462a-9674-bdd96654e99a)

Før:
![image](https://github.com/user-attachments/assets/c954a46d-df9f-4688-9954-77a6a58fa0ee)

![image](https://github.com/user-attachments/assets/884a95d3-1699-4155-8748-efb07cca5e40)

