### PR TITLE
Skal sjekke totrinnstatus innenfor provideren til contexten

### DIFF
--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -12,6 +12,7 @@ import { VedtakFerdigstiltModal } from './VedtakFerdigstiltModal';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { BrevFeilContextProvider } from '../../../context/BrevFeilContext';
 import { usePersonopplysninger } from '../../../context/PersonopplysningerContext';
+import { useTotrinnskontroll } from '../../../context/TotrinnskontrollContext';
 import { useContextBrevmottakereSak } from '../../../hooks/useBrevmottakere';
 import { useVedtak } from '../../../hooks/useVedtak';
 import Brevmeny from '../../../komponenter/Brev/Brevmeny';
@@ -23,6 +24,7 @@ import BrevMottakere from '../../../komponenter/Brevmottakere/BrevMottakere';
 import DataViewer from '../../../komponenter/DataViewer';
 import PdfVisning from '../../../komponenter/PdfVisning';
 import { RessursStatus } from '../../../typer/ressurs';
+import { TotrinnskontrollStatus } from '../Totrinnskontroll/typer';
 
 const Container = styled.div`
     padding: 2rem;
@@ -59,6 +61,8 @@ const Brev: React.FC = () => {
 
     const { vedtak } = useVedtak();
 
+    const { totrinnskontroll } = useTotrinnskontroll();
+
     useEffect(() => {
         const brevmalFraMellomlagerErGyldigForResultat =
             mellomlagretBrev.status === RessursStatus.SUKSESS &&
@@ -81,6 +85,10 @@ const Brev: React.FC = () => {
             hentMalStruktur();
         }
     }, [behandlingErRedigerbar, hentMalStruktur]);
+
+    const kanSendeKommentarTilBeslutter =
+        totrinnskontroll.status === RessursStatus.SUKSESS &&
+        totrinnskontroll.data?.status === TotrinnskontrollStatus.TOTRINNSKONTROLL_UNDERKJENT;
 
     return (
         <Container>
@@ -114,6 +122,8 @@ const Brev: React.FC = () => {
                                                     tittel: 'Send til beslutter',
                                                     onClick: sendTilBeslutter,
                                                     visKnapp: true,
+                                                    kanSendeKommentarTilBeslutter:
+                                                        kanSendeKommentarTilBeslutter,
                                                 }}
                                             />
                                         )}

--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, Button, List, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, List, Textarea, VStack } from '@navikt/ds-react';
 
 import { MalStruktur, Valg, Valgfelt } from './typer';
 import { FeilIDelmal, FeilIDelmalType, useBrevFeilContext } from '../../context/BrevFeilContext';
@@ -22,6 +22,7 @@ interface Props {
     inkluderteDelmaler: Record<string, boolean>;
     valgfelt: Partial<Record<string, Record<Valgfelt['_id'], Valg>>>;
     variabler: Partial<Record<string, string>>;
+    kanSendeKommentarTilBeslutter?: boolean;
 }
 
 export const Brevknapp = ({
@@ -31,12 +32,12 @@ export const Brevknapp = ({
     inkluderteDelmaler,
     valgfelt,
     variabler,
+    kanSendeKommentarTilBeslutter = false,
 }: Props) => {
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<string>();
-    //const [kommentarTilBeslutter, settKommentarTilBeslutter] = useState<string>();
+    const [kommentarTilBeslutter, settKommentarTilBeslutter] = useState<string>();
     const { oppdaterMangelIBrev } = useBrevFeilContext();
-    //const { totrinnskontroll } = useTotrinnskontroll();
 
     const trykkPåKnapp = () => {
         settFeilmelding(undefined);
@@ -49,23 +50,16 @@ export const Brevknapp = ({
 
         settLaster(true);
 
-        // TODO undefined
-        onClick(undefined)
+        onClick(kommentarTilBeslutter)
             .catch((error) =>
                 settFeilmelding(error instanceof Error ? error.message : String(error))
             )
             .finally(() => settLaster(false));
     };
 
-    /*
-    const kanGiKommentarTilBeslutter =
-        totrinnskontroll.status === RessursStatus.SUKSESS &&
-        totrinnskontroll.data?.status === TotrinnskontrollStatus.TOTRINNSKONTROLL_UNDERKJENT;
-     */
-
     return (
         <VStack gap={'2'}>
-            {/*kanGiKommentarTilBeslutter && (
+            {kanSendeKommentarTilBeslutter && (
                 <Textarea
                     label="Kommentar til beslutter"
                     description="Skal kun brukes til intern dialog med beslutter. Endelige vurderinger skal skrives i respektive begrunnelsesfelt."
@@ -73,8 +67,7 @@ export const Brevknapp = ({
                     onChange={(e) => settKommentarTilBeslutter(e.target.value)}
                     style={{ maxWidth: '400px' }}
                 />
-            )*/}
-
+            )}
             <Knapp onClick={trykkPåKnapp} disabled={laster} size="small">
                 {tittel}
             </Knapp>

--- a/src/frontend/komponenter/Brev/Brevmeny.tsx
+++ b/src/frontend/komponenter/Brev/Brevmeny.tsx
@@ -24,6 +24,7 @@ type Props = {
         tittel: string;
         onClick: (kommentarTilBeslutter: string | undefined) => Promise<void>;
         visKnapp: boolean;
+        kanSendeKommentarTilBeslutter?: boolean;
     };
 } & (
     | { behandling: Behandling; vedtak?: VedtakResponse; fagsakId?: never }
@@ -196,6 +197,7 @@ const Brevmeny: React.FC<Props> = ({
                     inkluderteDelmaler={inkluderteDelmaler}
                     valgfelt={valgfelt}
                     variabler={variabler}
+                    kanSendeKommentarTilBeslutter={brevknapp.kanSendeKommentarTilBeslutter}
                 />
             )}
         </FlexColumn>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
I PR #694 bruktes `useTotrinnskontroll` utenfor provideren fordi brevknapp både brukes i behandling og frittstående brev. Har nå flyttet dette lenger ut slik at brevknappen i frittstående brev ikke trigger feilmelding. 