### PR TITLE
 ✨Statustag på vedtaksperioder

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StatusTag.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/StatusTag.tsx
@@ -4,15 +4,15 @@ import styled from 'styled-components';
 
 import { Tag } from '@navikt/ds-react';
 
-import { StønadsperiodeStatus } from '../typer/stønadsperiode';
+import { PeriodeStatus } from '../../../../typer/behandling/periodeStatus';
 
 const StyledTag = styled(Tag)`
     max-width: fit-content;
     min-height: 20px;
 `;
 
-export const StatusTag: React.FC<{ status?: StønadsperiodeStatus }> = ({ status }) => {
-    if (status === StønadsperiodeStatus.ENDRET) {
+export const StatusTag: React.FC<{ status?: PeriodeStatus }> = ({ status }) => {
+    if (status === PeriodeStatus.ENDRET) {
         return (
             <StyledTag size="small" variant="warning">
                 Endret
@@ -20,7 +20,7 @@ export const StatusTag: React.FC<{ status?: StønadsperiodeStatus }> = ({ status
         );
     }
 
-    if (status === StønadsperiodeStatus.NY) {
+    if (status === PeriodeStatus.NY) {
         return (
             <StyledTag size="small" variant="success">
                 Ny

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/stønadsperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/stønadsperiode.ts
@@ -1,5 +1,6 @@
 import { AktivitetType } from './vilkårperiode/aktivitet';
 import { MålgruppeType } from './vilkårperiode/målgruppe';
+import { PeriodeStatus } from '../../../../typer/behandling/periodeStatus';
 import { Periode } from '../../../../utils/periode';
 
 /**
@@ -11,11 +12,5 @@ export interface Stønadsperiode extends Periode {
     id?: string;
     målgruppe: MålgruppeType | '';
     aktivitet: AktivitetType | '';
-    status?: StønadsperiodeStatus;
-}
-
-export enum StønadsperiodeStatus {
-    UENDRET = 'UENDRET',
-    ENDRET = 'ENDRET',
-    NY = 'NY',
+    status?: PeriodeStatus;
 }

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -33,10 +33,6 @@ export interface Vedtaksperiode extends Periode {
     status?: PeriodeStatus;
 }
 
-export interface VedtaksperiodeMedEndretKey extends Vedtaksperiode {
-    endretKey: string;
-}
-
 export const InnvilgeLæremidler: React.FC<{
     lagretVedtak: InnvilgelseLæremidler | undefined;
     vedtaksperioderForrigeBehandling: Vedtaksperiode[] | undefined;
@@ -47,7 +43,7 @@ export const InnvilgeLæremidler: React.FC<{
 
     const { stønadsperioder } = useStønadsperioder(behandling.id);
 
-    const [vedtaksperioder, settVedtaksperioder] = useState<VedtaksperiodeMedEndretKey[]>(
+    const [vedtaksperioder, settVedtaksperioder] = useState<Vedtaksperiode[]>(
         initialiserVedtaksperioder(
             lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling
         )

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -21,15 +21,26 @@ import {
     InnvilgelseLæremidler,
     InnvilgelseLæremidlerRequest,
 } from '../../../../../typer/vedtak/vedtakLæremidler';
-import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
+import { Periode } from '../../../../../utils/periode';
 import { FanePath } from '../../../faner';
 import { StønadsperiodeListe } from '../../../Stønadsvilkår/OppsummeringStønadsperioder';
 import { validerVedtaksperioder } from '../validering';
 import { initialiserVedtaksperioder } from '../vedtakLæremidlerUtils';
 
+type VedtaksperiodeStatus = 'NY' | 'UENDRET' | 'ENDRET' | 'SLETTET';
+
+export interface Vedtaksperiode extends Periode {
+    id: string;
+    status?: VedtaksperiodeStatus;
+}
+
+export interface VedtaksperiodeMedEndretKey extends Vedtaksperiode {
+    endretKey: string;
+}
+
 export const InnvilgeLæremidler: React.FC<{
     lagretVedtak: InnvilgelseLæremidler | undefined;
-    vedtaksperioderForrigeBehandling: Periode[] | undefined;
+    vedtaksperioderForrigeBehandling: Vedtaksperiode[] | undefined;
 }> = ({ lagretVedtak, vedtaksperioderForrigeBehandling }) => {
     const { request } = useApp();
     const { behandling } = useBehandling();
@@ -37,11 +48,12 @@ export const InnvilgeLæremidler: React.FC<{
 
     const { stønadsperioder } = useStønadsperioder(behandling.id);
 
-    const [vedtaksperioder, settVedtaksperioder] = useState<PeriodeMedEndretKey[]>(
+    const [vedtaksperioder, settVedtaksperioder] = useState<VedtaksperiodeMedEndretKey[]>(
         initialiserVedtaksperioder(
             lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling
         )
     );
+
     const [visHarIkkeBeregnetFeilmelding, settVisHarIkkeBeregnetFeilmelding] = useState<boolean>();
 
     const [beregningsresultat, settBeregningsresultat] =

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -13,7 +13,6 @@ import DataViewer from '../../../../../komponenter/DataViewer';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
 import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
-import { PeriodeStatus } from '../../../../../typer/behandling/periodeStatus';
 import { Steg } from '../../../../../typer/behandling/steg';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '../../../../../typer/ressurs';
 import { TypeVedtak } from '../../../../../typer/vedtak/vedtak';
@@ -21,17 +20,13 @@ import {
     BeregningsresultatLæremidler,
     InnvilgelseLæremidler,
     InnvilgelseLæremidlerRequest,
+    Vedtaksperiode,
 } from '../../../../../typer/vedtak/vedtakLæremidler';
 import { Periode } from '../../../../../utils/periode';
 import { FanePath } from '../../../faner';
 import { StønadsperiodeListe } from '../../../Stønadsvilkår/OppsummeringStønadsperioder';
 import { validerVedtaksperioder } from '../validering';
 import { initialiserVedtaksperioder } from '../vedtakLæremidlerUtils';
-
-export interface Vedtaksperiode extends Periode {
-    id: string;
-    status?: PeriodeStatus;
-}
 
 export const InnvilgeLæremidler: React.FC<{
     lagretVedtak: InnvilgelseLæremidler | undefined;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -13,6 +13,7 @@ import DataViewer from '../../../../../komponenter/DataViewer';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
 import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
+import { PeriodeStatus } from '../../../../../typer/behandling/periodeStatus';
 import { Steg } from '../../../../../typer/behandling/steg';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '../../../../../typer/ressurs';
 import { TypeVedtak } from '../../../../../typer/vedtak/vedtak';
@@ -27,11 +28,9 @@ import { StønadsperiodeListe } from '../../../Stønadsvilkår/OppsummeringStøn
 import { validerVedtaksperioder } from '../validering';
 import { initialiserVedtaksperioder } from '../vedtakLæremidlerUtils';
 
-type VedtaksperiodeStatus = 'NY' | 'UENDRET' | 'ENDRET' | 'SLETTET';
-
 export interface Vedtaksperiode extends Periode {
     id: string;
-    status?: VedtaksperiodeStatus;
+    status?: PeriodeStatus;
 }
 
 export interface VedtaksperiodeMedEndretKey extends Vedtaksperiode {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { InnvilgeLæremidler, Vedtaksperiode } from './InnvilgeLæremidler';
+import { InnvilgeLæremidler } from './InnvilgeLæremidler';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { useVedtakForrigeBehandling } from '../../../../../hooks/useVedtak';
@@ -10,6 +10,7 @@ import { TypeVedtak } from '../../../../../typer/vedtak/vedtak';
 import {
     InnvilgelseLæremidler,
     VedtakLæremidler,
+    Vedtaksperiode,
 } from '../../../../../typer/vedtak/vedtakLæremidler';
 
 export const InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling: React.FC<{

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
@@ -1,6 +1,6 @@
 import React, { useEffect } from 'react';
 
-import { InnvilgeLæremidler } from './InnvilgeLæremidler';
+import { InnvilgeLæremidler, Vedtaksperiode } from './InnvilgeLæremidler';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { useVedtakForrigeBehandling } from '../../../../../hooks/useVedtak';
@@ -11,7 +11,6 @@ import {
     InnvilgelseLæremidler,
     VedtakLæremidler,
 } from '../../../../../typer/vedtak/vedtakLæremidler';
-import { Periode } from '../../../../../utils/periode';
 
 export const InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling: React.FC<{
     lagretVedtak: InnvilgelseLæremidler | undefined;
@@ -65,7 +64,7 @@ const InnvilgeLæremidlerMedPerioderFraForrigeBehandling = ({
     );
 };
 
-const vedtaksperioderForrigeVedtak = (vedtak: VedtakLæremidler): Periode[] | undefined => {
+const vedtaksperioderForrigeVedtak = (vedtak: VedtakLæremidler): Vedtaksperiode[] | undefined => {
     switch (vedtak.type) {
         case TypeVedtak.INNVILGELSE:
             return vedtak.vedtaksperioder;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
-import { Vedtaksperiode } from './InnvilgeLæremidler';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
 import { BehandlingType } from '../../../../../typer/behandling/behandlingType';
+import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakLæremidler';
 import { Periode } from '../../../../../utils/periode';
 import { StatusTag } from '../../../Inngangsvilkår/Stønadsperioder/StatusTag';
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -4,10 +4,13 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
 import { VedtaksperiodeMedEndretKey } from './InnvilgeLæremidler';
+import { useBehandling } from '../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
+import { BehandlingType } from '../../../../../typer/behandling/behandlingType';
 import { Periode } from '../../../../../utils/periode';
+import { StatusTag } from '../../../Inngangsvilkår/Stønadsperioder/StatusTag';
 
 interface Props {
     vedtaksperiode: VedtaksperiodeMedEndretKey;
@@ -26,6 +29,7 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
     slettPeriode,
     erNyRad,
 }) => {
+    const { behandling } = useBehandling();
     const { alleFelterKanEndres, helePeriodenErLåstForEndring, kanSlettePeriode } =
         useRevurderingAvPerioder({
             periodeFom: vedtaksperiode.fom,
@@ -33,9 +37,12 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
             nyRadLeggesTil: erNyRad,
         });
 
+    const skalViseStatus = erLesevisning && behandling.type === BehandlingType.REVURDERING;
+
     return (
         <>
             <DateInputMedLeservisning
+                className="kolonne"
                 label="Fra"
                 hideLabel
                 erLesevisning={erLesevisning}
@@ -55,16 +62,18 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
                 feil={vedtaksperiodeFeil?.tom}
                 size="small"
             />
-            {kanSlettePeriode && !erLesevisning ? (
-                <Button
-                    variant="tertiary"
-                    onClick={() => slettPeriode()}
-                    icon={<TrashIcon />}
-                    size="xsmall"
-                />
-            ) : (
-                <div />
-            )}
+            <div>
+                {!erLesevisning
+                    ? kanSlettePeriode && (
+                          <Button
+                              variant="tertiary"
+                              onClick={() => slettPeriode()}
+                              icon={<TrashIcon />}
+                              size="xsmall"
+                          />
+                      )
+                    : skalViseStatus && <StatusTag status={vedtaksperiode.status} />}
+            </div>
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -63,16 +63,16 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
                 size="small"
             />
             <div>
-                {!erLesevisning
-                    ? kanSlettePeriode && (
+                {erLesevisning
+                    ? skalViseStatus && <StatusTag status={vedtaksperiode.status} />
+                    : kanSlettePeriode && (
                           <Button
                               variant="tertiary"
                               onClick={() => slettPeriode()}
                               icon={<TrashIcon />}
                               size="xsmall"
                           />
-                      )
-                    : skalViseStatus && <StatusTag status={vedtaksperiode.status} />}
+                      )}
             </div>
         </>
     );

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -3,13 +3,14 @@ import React from 'react';
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
+import { VedtaksperiodeMedEndretKey } from './InnvilgeLæremidler';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
-import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
+import { Periode } from '../../../../../utils/periode';
 
 interface Props {
-    vedtaksperiode: PeriodeMedEndretKey;
+    vedtaksperiode: VedtaksperiodeMedEndretKey;
     erLesevisning: boolean;
     vedtaksperiodeFeil: FormErrors<Periode> | undefined;
     oppdaterPeriode: (property: 'fom' | 'tom', value: string | undefined) => void;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { TrashIcon } from '@navikt/aksel-icons';
 import { Button } from '@navikt/ds-react';
 
-import { VedtaksperiodeMedEndretKey } from './InnvilgeLæremidler';
+import { Vedtaksperiode } from './InnvilgeLæremidler';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
@@ -13,7 +13,7 @@ import { Periode } from '../../../../../utils/periode';
 import { StatusTag } from '../../../Inngangsvilkår/Stønadsperioder/StatusTag';
 
 interface Props {
-    vedtaksperiode: VedtaksperiodeMedEndretKey;
+    vedtaksperiode: Vedtaksperiode;
     erLesevisning: boolean;
     vedtaksperiodeFeil: FormErrors<Periode> | undefined;
     oppdaterPeriode: (property: 'fom' | 'tom', value: string | undefined) => void;
@@ -37,7 +37,7 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
             nyRadLeggesTil: erNyRad,
         });
 
-    const skalViseStatus = erLesevisning && behandling.type === BehandlingType.REVURDERING;
+    const erRevurdering = behandling.type === BehandlingType.REVURDERING;
 
     return (
         <>
@@ -63,7 +63,7 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
             />
             <div>
                 {erLesevisning
-                    ? skalViseStatus && <StatusTag status={vedtaksperiode.status} />
+                    ? erRevurdering && <StatusTag status={vedtaksperiode.status} />
                     : kanSlettePeriode && (
                           <Button
                               variant="tertiary"

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -42,7 +42,6 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
     return (
         <>
             <DateInputMedLeservisning
-                className="kolonne"
                 label="Fra"
                 hideLabel
                 erLesevisning={erLesevisning}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -5,11 +5,12 @@ import styled from 'styled-components';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { BodyLong, Button, Heading, Label, ReadMore, VStack } from '@navikt/ds-react';
 
+import { VedtaksperiodeMedEndretKey } from './InnvilgeLæremidler';
 import { useApp } from '../../../../../context/AppContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { UlagretKomponent } from '../../../../../hooks/useUlagredeKomponenter';
-import { Periode, PeriodeMedEndretKey } from '../../../../../utils/periode';
+import { Periode } from '../../../../../utils/periode';
 import { tomVedtaksperiode } from '../vedtakLæremidlerUtils';
 import { VedtaksperiodeRad } from './VedtaksperiodeRad';
 
@@ -24,8 +25,8 @@ const Grid = styled.div`
 `;
 
 interface Props {
-    vedtaksperioder: PeriodeMedEndretKey[];
-    settVedtaksperioder: React.Dispatch<React.SetStateAction<PeriodeMedEndretKey[]>>;
+    vedtaksperioder: VedtaksperiodeMedEndretKey[];
+    settVedtaksperioder: React.Dispatch<React.SetStateAction<VedtaksperiodeMedEndretKey[]>>;
     vedtaksperioderFeil?: FormErrors<Periode>[];
     settVedtaksperioderFeil: React.Dispatch<
         React.SetStateAction<FormErrors<Periode>[] | undefined>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -17,8 +17,9 @@ import { VedtaksperiodeRad } from './VedtaksperiodeRad';
 const Grid = styled.div`
     display: grid;
     grid-template-columns: repeat(3, max-content);
-    grid-gap: 0.5rem 1rem;
+    grid-gap: 0.5rem 1.5rem;
     align-items: start;
+
     > :nth-child(3n) {
         grid-column: 1;
     }
@@ -96,7 +97,8 @@ export const Vedtaksperioder: React.FC<Props> = ({
                         <VedtaksperiodeRad
                             key={vedtaksperiode.endretKey}
                             vedtaksperiode={vedtaksperiode}
-                            erLesevisning={!erStegRedigerbart}
+                            // erLesevisning={!erStegRedigerbart}
+                            erLesevisning={true}
                             oppdaterPeriode={(property, value) => {
                                 oppdaterPeriodeFelt(indeks, property, value);
                             }}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { BodyLong, Button, Heading, Label, ReadMore, VStack } from '@navikt/ds-react';
 
-import { VedtaksperiodeMedEndretKey } from './InnvilgeLæremidler';
+import { Vedtaksperiode } from './InnvilgeLæremidler';
 import { useApp } from '../../../../../context/AppContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
@@ -26,8 +26,8 @@ const Grid = styled.div`
 `;
 
 interface Props {
-    vedtaksperioder: VedtaksperiodeMedEndretKey[];
-    settVedtaksperioder: React.Dispatch<React.SetStateAction<VedtaksperiodeMedEndretKey[]>>;
+    vedtaksperioder: Vedtaksperiode[];
+    settVedtaksperioder: React.Dispatch<React.SetStateAction<Vedtaksperiode[]>>;
     vedtaksperioderFeil?: FormErrors<Periode>[];
     settVedtaksperioderFeil: React.Dispatch<
         React.SetStateAction<FormErrors<Periode>[] | undefined>
@@ -43,7 +43,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
     const { erStegRedigerbart } = useSteg();
     const { settUlagretKomponent } = useApp();
 
-    const [endretKeyNyeRader, settEndretKeyNyeRader] = useState<Set<string>>(new Set());
+    const [idNyeRader, settIdNyeRader] = useState<Set<string>>(new Set());
 
     const oppdaterPeriodeFelt = (
         indeks: number,
@@ -65,7 +65,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
 
     const leggTilPeriode = () => {
         const nyVedtaksperiode = tomVedtaksperiode();
-        settEndretKeyNyeRader((prevState) => new Set([...prevState, nyVedtaksperiode.endretKey]));
+        settIdNyeRader((prevState) => new Set([...prevState, nyVedtaksperiode.id]));
         settVedtaksperioder([...vedtaksperioder, nyVedtaksperiode]);
         settUlagretKomponent(UlagretKomponent.BEREGNING_INNVILGE);
     };
@@ -95,7 +95,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                     <Label size="small">Til og med</Label>
                     {vedtaksperioder.map((vedtaksperiode, indeks) => (
                         <VedtaksperiodeRad
-                            key={vedtaksperiode.endretKey}
+                            key={vedtaksperiode.id}
                             vedtaksperiode={vedtaksperiode}
                             erLesevisning={!erStegRedigerbart}
                             oppdaterPeriode={(property, value) => {
@@ -103,7 +103,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                             }}
                             slettPeriode={() => slettPeriode(indeks)}
                             vedtaksperiodeFeil={vedtaksperioderFeil && vedtaksperioderFeil[indeks]}
-                            erNyRad={endretKeyNyeRader.has(vedtaksperiode.endretKey)}
+                            erNyRad={idNyeRader.has(vedtaksperiode.id)}
                         />
                     ))}
                 </Grid>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -5,7 +5,6 @@ import styled from 'styled-components';
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 import { BodyLong, Button, Heading, Label, ReadMore, VStack } from '@navikt/ds-react';
 
-import { Vedtaksperiode } from './InnvilgeLæremidler';
 import { useApp } from '../../../../../context/AppContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
@@ -13,6 +12,7 @@ import { UlagretKomponent } from '../../../../../hooks/useUlagredeKomponenter';
 import { Periode } from '../../../../../utils/periode';
 import { tomVedtaksperiode } from '../vedtakLæremidlerUtils';
 import { VedtaksperiodeRad } from './VedtaksperiodeRad';
+import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakLæremidler';
 
 const Grid = styled.div`
     display: grid;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -97,8 +97,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                         <VedtaksperiodeRad
                             key={vedtaksperiode.endretKey}
                             vedtaksperiode={vedtaksperiode}
-                            // erLesevisning={!erStegRedigerbart}
-                            erLesevisning={true}
+                            erLesevisning={!erStegRedigerbart}
                             oppdaterPeriode={(property, value) => {
                                 oppdaterPeriodeFelt(indeks, property, value);
                             }}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
@@ -1,8 +1,10 @@
+import { Vedtaksperiode } from './InnvilgeVedtak/InnvilgeLæremidler';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { ÅrsakAvslag, ÅrsakOpphør } from '../../../../typer/vedtak/vedtak';
-import { Periode, PeriodeMedEndretKey, validerPeriode } from '../../../../utils/periode';
+import { Periode, validerPeriode } from '../../../../utils/periode';
 import { harIkkeVerdi } from '../../../../utils/utils';
 
+// TODO: Dette er pliss likt barnetilsyn - fikse?
 export interface FeilmeldingVedtak {
     årsaker?: string;
     begrunnelse?: string;
@@ -25,5 +27,5 @@ export const valider = (
     return feilmeldinger;
 };
 
-export const validerVedtaksperioder = (vedtaksperioder: PeriodeMedEndretKey[]) =>
+export const validerVedtaksperioder = (vedtaksperioder: Vedtaksperiode[]) =>
     vedtaksperioder.map((periode) => validerPeriode(periode) as FormErrors<Periode>);

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/validering.ts
@@ -1,10 +1,9 @@
-import { Vedtaksperiode } from './InnvilgeVedtak/InnvilgeLæremidler';
 import { FormErrors } from '../../../../hooks/felles/useFormState';
 import { ÅrsakAvslag, ÅrsakOpphør } from '../../../../typer/vedtak/vedtak';
+import { Vedtaksperiode } from '../../../../typer/vedtak/vedtakLæremidler';
 import { Periode, validerPeriode } from '../../../../utils/periode';
 import { harIkkeVerdi } from '../../../../utils/utils';
 
-// TODO: Dette er pliss likt barnetilsyn - fikse?
 export interface FeilmeldingVedtak {
     årsaker?: string;
     begrunnelse?: string;

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
@@ -1,6 +1,6 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Vedtaksperiode } from './InnvilgeVedtak/InnvilgeLæremidler';
+import { Vedtaksperiode } from '../../../../typer/vedtak/vedtakLæremidler';
 
 export const initialiserVedtaksperioder = (
     vedtaksperioder: Vedtaksperiode[] | undefined

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
@@ -1,21 +1,15 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { Vedtaksperiode, VedtaksperiodeMedEndretKey } from './InnvilgeVedtak/InnvilgeLæremidler';
+import { Vedtaksperiode } from './InnvilgeVedtak/InnvilgeLæremidler';
 
 export const initialiserVedtaksperioder = (
     vedtaksperioder: Vedtaksperiode[] | undefined
-): VedtaksperiodeMedEndretKey[] => {
-    const perioderMedEndretKey = vedtaksperioder && tilVedtaksperiodeMedEndretKey(vedtaksperioder);
-
-    return perioderMedEndretKey ?? [tomVedtaksperiode()];
+): Vedtaksperiode[] => {
+    return vedtaksperioder ?? [tomVedtaksperiode()];
 };
 
-export const tomVedtaksperiode = (): VedtaksperiodeMedEndretKey => ({
+export const tomVedtaksperiode = (): Vedtaksperiode => ({
     fom: '',
     tom: '',
     id: uuidv4(),
-    endretKey: uuidv4(),
 });
-
-const tilVedtaksperiodeMedEndretKey = (utgifter: Vedtaksperiode[]): VedtaksperiodeMedEndretKey[] =>
-    utgifter.map((utgift) => ({ ...utgift, endretKey: uuidv4() }));

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
@@ -1,17 +1,21 @@
 import { v4 as uuidv4 } from 'uuid';
 
-import { tilPeriodeMedEndretKey, PeriodeMedEndretKey, Periode } from '../../../../utils/periode';
+import { Vedtaksperiode, VedtaksperiodeMedEndretKey } from './InnvilgeVedtak/InnvilgeLæremidler';
 
 export const initialiserVedtaksperioder = (
-    vedtaksperioder: Periode[] | undefined
-): PeriodeMedEndretKey[] => {
-    const perioderMedEndretKey = vedtaksperioder && tilPeriodeMedEndretKey(vedtaksperioder);
+    vedtaksperioder: Vedtaksperiode[] | undefined
+): VedtaksperiodeMedEndretKey[] => {
+    const perioderMedEndretKey = vedtaksperioder && tilVedtaksperiodeMedEndretKey(vedtaksperioder);
 
     return perioderMedEndretKey ?? [tomVedtaksperiode()];
 };
 
-export const tomVedtaksperiode = (): PeriodeMedEndretKey => ({
+export const tomVedtaksperiode = (): VedtaksperiodeMedEndretKey => ({
     fom: '',
     tom: '',
+    id: uuidv4(),
     endretKey: uuidv4(),
 });
+
+const tilVedtaksperiodeMedEndretKey = (utgifter: Vedtaksperiode[]): VedtaksperiodeMedEndretKey[] =>
+    utgifter.map((utgift) => ({ ...utgift, endretKey: uuidv4() }));

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -14,7 +14,6 @@ export interface DateInputProps {
     readOnly?: boolean;
     fromDate?: Date;
     toDate?: Date;
-    className?: string;
 }
 
 const DateInput: React.FC<DateInputProps> = ({
@@ -27,7 +26,6 @@ const DateInput: React.FC<DateInputProps> = ({
     readOnly = false,
     fromDate,
     toDate,
-    className,
 }) => {
     const { datepickerProps, inputProps } = useDatepicker({
         defaultSelected: nullableTilDato(value),
@@ -37,7 +35,7 @@ const DateInput: React.FC<DateInputProps> = ({
     });
 
     return (
-        <DatePicker {...datepickerProps} className={className}>
+        <DatePicker {...datepickerProps}>
             <DatePicker.Input
                 {...inputProps}
                 label={label}

--- a/src/frontend/komponenter/Skjema/DateInput.tsx
+++ b/src/frontend/komponenter/Skjema/DateInput.tsx
@@ -14,6 +14,7 @@ export interface DateInputProps {
     readOnly?: boolean;
     fromDate?: Date;
     toDate?: Date;
+    className?: string;
 }
 
 const DateInput: React.FC<DateInputProps> = ({
@@ -26,6 +27,7 @@ const DateInput: React.FC<DateInputProps> = ({
     readOnly = false,
     fromDate,
     toDate,
+    className,
 }) => {
     const { datepickerProps, inputProps } = useDatepicker({
         defaultSelected: nullableTilDato(value),
@@ -35,7 +37,7 @@ const DateInput: React.FC<DateInputProps> = ({
     });
 
     return (
-        <DatePicker {...datepickerProps}>
+        <DatePicker {...datepickerProps} className={className}>
             <DatePicker.Input
                 {...inputProps}
                 label={label}

--- a/src/frontend/komponenter/Skjema/DateInputMedLeservisning.tsx
+++ b/src/frontend/komponenter/Skjema/DateInputMedLeservisning.tsx
@@ -27,7 +27,14 @@ const DateInputMedLeservisning: React.FC<Props> = ({
             size={size}
         />
     ) : (
-        <DateInput {...props} label={label} hideLabel={hideLabel} value={value} size={size} />
+        <DateInput
+            {...props}
+            className={className}
+            label={label}
+            hideLabel={hideLabel}
+            value={value}
+            size={size}
+        />
     );
 };
 

--- a/src/frontend/komponenter/Skjema/DateInputMedLeservisning.tsx
+++ b/src/frontend/komponenter/Skjema/DateInputMedLeservisning.tsx
@@ -27,14 +27,7 @@ const DateInputMedLeservisning: React.FC<Props> = ({
             size={size}
         />
     ) : (
-        <DateInput
-            {...props}
-            className={className}
-            label={label}
-            hideLabel={hideLabel}
-            value={value}
-            size={size}
-        />
+        <DateInput {...props} label={label} hideLabel={hideLabel} value={value} size={size} />
     );
 };
 

--- a/src/frontend/typer/behandling/periodeStatus.ts
+++ b/src/frontend/typer/behandling/periodeStatus.ts
@@ -1,0 +1,5 @@
+export enum PeriodeStatus {
+    UENDRET = 'UENDRET',
+    ENDRET = 'ENDRET',
+    NY = 'NY',
+}

--- a/src/frontend/typer/vedtak/vedtakLæremidler.ts
+++ b/src/frontend/typer/vedtak/vedtakLæremidler.ts
@@ -1,17 +1,17 @@
 import { TypeVedtak, ÅrsakAvslag, ÅrsakOpphør } from './vedtak';
 import { Studienivå } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
-import { Periode } from '../../utils/periode';
+import { Vedtaksperiode } from '../../Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler';
 
 export type VedtakLæremidler = InnvilgelseLæremidler | AvslagLæremidler | OpphørLæremidler;
 
 export type InnvilgelseLæremidlerRequest = {
     type: TypeVedtak.INNVILGELSE;
-    vedtaksperioder: Periode[];
+    vedtaksperioder: Vedtaksperiode[];
 };
 
 export interface InnvilgelseLæremidler {
     type: TypeVedtak.INNVILGELSE;
-    vedtaksperioder: Periode[];
+    vedtaksperioder: Vedtaksperiode[];
     beregningsresultat: BeregningsresultatLæremidler;
     gjelderFraOgMed: string;
     gjelderTilOgMed: string;

--- a/src/frontend/typer/vedtak/vedtakLæremidler.ts
+++ b/src/frontend/typer/vedtak/vedtakLæremidler.ts
@@ -1,6 +1,7 @@
 import { TypeVedtak, ÅrsakAvslag, ÅrsakOpphør } from './vedtak';
 import { Studienivå } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
-import { Vedtaksperiode } from '../../Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler';
+import { Periode } from '../../utils/periode';
+import { PeriodeStatus } from '../behandling/periodeStatus';
 
 export type VedtakLæremidler = InnvilgelseLæremidler | AvslagLæremidler | OpphørLæremidler;
 
@@ -48,3 +49,8 @@ export type OpphørLæremidlerRequest = {
 };
 
 export type OpphørLæremidler = OpphørLæremidlerRequest;
+
+export interface Vedtaksperiode extends Periode {
+    id: string;
+    status?: PeriodeStatus;
+}

--- a/src/frontend/utils/periode.ts
+++ b/src/frontend/utils/periode.ts
@@ -1,15 +1,9 @@
-import { v4 as uuidv4 } from 'uuid';
-
 import { dagenFør, datoErIPeriodeInklusivSlutt, erDatoEtterEllerLik } from './dato';
 
 export type Periode = {
     fom: string;
     tom: string;
 };
-
-export interface PeriodeMedEndretKey extends Periode {
-    endretKey: string; // intern for re-rendring
-}
 
 export const validerPeriode = (
     periode: Periode,
@@ -83,6 +77,3 @@ const validerTomEtterEllerLikRevurderingsdato = (tom: string, tidligsteMuligeTom
         };
     }
 };
-
-export const tilPeriodeMedEndretKey = (utgifter: Periode[]): PeriodeMedEndretKey[] =>
-    utgifter.map((utgift) => ({ ...utgift, endretKey: uuidv4() }));


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

I revurdering av læremidler må beslutter kunne se hvilke perioder som er endret og hvilke som er nye, på lik linje som for stønadsperiodene. 

Koden er satt opp slik at det kan merges inn uten å påvirke noe eksisterende. Det er først når backend begynner å sende "id" og "status" at tagsene trer i kraft. 

## Nye perioder i en revurdering ser sånn ut:
Ørlite eyetwitch at tagsene ikke er heeelt sentrert 🥲 Fant ikke ut av hvorfor det skjer. Noen med bedre forståelse av CSS enn meg kan jo prøve å fikse. 
![image](https://github.com/user-attachments/assets/13dad307-15a6-4bf4-97c0-b9a6a407846f)

## Førstegangsbehandling (eller revurdering uten endringer i backend først) blir ikke påvirket: 
Lesemodus:
![image](https://github.com/user-attachments/assets/402b5d55-51d3-4d71-aff7-508eba8d02f7)
Endringsmodus: 
![image](https://github.com/user-attachments/assets/d527b8c8-b2cc-4e39-b55c-42b7cad4b745)

