### PR TITLE
Skal vise alert om at gjenlevende etter gammelt regelverk ikke støttes

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -157,6 +157,8 @@ const EndreMålgruppeRad: React.FC<{
             ? målgruppeTypeOptionsForStønad(stønadstype)
             : [];
 
+    const erMålgruppeSomStøttes = form.type !== MålgruppeType.GJENLEVENDE_GAMMELT_REGELVERK;
+
     return (
         <VilkårperiodeKortBase vilkårperiode={målgruppe} redigeres>
             <FeltContainer>
@@ -168,6 +170,7 @@ const EndreMålgruppeRad: React.FC<{
                     formFeil={vilkårsperiodeFeil}
                     alleFelterKanEndres={alleFelterKanEndres}
                     kanEndreType={kanEndreType}
+                    erStøttetType={erMålgruppeSomStøttes}
                 />
             </FeltContainer>
 
@@ -181,17 +184,22 @@ const EndreMålgruppeRad: React.FC<{
                     }))
                 }
             />
-
-            <Begrunnelse
-                begrunnelse={form?.begrunnelse || ''}
-                oppdaterBegrunnelse={(nyBegrunnelse) => oppdaterForm('begrunnelse', nyBegrunnelse)}
-                delvilkårSomKreverBegrunnelse={delvilkårSomKreverBegrunnelse}
-                feil={vilkårsperiodeFeil?.begrunnelse}
-            />
+            {erMålgruppeSomStøttes && (
+                <Begrunnelse
+                    begrunnelse={form?.begrunnelse || ''}
+                    oppdaterBegrunnelse={(nyBegrunnelse) =>
+                        oppdaterForm('begrunnelse', nyBegrunnelse)
+                    }
+                    delvilkårSomKreverBegrunnelse={delvilkårSomKreverBegrunnelse}
+                    feil={vilkårsperiodeFeil?.begrunnelse}
+                />
+            )}
             <HStack gap="4">
-                <Button size="xsmall" onClick={lagre}>
-                    Lagre
-                </Button>
+                {erMålgruppeSomStøttes && (
+                    <Button size="xsmall" onClick={lagre}>
+                        Lagre
+                    </Button>
+                )}
 
                 <Button onClick={avbrytRedigering} variant="secondary" size="xsmall">
                     Avbryt

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 import styled from 'styled-components';
 
+import { Alert, BodyLong, Heading } from '@navikt/ds-react';
+
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import { målgruppeTilMedlemskapHjelpetekst } from './hjelpetekstVurdereMålgruppe';
 import { målgrupperHvorMedlemskapMåVurderes, skalVurdereDekkesAvAnnetRegelverk } from './utils';
 import { JaNeiVurdering } from '../../Vilkårvurdering/JaNeiVurdering';
