### PR TITLE
✨ Legg til behandlingsinfo på vedtakssiden for tilsyn barn

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/BehandlingInfo.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/BehandlingInfo.tsx
@@ -1,0 +1,118 @@
+import React, { useCallback, useEffect, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { BodyShort, HGrid, HStack, VStack } from '@navikt/ds-react';
+
+import { useApp } from '../../../../../context/AppContext';
+import { useVilkårperioder } from '../../../../../hooks/useVilkårperioder';
+import DataViewer from '../../../../../komponenter/DataViewer';
+import { VilkårsresultatIkon } from '../../../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
+import { BehandlingFaktaTilsynBarn } from '../../../../../typer/behandling/behandlingFakta/behandlingFakta';
+import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../../../typer/ressurs';
+import { formaterNullablePeriode } from '../../../../../utils/dato';
+import { aktivitetTypeTilTekst } from '../../../Inngangsvilkår/Aktivitet/utilsAktivitet';
+import { målgruppeTypeTilTekst } from '../../../Inngangsvilkår/typer/vilkårperiode/målgruppe';
+import { VilkårPeriodeResultat } from '../../../Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
+import { Vilkårsresultat, Vilkårsvurdering } from '../../../vilkår';
+
+const StyledHGrid = styled(HGrid)<{ bottomBorder?: boolean }>`
+    padding-bottom: 1rem;
+    ${(props) => props.bottomBorder && `border-bottom: solid 1px white;`}
+`;
+
+export const BehandlingInfo: React.FC<{ behandlingId: string }> = ({ behandlingId }) => {
+    const { request } = useApp();
+    const { vilkårperioderResponse } = useVilkårperioder(behandlingId);
+
+    const [vilkårsvurdering, settVilkårsvurdering] =
+        useState<Ressurs<Vilkårsvurdering>>(byggTomRessurs());
+
+    const hentVilkårsvurdering = useCallback(() => {
+        settVilkårsvurdering(byggHenterRessurs());
+        return request<Vilkårsvurdering, void>(`/api/sak/vilkar/${behandlingId}`).then(
+            settVilkårsvurdering
+        );
+    }, [request, behandlingId]);
+
+    useEffect(() => {
+        hentVilkårsvurdering();
+    }, [hentVilkårsvurdering]);
+
+    const finnBarnNavn = (
+        barnId: string | undefined,
+        behandlingFakta: BehandlingFaktaTilsynBarn
+    ) => {
+        return behandlingFakta.barn.find((barn) => barn.barnId === barnId)?.registergrunnlag.navn;
+    };
+
+    return (
+        <DataViewer response={{ vilkårsvurdering, vilkårperioderResponse }}>
+            {({ vilkårsvurdering, vilkårperioderResponse }) => (
+                <VStack gap={'6'}>
+                    <StyledHGrid bottomBorder columns={'125px auto'}>
+                        <BodyShort>Aktivitet</BodyShort>
+                        <VStack>
+                            {vilkårperioderResponse.vilkårperioder.aktiviteter.map((aktivitet) => (
+                                <InfoRad
+                                    key={aktivitet.id}
+                                    resultat={aktivitet.resultat}
+                                    fom={aktivitet.fom}
+                                    tom={aktivitet.tom}
+                                    gjelder={aktivitetTypeTilTekst(aktivitet.type)}
+                                />
+                            ))}
+                        </VStack>
+                    </StyledHGrid>
+                    <StyledHGrid bottomBorder columns={'125px auto'}>
+                        <BodyShort>Målgruppe</BodyShort>
+                        <VStack>
+                            {vilkårperioderResponse.vilkårperioder.målgrupper.map((målgruppe) => (
+                                <InfoRad
+                                    key={målgruppe.id}
+                                    resultat={målgruppe.resultat}
+                                    fom={målgruppe.fom}
+                                    tom={målgruppe.tom}
+                                    gjelder={målgruppeTypeTilTekst(målgruppe.type)}
+                                />
+                            ))}
+                        </VStack>
+                    </StyledHGrid>
+                    <StyledHGrid columns={'125px auto'}>
+                        <BodyShort>Pass av barn</BodyShort>
+                        <VStack gap={'2'}>
+                            {vilkårsvurdering.vilkårsett.map((vilkår) => (
+                                <InfoRad
+                                    key={vilkår.id}
+                                    resultat={vilkår.resultat}
+                                    fom={vilkår.fom}
+                                    tom={vilkår.tom}
+                                    gjelder={finnBarnNavn(
+                                        vilkår.barnId,
+                                        vilkårsvurdering.grunnlag as BehandlingFaktaTilsynBarn
+                                    )}
+                                />
+                            ))}
+                        </VStack>
+                    </StyledHGrid>
+                </VStack>
+            )}
+        </DataViewer>
+    );
+};
+
+interface InfoRadProps {
+    resultat: VilkårPeriodeResultat | Vilkårsresultat;
+    fom?: string;
+    tom?: string;
+    gjelder?: string;
+}
+
+const InfoRad: React.FC<InfoRadProps> = ({ resultat, fom, tom, gjelder }) => {
+    return (
+        <HStack gap={'2'} align={'center'}>
+            <VilkårsresultatIkon vilkårsresultat={resultat} height={18} width={18} />
+            <BodyShort>{`${formaterNullablePeriode(fom, tom)}: ${gjelder}`}</BodyShort>
+        </HStack>
+    );
+};

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsynV2.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsynV2.tsx
@@ -25,6 +25,7 @@ import {
 import { FanePath } from '../../../faner';
 import { lenkerBeregningTilsynBarn } from '../../../lenker';
 import { initialiserVedtaksperioder } from '../VedtakBarnetilsynUtils';
+import { BehandlingInfo } from './BehandlingInfo';
 
 interface Props {
     lagretVedtak?: InnvilgelseBarnetilsyn;
@@ -119,6 +120,7 @@ export const InnvilgeBarnetilsynV2: React.FC<Props> = ({
     return (
         <>
             <Panel tittel="Beregning" ekstraHeading={<HeadingBeregning />}>
+                <BehandlingInfo behandlingId={behandling.id} />
                 <Vedtaksperioder
                     vedtaksperioder={vedtaksperioder}
                     settVedtaksperioder={settVedtaksperioder}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Viser valg som saksbehandler har gjort tidligere i behandlingen for å enklere kunne sette vedtaksperioder.
Det som er i den rød boksen er nytt

<img width="1247" alt="image" src="https://github.com/user-attachments/assets/b2e77bbb-64e4-4e65-a015-ab01223386c8" />
