### PR TITLE
Mapper til funksjonell feil hvis httpstatus er 400 for å kunne vise u…

### DIFF
--- a/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
@@ -19,7 +19,7 @@ import { JournalføringState, useJournalføringState } from '../../../hooks/useJ
 import DataViewer from '../../../komponenter/DataViewer';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
 import { JournalpostResponse } from '../../../typer/journalpost';
-import { RessursStatus } from '../../../typer/ressurs';
+import { erFeilressurs, RessursStatus } from '../../../typer/ressurs';
 import { JOURNALPOST_QUERY_STRING, OPPGAVEID_QUERY_STRING } from '../../Oppgavebenk/oppgaveutils';
 import PdfVisning from '../Felles/PdfVisning';
 import { journalføringGjelderKlage, skalViseBekreftelsesmodal } from '../Felles/utils';
@@ -109,10 +109,9 @@ const JournalføringSide: React.FC<Props> = ({ journalResponse, oppgaveId }) => 
 
     const senderInnJournalføring = journalpostState.innsending.status == RessursStatus.HENTER;
     const erPapirSøknad = journalføringsårsak === Journalføringsårsak.PAPIRSØKNAD;
-    const innsendingsfeil =
-        journalpostState.innsending.status === RessursStatus.FEILET
-            ? journalpostState.innsending.frontendFeilmelding
-            : undefined;
+    const innsendingsfeil = erFeilressurs(journalpostState.innsending)
+        ? journalpostState.innsending.frontendFeilmelding
+        : undefined;
 
     const validerOgJournalfør = () => {
         settFeilmelding('');

--- a/src/frontend/utils/fetch.ts
+++ b/src/frontend/utils/fetch.ts
@@ -58,15 +58,13 @@ const håndterSuksess = <ResponseData>(res: Response): Promise<RessursSuksess<Re
     });
 };
 
-const håndterFeil = (res: Response, headers: Headers): Promise<RessursFeilet> =>
-    res.json().then((res) => {
-        return {
-            status: RessursStatus.FEILET,
-            frontendFeilmelding: feilmeldingMedCallId(res.detail, headers),
-            frontendFeilmeldingUtenFeilkode: res.detail,
-            feilkode: feilkode(headers),
-        };
-    });
+const håndterFeil = (response: Response, headers: Headers): Promise<RessursFeilet> =>
+    response.json().then((res) => ({
+        status: response.status === 400 ? RessursStatus.FUNKSJONELL_FEIL : RessursStatus.FEILET,
+        frontendFeilmelding: feilmeldingMedCallId(res.detail, headers),
+        frontendFeilmeldingUtenFeilkode: res.detail,
+        feilkode: feilkode(headers),
+    }));
 
 const feilmeldingMedCallId = (feilmelding: string, headers?: Headers): string => {
     const callId = feilkode(headers);


### PR DESCRIPTION
…like variants på feilmelding

- warning/error

### Hvorfor er denne endringen nødvendig? ✨
@sarahjelle jobber med å ev vise feilmeldinger som error/warnings, og kan då bruke warning for funkjsonell feil
Funksjonell feil blir mappet fra 400-feil som kommer av `brukerfeilHvis(){}` i backend
