### PR TITLE
Løftet henting av behandlingshistorikk opp til BehandlingContext. 

### DIFF
--- a/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
+++ b/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
@@ -32,7 +32,7 @@ const SettPåVentForm: React.FC<{
     settStatusPåVent: (status: Ressurs<StatusSettPåVent>) => void;
     settStatusPåVentRedigering: React.Dispatch<React.SetStateAction<boolean>>;
 }> = ({ status, settStatusPåVent, settStatusPåVentRedigering }) => {
-    const { behandling, hentBehandling } = useBehandling();
+    const { behandling, hentBehandling, hentBehandlingshistorikk } = useBehandling();
     const { request } = useApp();
 
     const [laster, settLaster] = useState(false);
@@ -81,6 +81,9 @@ const SettPåVentForm: React.FC<{
                 settStatusPåVentRedigering(false);
                 settFeilmelding(undefined);
                 settStatusPåVent(response);
+                if (oppdatererEksisterendeSettPåVent) {
+                    hentBehandlingshistorikk.rerun();
+                }
                 hentBehandling.rerun();
             } else {
                 settFeilmelding(response.frontendFeilmelding);

--- a/src/frontend/Sider/Behandling/Venstremeny/Historikk/Historikk.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Historikk/Historikk.tsx
@@ -1,13 +1,10 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 
 import styled from 'styled-components';
 
 import HistorikkElement from './HistorikkElement';
-import { HistorikkHendelse } from './typer';
-import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import DataViewer from '../../../../komponenter/DataViewer';
-import { Ressurs, byggTomRessurs } from '../../../../typer/ressurs';
 
 const Container = styled.ul`
     margin: 0;
@@ -15,23 +12,14 @@ const Container = styled.ul`
 `;
 
 const Historikk: React.FC = () => {
-    const { request } = useApp();
-    const { behandling } = useBehandling();
-
-    const [historikk, settHistorikk] = useState<Ressurs<HistorikkHendelse[]>>(byggTomRessurs());
-
-    useEffect(() => {
-        request<HistorikkHendelse[], null>(`/api/sak/behandlingshistorikk/${behandling.id}`).then(
-            settHistorikk
-        );
-    }, [request, behandling.id, behandling.status]);
+    const { behandlingshistorikk } = useBehandling();
 
     return (
-        <DataViewer response={{ historikk }}>
-            {({ historikk }) => (
+        <DataViewer response={{ behandlingshistorikk }}>
+            {({ behandlingshistorikk }) => (
                 <Container>
-                    {historikk.map((historikkElement, index) => {
-                        const erSisteElementIListe = index === historikk.length - 1;
+                    {behandlingshistorikk.map((historikkElement, index) => {
+                        const erSisteElementIListe = index === behandlingshistorikk.length - 1;
 
                         return (
                             <HistorikkElement

--- a/src/frontend/context/BehandlingContext.ts
+++ b/src/frontend/context/BehandlingContext.ts
@@ -4,11 +4,14 @@ import { useFlag } from '@unleash/proxy-client-react';
 import constate from 'constate';
 
 import { useApp } from './AppContext';
+import { useBehandlingshistorikk } from '../hooks/useBehandlingshistorikk';
 import { RerrunnableEffect } from '../hooks/useRerunnableEffect';
+import { HistorikkHendelse } from '../Sider/Behandling/Venstremeny/Historikk/typer';
 import { Behandling } from '../typer/behandling/behandling';
 import { BehandlingFakta } from '../typer/behandling/behandlingFakta/behandlingFakta';
 import { erBehandlingRedigerbar } from '../typer/behandling/behandlingStatus';
 import { Stønadstype } from '../typer/behandling/behandlingTema';
+import { Ressurs } from '../typer/ressurs';
 import { Toggle } from '../utils/toggles';
 
 interface Props {
@@ -27,6 +30,8 @@ interface BehandlingContext {
     behandling: Behandling;
     behandlingErRedigerbar: boolean;
     hentBehandling: RerrunnableEffect;
+    behandlingshistorikk: Ressurs<HistorikkHendelse[]>;
+    hentBehandlingshistorikk: RerrunnableEffect;
     behandlingFakta: BehandlingFakta;
     toggleKanSaksbehandle: boolean;
     kanSetteBehandlingPåVent: boolean;
@@ -70,6 +75,9 @@ export const [BehandlingProvider, useBehandling] = constate(
             useState<boolean>(false);
         const [visHenleggModal, settVisHenleggModal] = useState<boolean>(false);
 
+        const { hentBehandlingshistorikk, behandlingshistorikk } =
+            useBehandlingshistorikk(behandling);
+
         const kanSaksbehandle = useKanSaksbehandle(behandling.stønadstype);
         const kanRevurdere = useKanRevurdere(behandling.stønadstype);
 
@@ -83,6 +91,8 @@ export const [BehandlingProvider, useBehandling] = constate(
             behandling,
             behandlingErRedigerbar: behandlingErRedigerbar && toggleKanSaksbehandleEllerRevurdere,
             hentBehandling,
+            behandlingshistorikk,
+            hentBehandlingshistorikk,
             behandlingFakta,
             toggleKanSaksbehandle: toggleKanSaksbehandleEllerRevurdere,
             kanSetteBehandlingPåVent: behandlingErRedigerbar,

--- a/src/frontend/hooks/useBehandlingshistorikk.ts
+++ b/src/frontend/hooks/useBehandlingshistorikk.ts
@@ -1,0 +1,36 @@
+import { useCallback, useState } from 'react';
+
+import { RerrunnableEffect, useRerunnableEffect } from './useRerunnableEffect';
+import { useApp } from '../context/AppContext';
+import { HistorikkHendelse } from '../Sider/Behandling/Venstremeny/Historikk/typer';
+import { Behandling } from '../typer/behandling/behandling';
+import { byggTomRessurs, Ressurs } from '../typer/ressurs';
+
+interface BehandlingshistorikkResponse {
+    hentBehandlingshistorikk: RerrunnableEffect;
+    behandlingshistorikk: Ressurs<HistorikkHendelse[]>;
+}
+
+export const useBehandlingshistorikk = (behandling: Behandling): BehandlingshistorikkResponse => {
+    const { request } = useApp();
+
+    const [behandlingshistorikk, settBehandlingshistorikk] =
+        useState<Ressurs<HistorikkHendelse[]>>(byggTomRessurs());
+
+    const hentBehandlingshistorikkCallback = useCallback(() => {
+        request<HistorikkHendelse[], null>(`/api/sak/behandlingshistorikk/${behandling.id}`).then(
+            settBehandlingshistorikk
+        );
+    }, [request, behandling.id]);
+
+    const hentBehandlingshistorikk = useRerunnableEffect(hentBehandlingshistorikkCallback, [
+        request,
+        behandling.id,
+        behandling.status,
+    ]);
+
+    return {
+        hentBehandlingshistorikk,
+        behandlingshistorikk,
+    };
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-22956

Formålet er å kunne trigge re-henting av historikk også når status på behandling ikke endrer seg, e.g. ved oppdatering av "sett på vent".

@sarahjelle har du anledning til å 👀? 