-import { SvarMålgruppe } from '../typer/vilkårperiode/målgruppe';
+import { MålgruppeType, SvarMålgruppe } from '../typer/vilkårperiode/målgruppe';
 import { SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
 
 const Container = styled.div`
@@ -25,8 +27,14 @@ const MålgruppeVilkår: React.FC<{
 
     const skalVurdereMedlemskap = målgrupperHvorMedlemskapMåVurderes.includes(målgruppeForm.type);
     const skalVurdereDekketAvAnnetRegelverk = skalVurdereDekkesAvAnnetRegelverk(målgruppeForm.type);
+    const erGjenlevendeGammeltRegelverk =
+        målgruppeForm.type === MålgruppeType.GJENLEVENDE_GAMMELT_REGELVERK;
 
-    if (!skalVurdereMedlemskap && !skalVurdereDekketAvAnnetRegelverk) {
+    if (
+        !skalVurdereMedlemskap &&
+        !skalVurdereDekketAvAnnetRegelverk &&
+        !erGjenlevendeGammeltRegelverk
+    ) {
         return null;
     }
 
@@ -52,6 +60,21 @@ const MålgruppeVilkår: React.FC<{
                         oppdaterVurderinger('svarUtgifterDekketAvAnnetRegelverk', nyttSvar)
                     }
                 />
+            )}
+            {erGjenlevendeGammeltRegelverk && (
+                <Alert variant="warning" size="small">
+                    <Heading spacing size="xsmall" level="3">
+                        Gjenlevende etter gammelt regelverk kan ikke behandles
+                    </Heading>
+                    <BodyLong size="small" spacing>
+                        Det er per d.d. ikke mulig å behandle saker hvor bruker er gjenlevende og
+                        har rett til ytelser etter gammelt regelverk.
+                    </BodyLong>
+                    <BodyLong size="small">
+                        Sett saken på vent og gi beskjed til TS-teamet på teams med saksnummeret det
+                        gjelder.
+                    </BodyLong>
+                </Alert>
             )}
         </Container>
     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -67,8 +67,9 @@ const MålgruppeVilkår: React.FC<{
                         Gjenlevende etter gammelt regelverk kan ikke behandles
                     </Heading>
                     <BodyLong size="small" spacing>
-                        Det er per d.d. ikke mulig å behandle saker hvor bruker er gjenlevende og
-                        har rett til ytelser etter gammelt regelverk.
+                        Det er per d.d. ikke mulig å behandle saker hvor bruker hvor bruker er
+                        gjenlevende med rett til ytelser etter reglene som gjaldt før 1. januar
+                        2024.
                     </BodyLong>
                     <BodyLong size="small">
                         Sett saken på vent og gi beskjed til TS-teamet på teams med saksnummeret det

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
@@ -23,6 +23,7 @@ interface Props<T extends MålgruppeEllerAktivitet> {
     formFeil?: FormErrors<TypeOgDatoFelter>;
     alleFelterKanEndres: boolean;
     kanEndreType: boolean;
+    erStøttetType?: boolean;
 }
 
 export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
@@ -33,6 +34,7 @@ export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
     formFeil,
     alleFelterKanEndres,
     kanEndreType,
+    erStøttetType = true,
 }: Props<T>) => {
     const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
         useTriggRerendringAvDateInput();
@@ -62,7 +64,7 @@ export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
             <FeilmeldingMaksBredde>
                 <DateInputMedLeservisning
                     key={fomKeyDato}
-                    readOnly={!alleFelterKanEndres}
+                    readOnly={!alleFelterKanEndres || !erStøttetType}
                     label={'Fra'}
                     value={form?.fom}
                     onChange={(dato) => oppdaterPeriode('fom', dato || '')}
@@ -73,6 +75,7 @@ export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
             <FeilmeldingMaksBredde>
                 <DateInputMedLeservisning
                     key={tomKeyDato}
+                    readOnly={!erStøttetType}
                     label={'Til'}
                     value={form?.tom}
                     onChange={(dato) => oppdaterPeriode('tom', dato || '')}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -16,6 +16,7 @@ export enum MålgruppeType {
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
     SYKEPENGER_100_PROSENT = 'SYKEPENGER_100_PROSENT',
     INGEN_MÅLGRUPPE = 'INGEN_MÅLGRUPPE',
+    GJENLEVENDE_GAMMELT_REGELVERK = 'GJENLEVENDE_GAMMELT_REGELVERK', // Ikke støttet i backend, brukes kun for å vise feilmelding om manglende støtte ved valg av denne
 }
 
 export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
@@ -26,6 +27,7 @@ export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
     NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
     SYKEPENGER_100_PROSENT: '100% sykepenger',
     INGEN_MÅLGRUPPE: 'Ingen målgruppe',
+    GJENLEVENDE_GAMMELT_REGELVERK: 'Gjenlevende - gammelt regelverk',
 };
 
 const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
@@ -37,6 +39,7 @@ const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
         NEDSATT_ARBEIDSEVNE: true,
         SYKEPENGER_100_PROSENT: true,
         INGEN_MÅLGRUPPE: true,
+        GJENLEVENDE_GAMMELT_REGELVERK: true,
     },
     [Stønadstype.LÆREMIDLER]: {
         AAP: true,
@@ -46,6 +49,7 @@ const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
         NEDSATT_ARBEIDSEVNE: true,
         SYKEPENGER_100_PROSENT: false,
         INGEN_MÅLGRUPPE: true,
+        GJENLEVENDE_GAMMELT_REGELVERK: true,
     },
     [Stønadstype.BOUTGIFTER]: {
         AAP: true,
@@ -55,6 +59,7 @@ const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
         NEDSATT_ARBEIDSEVNE: true,
         SYKEPENGER_100_PROSENT: false,
         INGEN_MÅLGRUPPE: true,
+        GJENLEVENDE_GAMMELT_REGELVERK: true,
     },
 };
 
@@ -114,6 +119,7 @@ export const MålgruppeTypeTilFaktiskMålgruppe: Record<MålgruppeType, FaktiskM
     NEDSATT_ARBEIDSEVNE: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
     SYKEPENGER_100_PROSENT: FaktiskMålgruppe.SYKEPENGER_100_PROSENT,
     INGEN_MÅLGRUPPE: FaktiskMålgruppe.INGEN_MÅLGRUPPE,
+    GJENLEVENDE_GAMMELT_REGELVERK: FaktiskMålgruppe.GJENLEVENDE,
 };
 
 export interface MålgruppeVurderinger {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Lagt til "Gjenlevende - gammelt regelverk" som en målgruppe som er mulig å velge når man legger til målgruppe, men valg av denne trigger en alert og det er ikke mulig å lagre.

<img width="312" alt="image" src="https://github.com/user-attachments/assets/684e1518-0345-4193-afb8-63d582ac5477" />

<img width="1135" alt="image" src="https://github.com/user-attachments/assets/91836ba9-8991-4c99-8f1c-fa486fa08dc5" />
