### PR TITLE
Vedtaksperiode læremidler endre dato før revurder-fra

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -27,6 +27,7 @@ import { FanePath } from '../../../faner';
 import { StønadsperiodeListe } from '../../../Stønadsvilkår/OppsummeringStønadsperioder';
 import { initialiserVedtaksperioder } from '../vedtakLæremidlerUtils';
 import { validerVedtaksperioder } from './validering';
+import { useMapById } from '../../../../../hooks/useMapById';
 
 export const InnvilgeLæremidler: React.FC<{
     lagretVedtak: InnvilgelseLæremidler | undefined;
@@ -38,10 +39,13 @@ export const InnvilgeLæremidler: React.FC<{
 
     const { stønadsperioder } = useStønadsperioder(behandling.id);
 
-    const lagredeVedtaksperioder =
-        lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling;
     const [vedtaksperioder, settVedtaksperioder] = useState<Vedtaksperiode[]>(
-        initialiserVedtaksperioder(lagredeVedtaksperioder)
+        initialiserVedtaksperioder(
+            lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling
+        )
+    );
+    const lagredeVedtaksperioder = useMapById(
+        lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling || []
     );
     const [visHarIkkeBeregnetFeilmelding, settVisHarIkkeBeregnetFeilmelding] = useState<boolean>();
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -39,10 +39,10 @@ export const InnvilgeLæremidler: React.FC<{
 
     const { stønadsperioder } = useStønadsperioder(behandling.id);
 
+    const lagredeVedtaksperioder =
+        lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling;
     const [vedtaksperioder, settVedtaksperioder] = useState<Vedtaksperiode[]>(
-        initialiserVedtaksperioder(
-            lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling
-        )
+        initialiserVedtaksperioder(lagredeVedtaksperioder)
     );
     const [visHarIkkeBeregnetFeilmelding, settVisHarIkkeBeregnetFeilmelding] = useState<boolean>();
 
@@ -111,6 +111,7 @@ export const InnvilgeLæremidler: React.FC<{
                 </DataViewer>
                 <Vedtaksperioder
                     vedtaksperioder={vedtaksperioder}
+                    lagredeVedtaksperioder={lagredeVedtaksperioder}
                     settVedtaksperioder={settVedtaksperioder}
                     vedtaksperioderFeil={vedtaksperiodeFeil}
                     settVedtaksperioderFeil={settVedtaksperiodeFeil}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -22,13 +22,12 @@ import {
     InnvilgelseLæremidlerRequest,
     Vedtaksperiode,
 } from '../../../../../typer/vedtak/vedtakLæremidler';
-import { Periode, validerPeriode } from '../../../../../utils/periode';
+import { Periode } from '../../../../../utils/periode';
 import { FanePath } from '../../../faner';
 import { StønadsperiodeListe } from '../../../Stønadsvilkår/OppsummeringStønadsperioder';
 import { initialiserVedtaksperioder } from '../vedtakLæremidlerUtils';
+import { validerVedtaksperioder } from './validering';
 
-export const validerVedtaksperioder = (vedtaksperioder: Vedtaksperiode[]) =>
-    vedtaksperioder.map((periode) => validerPeriode(periode) as FormErrors<Periode>);
 export const InnvilgeLæremidler: React.FC<{
     lagretVedtak: InnvilgelseLæremidler | undefined;
     vedtaksperioderForrigeBehandling: Vedtaksperiode[] | undefined;
@@ -71,7 +70,11 @@ export const InnvilgeLæremidler: React.FC<{
     };
 
     const validerForm = (): boolean => {
-        const vedtaksperiodeFeil = validerVedtaksperioder(vedtaksperioder);
+        const vedtaksperiodeFeil = validerVedtaksperioder(
+            vedtaksperioder,
+            lagredeVedtaksperioder,
+            behandling.revurderFra
+        );
         settVedtaksperiodeFeil(vedtaksperiodeFeil);
 
         return isValid(vedtaksperiodeFeil);

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -7,6 +7,7 @@ import { useBehandling } from '../../../../../context/BehandlingContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
 import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInputMedLeservisning';
+import { FeilmeldingMaksBredde } from '../../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { BehandlingType } from '../../../../../typer/behandling/behandlingType';
 import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakLæremidler';
 import { Periode } from '../../../../../utils/periode';
@@ -43,26 +44,30 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
 
     return (
         <>
-            <DateInputMedLeservisning
-                label="Fra"
-                hideLabel
-                erLesevisning={erLesevisning}
-                readOnly={!alleFelterKanEndres}
-                value={vedtaksperiode.fom}
-                onChange={(dato?: string) => oppdaterPeriode('fom', dato)}
-                feil={vedtaksperiodeFeil?.fom}
-                size="small"
-            />
-            <DateInputMedLeservisning
-                label="Til"
-                hideLabel
-                erLesevisning={erLesevisning}
-                readOnly={helePeriodenErLåstForEndring}
-                value={vedtaksperiode.tom}
-                onChange={(dato?: string) => oppdaterPeriode('tom', dato)}
-                feil={vedtaksperiodeFeil?.tom}
-                size="small"
-            />
+            <FeilmeldingMaksBredde>
+                <DateInputMedLeservisning
+                    label="Fra"
+                    hideLabel
+                    erLesevisning={erLesevisning}
+                    readOnly={!alleFelterKanEndres}
+                    value={vedtaksperiode.fom}
+                    onChange={(dato?: string) => oppdaterPeriode('fom', dato)}
+                    feil={vedtaksperiodeFeil?.fom}
+                    size="small"
+                />
+            </FeilmeldingMaksBredde>
+            <FeilmeldingMaksBredde>
+                <DateInputMedLeservisning
+                    label="Til"
+                    hideLabel
+                    erLesevisning={erLesevisning}
+                    readOnly={helePeriodenErLåstForEndring}
+                    value={vedtaksperiode.tom}
+                    onChange={(dato?: string) => oppdaterPeriode('tom', dato)}
+                    feil={vedtaksperiodeFeil?.tom}
+                    size="small"
+                />
+            </FeilmeldingMaksBredde>
             <div>
                 {erLesevisning
                     ? erRevurdering && <StatusTag status={vedtaksperiode.status} />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -14,6 +14,7 @@ import { StatusTag } from '../../../Inngangsvilkår/Stønadsperioder/StatusTag';
 
 interface Props {
     vedtaksperiode: Vedtaksperiode;
+    lagretVedtaksperiode: Vedtaksperiode | undefined;
     erLesevisning: boolean;
     vedtaksperiodeFeil: FormErrors<Periode> | undefined;
     oppdaterPeriode: (property: 'fom' | 'tom', value: string | undefined) => void;
@@ -23,6 +24,7 @@ interface Props {
 
 export const VedtaksperiodeRad: React.FC<Props> = ({
     vedtaksperiode,
+    lagretVedtaksperiode,
     erLesevisning,
     vedtaksperiodeFeil,
     oppdaterPeriode,
@@ -32,8 +34,8 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
     const { behandling } = useBehandling();
     const { alleFelterKanEndres, helePeriodenErLåstForEndring, kanSlettePeriode } =
         useRevurderingAvPerioder({
-            periodeFom: vedtaksperiode.fom,
-            periodeTom: vedtaksperiode.tom,
+            periodeFom: lagretVedtaksperiode?.fom,
+            periodeTom: lagretVedtaksperiode?.tom,
             nyRadLeggesTil: erNyRad,
         });
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,7 +27,7 @@ const Grid = styled.div`
 
 interface Props {
     vedtaksperioder: Vedtaksperiode[];
-    lagredeVedtaksperioder: Vedtaksperiode[] | undefined;
+    lagredeVedtaksperioder: Map<string, Vedtaksperiode>;
     settVedtaksperioder: React.Dispatch<React.SetStateAction<Vedtaksperiode[]>>;
     vedtaksperioderFeil?: FormErrors<Periode>[];
     settVedtaksperioderFeil: React.Dispatch<
@@ -46,18 +46,6 @@ export const Vedtaksperioder: React.FC<Props> = ({
     const { settUlagretKomponent } = useApp();
 
     const [idNyeRader, settIdNyeRader] = useState<Set<string>>(new Set());
-
-    const lagredeVedtaksperioderObjekt = useMemo(
-        () =>
-            (lagredeVedtaksperioder || []).reduce(
-                (prev, current) => {
-                    prev[current.id] = current;
-                    return prev;
-                },
-                {} as Record<string, Vedtaksperiode>
-            ),
-        [lagredeVedtaksperioder]
-    );
 
     const oppdaterPeriodeFelt = (
         indeks: number,
@@ -111,7 +99,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                         <VedtaksperiodeRad
                             key={vedtaksperiode.id}
                             vedtaksperiode={vedtaksperiode}
-                            lagretVedtaksperiode={lagredeVedtaksperioderObjekt[vedtaksperiode.id]}
+                            lagretVedtaksperiode={lagredeVedtaksperioder.get(vedtaksperiode.id)}
                             erLesevisning={!erStegRedigerbart}
                             oppdaterPeriode={(property, value) => {
                                 oppdaterPeriodeFelt(indeks, property, value);

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useMemo, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -27,6 +27,7 @@ const Grid = styled.div`
 
 interface Props {
     vedtaksperioder: Vedtaksperiode[];
+    lagredeVedtaksperioder: Vedtaksperiode[] | undefined;
     settVedtaksperioder: React.Dispatch<React.SetStateAction<Vedtaksperiode[]>>;
     vedtaksperioderFeil?: FormErrors<Periode>[];
     settVedtaksperioderFeil: React.Dispatch<
@@ -36,6 +37,7 @@ interface Props {
 
 export const Vedtaksperioder: React.FC<Props> = ({
     vedtaksperioder,
+    lagredeVedtaksperioder,
     settVedtaksperioder,
     vedtaksperioderFeil,
     settVedtaksperioderFeil,
@@ -44,6 +46,18 @@ export const Vedtaksperioder: React.FC<Props> = ({
     const { settUlagretKomponent } = useApp();
 
     const [idNyeRader, settIdNyeRader] = useState<Set<string>>(new Set());
+
+    const lagredeVedtaksperioderObjekt = useMemo(
+        () =>
+            (lagredeVedtaksperioder || []).reduce(
+                (prev, current) => {
+                    prev[current.id] = current;
+                    return prev;
+                },
+                {} as Record<string, Vedtaksperiode>
+            ),
+        [lagredeVedtaksperioder]
+    );
 
     const oppdaterPeriodeFelt = (
         indeks: number,
@@ -97,6 +111,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                         <VedtaksperiodeRad
                             key={vedtaksperiode.id}
                             vedtaksperiode={vedtaksperiode}
+                            lagretVedtaksperiode={lagredeVedtaksperioderObjekt[vedtaksperiode.id]}
                             erLesevisning={!erStegRedigerbart}
                             oppdaterPeriode={(property, value) => {
                                 oppdaterPeriodeFelt(indeks, property, value);

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/validering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/validering.ts
@@ -1,0 +1,29 @@
+import { FormErrors } from '../../../../../hooks/felles/useFormState';
+import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakLæremidler';
+import { Periode, validerPeriode } from '../../../../../utils/periode';
+
+export const validerVedtaksperioder = (
+    vedtaksperioder: Vedtaksperiode[],
+    lagredeVedstaksperioder: Vedtaksperiode[] | undefined,
+    revurderesFraDato?: string
+): FormErrors<Periode[]> =>
+    vedtaksperioder.map((periode) => {
+        const feil: FormErrors<Periode> = {
+            fom: undefined,
+            tom: undefined,
+        };
+
+        const lagretPeriode = (lagredeVedstaksperioder || []).find(
+            (lagretVedtaksperiode) => lagretVedtaksperiode.id === periode.id
+        );
+
+        const periodeValidering = validerPeriode(periode, lagretPeriode, revurderesFraDato);
+        if (periodeValidering) {
+            return {
+                ...feil,
+                ...periodeValidering,
+            };
+        }
+
+        return feil;
+    });

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/validering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/validering.ts
@@ -4,7 +4,7 @@ import { Periode, validerPeriode } from '../../../../../utils/periode';
 
 export const validerVedtaksperioder = (
     vedtaksperioder: Vedtaksperiode[],
-    lagredeVedstaksperioder: Vedtaksperiode[] | undefined,
+    lagredeVedstaksperioder: Map<string, Vedtaksperiode>,
     revurderesFraDato?: string
 ): FormErrors<Periode[]> =>
     vedtaksperioder.map((periode) => {
@@ -13,9 +13,7 @@ export const validerVedtaksperioder = (
             tom: undefined,
         };
 
-        const lagretPeriode = (lagredeVedstaksperioder || []).find(
-            (lagretVedtaksperiode) => lagretVedtaksperiode.id === periode.id
-        );
+        const lagretPeriode = lagredeVedstaksperioder.get(periode.id);
 
         const periodeValidering = validerPeriode(periode, lagretPeriode, revurderesFraDato);
         if (periodeValidering) {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/vedtakLæremidlerUtils.ts
@@ -5,7 +5,7 @@ import { Vedtaksperiode } from '../../../../typer/vedtak/vedtakLæremidler';
 export const initialiserVedtaksperioder = (
     vedtaksperioder: Vedtaksperiode[] | undefined
 ): Vedtaksperiode[] => {
-    return vedtaksperioder ?? [tomVedtaksperiode()];
+    return vedtaksperioder?.length ? vedtaksperioder : [tomVedtaksperiode()];
 };
 
 export const tomVedtaksperiode = (): Vedtaksperiode => ({

--- a/src/frontend/hooks/useMapById.ts
+++ b/src/frontend/hooks/useMapById.ts
@@ -1,0 +1,11 @@
+import { useMemo } from 'react';
+
+/**
+ * Mapper om en liste til Map for å enkelt kunne hente ut et objekt ut fra id
+ */
+export const useMapById = <T extends { id: string }>(list: T[]): Map<string, T> =>
+    useMemo(() => {
+        const map = new Map<string, T>();
+        list.forEach((item) => map.set(item.id, item));
+        return map;
+    }, [list]);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24129

* Det var tidligere mulig å sette datoet før revurder fra og de ble då låste
  * Dette er løst med at perioder blir låste i forhold til perioden for den opprinnelige perioden var. På lik måte som det gjøres i stønadsperioder idag

* Lagt til at man validerer fom/tom mot revurder fra
