### PR TITLE
🦺 Skal ikke låse felter når man endrer fom/tom før revurder fra dato

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsynV2.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsynV2.tsx
@@ -25,6 +25,7 @@ import { FanePath } from '../../../faner';
 import { lenkerBeregningTilsynBarn } from '../../../lenker';
 import { initialiserVedtaksperioder } from '../VedtakBarnetilsynUtils';
 import { BehandlingInfo } from './BehandlingInfo';
+import { useMapById } from '../../../../../hooks/useMapById';
 
 interface Props {
     lagretVedtak?: InnvilgelseBarnetilsyn;
@@ -58,6 +59,11 @@ export const InnvilgeBarnetilsynV2: React.FC<Props> = ({
             lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling
         )
     );
+
+    const lagredeVedtaksperioder = useMapById(
+        lagretVedtak?.vedtaksperioder || vedtaksperioderForrigeBehandling || []
+    );
+
     const [vedtaksperiodeFeil, settVedtaksperiodeFeil] =
         useState<FormErrors<VedtaksperiodeTilsynBarn>[]>();
     const [foreslåPeriodeFeil, settForeslåPeriodeFeil] = useState<string>();
@@ -87,7 +93,7 @@ export const InnvilgeBarnetilsynV2: React.FC<Props> = ({
     const validerForm = (): boolean => {
         const vedtaksperiodeFeil = validerVedtaksperioder(
             vedtaksperioder,
-            vedtaksperioderForrigeBehandling,
+            lagredeVedtaksperioder,
             behandling.revurderFra
         );
         settVedtaksperiodeFeil(vedtaksperiodeFeil);
@@ -122,6 +128,7 @@ export const InnvilgeBarnetilsynV2: React.FC<Props> = ({
                 <BehandlingInfo behandlingId={behandling.id} />
                 <Vedtaksperioder
                     vedtaksperioder={vedtaksperioder}
+                    lagredeVedtaksperioder={lagredeVedtaksperioder}
                     settVedtaksperioder={settVedtaksperioder}
                     vedtaksperioderFeil={vedtaksperiodeFeil}
                     settVedtaksperioderFeil={settVedtaksperiodeFeil}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/VedtaksperiodeRad.tsx
@@ -22,6 +22,7 @@ import {
 
 interface Props {
     vedtaksperiode: VedtaksperiodeTilsynBarn;
+    lagretVedtaksperiode: VedtaksperiodeTilsynBarn | undefined;
     erLesevisning: boolean;
     vedtaksperiodeFeil: FormErrors<VedtaksperiodeTilsynBarn> | undefined;
     oppdaterPeriode: (
@@ -34,6 +35,7 @@ interface Props {
 
 export const VedtaksperiodeRad: React.FC<Props> = ({
     vedtaksperiode,
+    lagretVedtaksperiode,
     erLesevisning,
     vedtaksperiodeFeil,
     oppdaterPeriode,
@@ -43,8 +45,8 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
     const { behandling } = useBehandling();
     const { alleFelterKanEndres, helePeriodenErLåstForEndring, kanSlettePeriode } =
         useRevurderingAvPerioder({
-            periodeFom: vedtaksperiode.fom,
-            periodeTom: vedtaksperiode.tom,
+            periodeFom: lagretVedtaksperiode?.fom,
+            periodeTom: lagretVedtaksperiode?.tom,
             nyRadLeggesTil: erNyRad,
         });
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -29,6 +29,7 @@ const Grid = styled.div`
 
 interface Props {
     vedtaksperioder: VedtaksperiodeTilsynBarn[];
+    lagredeVedtaksperioder: Map<string, VedtaksperiodeTilsynBarn>;
     settVedtaksperioder: React.Dispatch<React.SetStateAction<VedtaksperiodeTilsynBarn[]>>;
     vedtaksperioderFeil?: FormErrors<VedtaksperiodeTilsynBarn>[];
     settVedtaksperioderFeil: React.Dispatch<
@@ -40,6 +41,7 @@ interface Props {
 
 export const Vedtaksperioder: React.FC<Props> = ({
     vedtaksperioder,
+    lagredeVedtaksperioder,
     settVedtaksperioder,
     vedtaksperioderFeil,
     settVedtaksperioderFeil,
@@ -123,6 +125,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                         <VedtaksperiodeRad
                             key={vedtaksperiode.id}
                             vedtaksperiode={vedtaksperiode}
+                            lagretVedtaksperiode={lagredeVedtaksperioder.get(vedtaksperiode.id)}
                             erLesevisning={!erStegRedigerbart}
                             oppdaterPeriode={(property, value) => {
                                 oppdaterPeriodeFelt(indeks, property, value);

--- a/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
+++ b/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
@@ -79,7 +79,7 @@ export interface VedtaksperiodeTilsynBarn extends Periode {
 
 export const validerVedtaksperioder = (
     vedtaksperioder: VedtaksperiodeTilsynBarn[],
-    lagretVedtaksperioder?: VedtaksperiodeTilsynBarn[] | [],
+    lagretVedtaksperioder: Map<string, VedtaksperiodeTilsynBarn>,
     revurderesFraDato?: string
 ): FormErrors<VedtaksperiodeTilsynBarn[]> =>
     vedtaksperioder.map((vedtaksperiode) => {
@@ -99,9 +99,7 @@ export const validerVedtaksperioder = (
             return { ...vedtaksperiodeFeil, målgruppeType: 'Mangler målgruppe for periode' };
         }
 
-        const lagretPeriode = lagretVedtaksperioder?.find(
-            (periode) => periode.id === vedtaksperiode.id
-        );
+        const lagretPeriode = lagretVedtaksperioder.get(vedtaksperiode.id);
 
         const periodeValidering = validerPeriode(vedtaksperiode, lagretPeriode, revurderesFraDato);
         if (periodeValidering) {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det var tidligere mulig å sette datoen for fom/tom før revurder fra som gjorde at datofeltene ble låst


Samme som ble gjort for læremidler her: https://github.com/navikt/tilleggsstonader-sak-frontend/pull/697