### PR TITLE
Skal gjenbruke forrige vedtak hvis riktig type, i stedet for å typecaste

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -13,10 +13,10 @@ import Panel from '../../../../komponenter/Panel/Panel';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { TypeVedtak } from '../../../../typer/vedtak/vedtak';
 import {
-    AvslagBarnetilsyn,
-    InnvilgelseBarnetilsyn,
-    OpphørBarnetilsyn,
     VedtakBarnetilsyn,
+    vedtakErAvslag,
+    vedtakErInnvilgelse,
+    vedtakErOpphør,
 } from '../../../../typer/vedtak/vedtakTilsynBarn';
 import VelgVedtakResultat from '../Felles/VelgVedtakResultat';
 
@@ -50,16 +50,22 @@ const VedtakOgBeregningBarnetilsyn: FC = () => {
                                     settTypeVedtak={settTypeVedtak}
                                 />
                                 {typeVedtak === TypeVedtak.AVSLAG && (
-                                    <AvslåVedtak vedtak={vedtak as AvslagBarnetilsyn} />
+                                    <AvslåVedtak
+                                        vedtak={vedtakErAvslag(vedtak) ? vedtak : undefined}
+                                    />
                                 )}
                                 {typeVedtak === TypeVedtak.OPPHØR && (
-                                    <OpphørVedtak vedtak={vedtak as OpphørBarnetilsyn} />
+                                    <OpphørVedtak
+                                        vedtak={vedtakErOpphør(vedtak) ? vedtak : undefined}
+                                    />
                                 )}
                             </HGrid>
                         </Panel>
 
                         {typeVedtak === TypeVedtak.INNVILGELSE && (
-                            <InnvilgeBarnetilsyn lagretVedtak={vedtak as InnvilgelseBarnetilsyn} />
+                            <InnvilgeBarnetilsyn
+                                lagretVedtak={vedtakErInnvilgelse(vedtak) ? vedtak : undefined}
+                            />
                         )}
                     </Container>
                 )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
@@ -11,9 +11,9 @@ import Panel from '../../../../komponenter/Panel/Panel';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { TypeVedtak } from '../../../../typer/vedtak/vedtak';
 import {
-    AvslagLæremidler,
-    InnvilgelseLæremidler,
-    OpphørLæremidler,
+    vedtakErInnvilgelse,
+    vedtakErAvslag,
+    vedtakErOpphør,
     VedtakLæremidler,
 } from '../../../../typer/vedtak/vedtakLæremidler';
 import VelgVedtakResultat from '../Felles/VelgVedtakResultat';
@@ -51,17 +51,19 @@ const VedtakOgBeregningLæremidler: FC = () => {
                                 />
                             }
                             {typeVedtak === TypeVedtak.AVSLAG && (
-                                <AvslåVedtak vedtak={vedtak as AvslagLæremidler} />
+                                <AvslåVedtak vedtak={vedtakErAvslag(vedtak) ? vedtak : undefined} />
                             )}
                             {typeVedtak === TypeVedtak.OPPHØR && (
-                                <OpphørVedtak vedtak={vedtak as OpphørLæremidler} />
+                                <OpphørVedtak
+                                    vedtak={vedtakErOpphør(vedtak) ? vedtak : undefined}
+                                />
                             )}
                         </HGrid>
                     </Panel>
 
                     {typeVedtak === TypeVedtak.INNVILGELSE && (
                         <InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling
-                            lagretVedtak={vedtak as InnvilgelseLæremidler}
+                            lagretVedtak={vedtakErInnvilgelse(vedtak) ? vedtak : undefined}
                         />
                     )}
                 </Container>

--- a/src/frontend/typer/vedtak/vedtakLæremidler.ts
+++ b/src/frontend/typer/vedtak/vedtakLæremidler.ts
@@ -5,6 +5,15 @@ import { PeriodeStatus } from '../behandling/periodeStatus';
 
 export type VedtakLæremidler = InnvilgelseLæremidler | AvslagLæremidler | OpphørLæremidler;
 
+export const vedtakErInnvilgelse = (vedtak: VedtakLæremidler): vedtak is InnvilgelseLæremidler =>
+    vedtak.type === TypeVedtak.INNVILGELSE;
+
+export const vedtakErAvslag = (vedtak: VedtakLæremidler): vedtak is AvslagLæremidler =>
+    vedtak.type === TypeVedtak.AVSLAG;
+
+export const vedtakErOpphør = (vedtak: VedtakLæremidler): vedtak is OpphørLæremidler =>
+    vedtak.type === TypeVedtak.OPPHØR;
+
 export type InnvilgelseLæremidlerRequest = {
     type: TypeVedtak.INNVILGELSE;
     vedtaksperioder: Vedtaksperiode[];

--- a/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
+++ b/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
@@ -4,10 +4,14 @@ import { MålgruppeType } from '../../Sider/Behandling/Inngangsvilkår/typer/vil
 
 export type VedtakBarnetilsyn = InnvilgelseBarnetilsyn | AvslagBarnetilsyn | OpphørBarnetilsyn;
 
-export const erVedtakInnvilgelse = (vedtak: VedtakBarnetilsyn): vedtak is InnvilgelseBarnetilsyn =>
+export const vedtakErInnvilgelse = (vedtak: VedtakBarnetilsyn): vedtak is InnvilgelseBarnetilsyn =>
     vedtak.type === TypeVedtak.INNVILGELSE;
 
-export const vedtakErAvslag = (vedtak: VedtakBarnetilsyn) => vedtak.type === TypeVedtak.AVSLAG;
+export const vedtakErAvslag = (vedtak: VedtakBarnetilsyn): vedtak is AvslagBarnetilsyn =>
+    vedtak.type === TypeVedtak.AVSLAG;
+
+export const vedtakErOpphør = (vedtak: VedtakBarnetilsyn): vedtak is OpphørBarnetilsyn =>
+    vedtak.type === TypeVedtak.OPPHØR;
 
 export type InnvilgeBarnetilsynRequest = {
     type: TypeVedtak.INNVILGELSE;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
- Hvis man i en revurdering først setter avslag og sen innvilgelse er det ønskelig å ikke sende med et typcastet avslag videre til innvilgelseskomponenten, men at man faktiskt henter forrige vedtak sånn at man får gjenbrukt perioder fra forrige behandling


https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24180

Et alternativ er å gjøre en hjelpemetode
```typescript
export const vedtakHvisType = <VEDTAK extends VedtakResponse, RESULT extends VEDTAK>(
    vedtak: VEDTAK,
    typechecker: (vedtak: VEDTAK) => vedtak is RESULT
): RESULT | undefined => {
    if (typechecker(vedtak)) {
        return vedtak;
    }
    return undefined;
};

// og bruke som
{typeVedtak === TypeVedtak.INNVILGELSE && (
  <InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling
    lagretVedtak={vedtakHvisType(vedtak, vedtakErInnvilgelse)}
  />
)}
```