### PR TITLE
Visning av feilmeldinger

### DIFF
--- a/src/frontend/Sider/Admin/Oppfølging/KontrollerOppfølging.tsx
+++ b/src/frontend/Sider/Admin/Oppfølging/KontrollerOppfølging.tsx
@@ -70,7 +70,7 @@ export const KontrollerOppfølging = ({
                 style={{ width: '15rem' }}
                 onChange={(e) => settKommentar(e.target.value)}
             />
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
             <HStack gap={'4'}>
                 <Button variant="tertiary" onClick={avbryt} loading={lagrer} size="small">
                     Avbryt

--- a/src/frontend/Sider/Admin/Oppfølging/KontrollerOppfølging.tsx
+++ b/src/frontend/Sider/Admin/Oppfølging/KontrollerOppfølging.tsx
@@ -10,6 +10,11 @@ import {
 } from './oppfølgingTyper';
 import { useApp } from '../../../context/AppContext';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
+import {
+    Feil,
+    feiletRessursTilFeilmelding,
+    lagFeilmelding,
+} from '../../../komponenter/Feil/feilmeldingUtils';
 import { RessursStatus } from '../../../typer/ressurs';
 
 export const KontrollerOppfølging = ({
@@ -24,7 +29,7 @@ export const KontrollerOppfølging = ({
     const { request } = useApp();
     const [kommentar, settKommentar] = useState<string>();
     const [utfall, settUtfall] = useState<OppfølgingUtfall>();
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
 
     const [lagrer, settLagrer] = useState<boolean>(false);
 
@@ -33,7 +38,7 @@ export const KontrollerOppfølging = ({
             return;
         }
         if (!utfall) {
-            settFeilmelding('Mangler utfall');
+            settFeilmelding(lagFeilmelding('Mangler utfall'));
             return;
         }
         settLagrer(true);
@@ -49,7 +54,7 @@ export const KontrollerOppfølging = ({
                     oppdaterOppfølging(response.data);
                     avbryt();
                 } else {
-                    settFeilmelding(response.frontendFeilmelding);
+                    settFeilmelding(feiletRessursTilFeilmelding(response));
                 }
             })
             .finally(() => settLagrer(false));

--- a/src/frontend/Sider/Behandling/Brev/useSendTilBeslutter.ts
+++ b/src/frontend/Sider/Behandling/Brev/useSendTilBeslutter.ts
@@ -2,6 +2,7 @@ import { useState } from 'react';
 
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
+import { feiletRessursTilFeilmelding } from '../../../komponenter/Feil/feilmeldingUtils';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
 import { SendTilBeslutterRequest, TotrinnskontrollResponse } from '../Totrinnskontroll/typer';
 
@@ -12,7 +13,7 @@ export const useSendTilBeslutter = () => {
     const behandlingId = behandling.id;
 
     const sendTilBeslutter = async (kommentarTilBeslutter?: string) => {
-        request<TotrinnskontrollResponse, SendTilBeslutterRequest>(
+        return request<TotrinnskontrollResponse, SendTilBeslutterRequest>(
             `/api/sak/totrinnskontroll/${behandlingId}/send-til-beslutter`,
             'POST',
             {
@@ -25,7 +26,7 @@ export const useSendTilBeslutter = () => {
                 settVisVedtakFerdigstiltModal(true);
                 return Promise.resolve();
             } else {
-                return Promise.reject(res.frontendFeilmelding);
+                return Promise.reject(feiletRessursTilFeilmelding(res));
             }
         });
     };

--- a/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
@@ -43,7 +43,7 @@ export const UtenBrev: React.FC = () => {
                     Send til beslutter
                 </Knapp>
             )}
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
             <VedtakFerdigstiltModal
                 visModal={visVedtakFerdigstiltModal}
                 lukkModal={lukkVedtakFerdigstiltModal}

--- a/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
@@ -6,7 +6,7 @@ import { Alert, Button, VStack } from '@navikt/ds-react';
 
 import { useSteg } from '../../../context/StegContext';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
-import { erFeil, Feil } from '../../../komponenter/Feil/feilmeldingUtils';
+import { erFeil, Feil, lagFeilmelding } from '../../../komponenter/Feil/feilmeldingUtils';
 import { useSendTilBeslutter } from '../Brev/useSendTilBeslutter';
 import { VedtakFerdigstiltModal } from '../Brev/VedtakFerdigstiltModal';
 
@@ -33,7 +33,11 @@ export const UtenBrev: React.FC = () => {
         settLaster(true);
         sendTilBeslutter()
             .then(() => settFeilmelding(undefined))
-            .catch((error) => erFeil(error) && settFeilmelding(error))
+            .catch((error) =>
+                erFeil(error)
+                    ? settFeilmelding(error)
+                    : settFeilmelding(lagFeilmelding('Ukjent feil oppstod'))
+            )
             .finally(() => settLaster(false));
     };
 

--- a/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
@@ -6,6 +6,7 @@ import { Alert, Button, VStack } from '@navikt/ds-react';
 
 import { useSteg } from '../../../context/StegContext';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
+import { erFeil, Feil } from '../../../komponenter/Feil/feilmeldingUtils';
 import { useSendTilBeslutter } from '../Brev/useSendTilBeslutter';
 import { VedtakFerdigstiltModal } from '../Brev/VedtakFerdigstiltModal';
 
@@ -20,7 +21,7 @@ const Knapp = styled(Button)`
 export const UtenBrev: React.FC = () => {
     const { erStegRedigerbart } = useSteg();
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
 
     const { sendTilBeslutter, visVedtakFerdigstiltModal, lukkVedtakFerdigstiltModal } =
         useSendTilBeslutter();
@@ -32,7 +33,7 @@ export const UtenBrev: React.FC = () => {
         settLaster(true);
         sendTilBeslutter()
             .then(() => settFeilmelding(undefined))
-            .catch((error) => settFeilmelding(error.message))
+            .catch((error) => erFeil(error) && settFeilmelding(error))
             .finally(() => settLaster(false));
     };
 

--- a/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
+++ b/src/frontend/Sider/Behandling/Fanemeny/UtenBrev.tsx
@@ -32,6 +32,7 @@ export const UtenBrev: React.FC = () => {
         settLaster(true);
         sendTilBeslutter()
             .then(() => settFeilmelding(undefined))
+            .catch((error) => settFeilmelding(error.message))
             .finally(() => settLaster(false));
     };
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -129,7 +129,7 @@ const Aktivitet: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = (
                         </div>
                     )}
 
-                    <Feilmelding ref={feilmeldingRef}>{feilmelding}</Feilmelding>
+                    <Feilmelding ref={feilmeldingRef} feil={feilmelding} />
 
                     {kanSetteNyRadIRedigeringsmodus && erStegRedigerbart && (
                         <Button

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -223,7 +223,7 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
                 )}
             </HStack>
 
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </VilkårperiodeKortBase>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -78,7 +78,7 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
         initaliserForm(aktivitet, aktivitetFraRegister)
     );
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
     const [vilkårsperiodeFeil, settVilkårsperiodeFeil] =
         useState<FormErrors<AktivitetValidering>>();
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBarnetilsyn.tsx
@@ -21,6 +21,7 @@ import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useLagreVilkårperiode } from '../../../../hooks/useLagreVilkårperiode';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { feiletRessursTilFeilmelding, Feil } from '../../../../komponenter/Feil/feilmeldingUtils';
 import TextField from '../../../../komponenter/Skjema/TextField';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
@@ -30,11 +31,7 @@ import { Periode } from '../../../../utils/periode';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
 import { Aktivitet, AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import { AktivitetBarnetilsyn } from '../typer/vilkårperiode/aktivitetBarnetilsyn';
-import {
-    KildeVilkårsperiode,
-    StønadsperiodeStatus,
-    SvarJaNei,
-} from '../typer/vilkårperiode/vilkårperiode';
+import { KildeVilkårsperiode, SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
 import Begrunnelse from '../Vilkårperioder/Begrunnelse/Begrunnelse';
 import { EndreTypeOgDatoer } from '../Vilkårperioder/EndreTypeOgDatoer';
 import SlettVilkårperiode from '../Vilkårperioder/SlettVilkårperiodeModal';
@@ -73,14 +70,15 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
     avbrytRedigering: () => void;
 }> = ({ aktivitet, avbrytRedigering, aktivitetFraRegister }) => {
     const { behandling, behandlingFakta } = useBehandling();
-    const { oppdaterAktivitet, leggTilAktivitet, settStønadsperiodeFeil } = useInngangsvilkår();
+    const { oppdaterAktivitet, leggTilAktivitet, oppdatertStønadsperiodeFeil } =
+        useInngangsvilkår();
     const { lagreVilkårperiode } = useLagreVilkårperiode();
 
     const [form, settForm] = useState<EndreAktivitetFormBarnetilsyn>(
         initaliserForm(aktivitet, aktivitetFraRegister)
     );
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
     const [vilkårsperiodeFeil, settVilkårsperiodeFeil] =
         useState<FormErrors<AktivitetValidering>>();
 
@@ -118,14 +116,16 @@ export const EndreAktivitetBarnetilsyn: React.FC<{
                             oppdaterAktivitet(res.data.periode);
                         }
 
-                        if (res.data.stønadsperiodeStatus === StønadsperiodeStatus.Ok) {
-                            settStønadsperiodeFeil(undefined);
-                        } else {
-                            settStønadsperiodeFeil(res.data.stønadsperiodeFeil);
-                        }
+                        oppdatertStønadsperiodeFeil(
+                            res.data.stønadsperiodeStatus,
+                            res.data.stønadsperiodeFeil
+                        );
+
                         avbrytRedigering();
                     } else {
-                        settFeilmelding(`Feilet legg til periode: ${res.frontendFeilmelding}`);
+                        settFeilmelding(
+                            feiletRessursTilFeilmelding(res, 'Feilet legg til periode')
+                        );
                     }
                 })
                 .finally(() => settLaster(false));

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -91,7 +91,7 @@ export const EndreAktivitetLæremidler: React.FC<{
         initaliserForm(aktivitet, aktivitetFraRegister)
     );
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
     const [vilkårsperiodeFeil, settVilkårsperiodeFeil] =
         useState<FormErrors<AktivitetValidering>>();
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -24,6 +24,7 @@ import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useLagreVilkårperiode } from '../../../../hooks/useLagreVilkårperiode';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { feiletRessursTilFeilmelding, Feil } from '../../../../komponenter/Feil/feilmeldingUtils';
 import TextField from '../../../../komponenter/Skjema/TextField';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
@@ -37,11 +38,7 @@ import {
     AktivitetTypeLæremidler,
     Studienivå,
 } from '../typer/vilkårperiode/aktivitetLæremidler';
-import {
-    KildeVilkårsperiode,
-    StønadsperiodeStatus,
-    SvarJaNei,
-} from '../typer/vilkårperiode/vilkårperiode';
+import { KildeVilkårsperiode, SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
 import Begrunnelse from '../Vilkårperioder/Begrunnelse/Begrunnelse';
 import { EndreTypeOgDatoer } from '../Vilkårperioder/EndreTypeOgDatoer';
 import SlettVilkårperiode from '../Vilkårperioder/SlettVilkårperiodeModal';
@@ -86,14 +83,15 @@ export const EndreAktivitetLæremidler: React.FC<{
     avbrytRedigering: () => void;
 }> = ({ aktivitet, avbrytRedigering, aktivitetFraRegister }) => {
     const { behandling, behandlingFakta } = useBehandling();
-    const { oppdaterAktivitet, leggTilAktivitet, settStønadsperiodeFeil } = useInngangsvilkår();
+    const { oppdaterAktivitet, leggTilAktivitet, oppdatertStønadsperiodeFeil } =
+        useInngangsvilkår();
     const { lagreVilkårperiode } = useLagreVilkårperiode();
 
     const [form, settForm] = useState<EndreAktivitetFormLæremidler>(
         initaliserForm(aktivitet, aktivitetFraRegister)
     );
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
     const [vilkårsperiodeFeil, settVilkårsperiodeFeil] =
         useState<FormErrors<AktivitetValidering>>();
 
@@ -131,14 +129,16 @@ export const EndreAktivitetLæremidler: React.FC<{
                             oppdaterAktivitet(res.data.periode);
                         }
 
-                        if (res.data.stønadsperiodeStatus === StønadsperiodeStatus.Ok) {
-                            settStønadsperiodeFeil(undefined);
-                        } else {
-                            settStønadsperiodeFeil(res.data.stønadsperiodeFeil);
-                        }
+                        oppdatertStønadsperiodeFeil(
+                            res.data.stønadsperiodeStatus,
+                            res.data.stønadsperiodeFeil
+                        );
+
                         avbrytRedigering();
                     } else {
-                        settFeilmelding(`Feilet legg til periode: ${res.frontendFeilmelding}`);
+                        settFeilmelding(
+                            feiletRessursTilFeilmelding(res, 'Feilet legg til periode')
+                        );
                     }
                 })
                 .finally(() => settLaster(false));

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetLæremidler.tsx
@@ -264,7 +264,7 @@ export const EndreAktivitetLæremidler: React.FC<{
                 )}
             </HStack>
 
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </VilkårperiodeKortBase>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -80,7 +80,7 @@ const EndreMålgruppeRad: React.FC<{
         initaliserForm(målgruppe, registerYtelsePeriode)
     );
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
     const [vilkårsperiodeFeil, settVilkårsperiodeFeil] =
         useState<FormErrors<MålgruppeValidering>>();
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -19,6 +19,11 @@ import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
 import { useLagreVilkårperiode } from '../../../../hooks/useLagreVilkårperiode';
 import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import {
+    feiletRessursTilFeilmelding,
+    Feil,
+    lagFeilmelding,
+} from '../../../../komponenter/Feil/feilmeldingUtils';
 import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { PeriodeYtelseRegister } from '../../../../typer/registerytelser';
@@ -75,7 +80,7 @@ const EndreMålgruppeRad: React.FC<{
         initaliserForm(målgruppe, registerYtelsePeriode)
     );
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
     const [vilkårsperiodeFeil, settVilkårsperiodeFeil] =
         useState<FormErrors<MålgruppeValidering>>();
 
@@ -119,12 +124,14 @@ const EndreMålgruppeRad: React.FC<{
                         }
                         if (res.data.stønadsperiodeStatus === StønadsperiodeStatus.Ok) {
                             settStønadsperiodeFeil(undefined);
-                        } else {
-                            settStønadsperiodeFeil(res.data.stønadsperiodeFeil);
+                        } else if (res.data.stønadsperiodeFeil) {
+                            settStønadsperiodeFeil(lagFeilmelding(res.data.stønadsperiodeFeil));
                         }
                         avbrytRedigering();
                     } else {
-                        settFeilmelding(`Feilet legg til periode: ${res.frontendFeilmelding}`);
+                        settFeilmelding(
+                            feiletRessursTilFeilmelding(res, 'Feilet legg til periode')
+                        );
                     }
                 })
                 .finally(() => settLaster(false));

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -204,7 +204,7 @@ const EndreMålgruppeRad: React.FC<{
                 )}
             </HStack>
 
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </VilkårperiodeKortBase>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -123,7 +123,7 @@ const Målgruppe: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = 
                         </div>
                     )}
 
-                    <Feilmelding ref={feilmeldingRef}>{feilmelding}</Feilmelding>
+                    <Feilmelding ref={feilmeldingRef} feil={feilmelding} />
 
                     {kanSetteNyRadIRedigeringsmodus && (
                         <Button

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/OppdaterGrunnlagKnapp.tsx
@@ -46,7 +46,6 @@ const OppdaterGrunnlagKnapp: React.FC<{
             >
                 {tekst}
             </Button>
-            <Feilmelding size={'small'}>{feilmelding}</Feilmelding>
             {visRedigerGrunnlagFomAdmin && (
                 <AdminEndreHenteGrunnlagFra>
                     <DateInput
@@ -68,19 +67,22 @@ const OppdaterGrunnlagKnapp: React.FC<{
 
     if (dagerSidenGrunnlagBleHentet > 0) {
         return (
-            <Alert variant={'warning'} size={'small'}>
-                <Heading size={'xsmall'} level="3">
-                    Det har gått {dagerSidenGrunnlagBleHentet}{' '}
-                    {dagerSidenGrunnlagBleHentet > 1 ? 'dager' : 'dag'} siden aktivitet og ytelse
-                    ble hentet
-                </Heading>
-                <HStack>
-                    <span>
-                        Informasjonen kan være utdatert. Vi anbefaler at du henter inn på nytt.
-                    </span>
-                    {knapp('Hent på nytt')}
-                </HStack>
-            </Alert>
+            <>
+                <Alert variant={'warning'} size={'small'}>
+                    <Heading size={'xsmall'} level="3">
+                        Det har gått {dagerSidenGrunnlagBleHentet}{' '}
+                        {dagerSidenGrunnlagBleHentet > 1 ? 'dager' : 'dag'} siden aktivitet og
+                        ytelse ble hentet
+                    </Heading>
+                    <HStack>
+                        <span>
+                            Informasjonen kan være utdatert. Vi anbefaler at du henter inn på nytt.
+                        </span>
+                        {knapp('Hent på nytt')}
+                    </HStack>
+                </Alert>
+                <Feilmelding feil={feilmelding} />
+            </>
         );
     }
     return <div>{knapp('Hent saksopplysninger om aktiviteter og ytelser på nytt')}</div>;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
@@ -16,7 +16,7 @@ export const useOppdaterGrunnlag = (hentVilkårperioder: () => void): OppdaterGr
     const { request, settToast } = useApp();
     const { behandling } = useBehandling();
     const [laster, settLaster] = useState(false);
-    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
 
     const oppdaterGrunnlag = (hentFom?: string) => {
         if (laster) {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/OppdaterGrunnlag/useOppdaterGrunnlag.ts
@@ -2,20 +2,21 @@ import { useState } from 'react';
 
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
+import { feiletRessursTilFeilmelding, Feil } from '../../../../komponenter/Feil/feilmeldingUtils';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Toast } from '../../../../typer/toast';
 
 interface OppdaterGrunnlag {
     oppdaterGrunnlag: (henteFom?: string) => void;
     laster: boolean;
-    feilmelding: string | undefined;
+    feilmelding: Feil | undefined;
 }
 
 export const useOppdaterGrunnlag = (hentVilkårperioder: () => void): OppdaterGrunnlag => {
     const { request, settToast } = useApp();
     const { behandling } = useBehandling();
     const [laster, settLaster] = useState(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
 
     const oppdaterGrunnlag = (hentFom?: string) => {
         if (laster) {
@@ -36,7 +37,7 @@ export const useOppdaterGrunnlag = (hentVilkårperioder: () => void): OppdaterGr
                     hentVilkårperioder();
                 } else {
                     settFeilmelding(
-                        `Oppdatering av grunnlag feilet: ${response.frontendFeilmelding}`
+                        feiletRessursTilFeilmelding(response, 'Oppdatering av grunnlag feilet')
                     );
                 }
             })

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -216,7 +216,7 @@ const Stønadsperioder: React.FC = () => {
                         </Grid>
                     )}
 
-                    <Feilmelding>{stønadsperiodeFeil}</Feilmelding>
+                    <Feilmelding feil={stønadsperiodeFeil} />
 
                     {erStegRedigerbart && (
                         <Aksjonsknapper

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Stønadsperioder/Stønadsperioder.tsx
@@ -19,6 +19,7 @@ import useFormState, { FormErrors, FormState } from '../../../../hooks/felles/us
 import { ListState } from '../../../../hooks/felles/useListState';
 import { UlagretKomponent } from '../../../../hooks/useUlagredeKomponenter';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { feiletRessursTilFeilmelding } from '../../../../komponenter/Feil/feilmeldingUtils';
 import Panel from '../../../../komponenter/Panel/Panel';
 import { RessursStatus } from '../../../../typer/ressurs';
 import { Stønadsperiode } from '../typer/stønadsperiode';
@@ -111,7 +112,9 @@ const Stønadsperioder: React.FC = () => {
                     settRedigerer(false);
                     oppdaterStønadsperioder(res.data);
                 } else {
-                    settStønadsperiodeFeil(`Feilet legg til periode: ${res.frontendFeilmelding}`);
+                    settStønadsperiodeFeil(
+                        feiletRessursTilFeilmelding(res, 'Feilet legg til periode')
+                    );
                 }
             })
             .finally(() => settLaster(false));

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/SlettVilkårperiodeModal.tsx
@@ -5,6 +5,7 @@ import { Button, Table, Textarea, VStack } from '@navikt/ds-react';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
+import { lagFeilmelding } from '../../../../komponenter/Feil/feilmeldingUtils';
 import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../typer/ressurs';
@@ -85,8 +86,8 @@ const SlettVilkårperiode: React.FC<{
     const oppdaterStønadsperiodeFeil = (response: Response) => {
         if (response.stønadsperiodeStatus === StønadsperiodeStatus.Ok) {
             settStønadsperiodeFeil(undefined);
-        } else {
-            settStønadsperiodeFeil(response.stønadsperiodeFeil);
+        } else if (response.stønadsperiodeFeil) {
+            settStønadsperiodeFeil(lagFeilmelding(response.stønadsperiodeFeil));
         }
     };
 

--- a/src/frontend/Sider/Behandling/RevurderFra/RevurderFra.tsx
+++ b/src/frontend/Sider/Behandling/RevurderFra/RevurderFra.tsx
@@ -9,6 +9,7 @@ import { VedtaksperioderRevurderFra } from './VedtaksperioderRevurderFra';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
+import { Feil, feiletRessursTilFeilmelding } from '../../../komponenter/Feil/feilmeldingUtils';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
 import DateInputMedLeservisning from '../../../komponenter/Skjema/DateInputMedLeservisning';
 import { Behandling } from '../../../typer/behandling/behandling';
@@ -26,7 +27,7 @@ export function RevurderFra() {
     const navigate = useNavigate();
 
     const [valideringsfeil, settValideringsfeil] = useState<string | undefined>();
-    const [feilVedLagring, settFeilVedLagring] = useState<string>();
+    const [feilVedLagring, settFeilVedLagring] = useState<Feil>();
     const [revurderFraDato, settRevurderFraDato] = useState<string | undefined>(
         behandling.revurderFra
     );
@@ -57,7 +58,7 @@ export function RevurderFra() {
             hentBehandling.rerun();
             navigate(`/behandling/${behandling.id}/${FanePath.INNGANGSVILKÅR}`);
         } else {
-            settFeilVedLagring(response.frontendFeilmelding);
+            settFeilVedLagring(feiletRessursTilFeilmelding(response));
         }
     }
 
@@ -83,7 +84,7 @@ export function RevurderFra() {
                     {behandlingErRedigerbar && (
                         <SmallButton onClick={lagreRevurderFraDato}>Lagre og gå videre</SmallButton>
                     )}
-                    {feilVedLagring && <Feilmelding>{feilVedLagring}</Feilmelding>}
+                    <Feilmelding feil={feilVedLagring} />
                 </VStack>
                 <VedtaksperioderRevurderFra />
             </VStack>

--- a/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
+++ b/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
@@ -149,7 +149,7 @@ const SettPåVentForm: React.FC<{
                     Angre
                 </Button>
             </HStack>
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </VStack>
     );
 };

--- a/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
+++ b/src/frontend/Sider/Behandling/SettPåVent/SettPåVentForm.tsx
@@ -20,6 +20,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import { FormErrors, isValid } from '../../../hooks/felles/useFormState';
 import { useTriggRerendringAvDateInput } from '../../../hooks/useTriggRerendringAvDateInput';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
+import { Feil, feiletRessursTilFeilmelding } from '../../../komponenter/Feil/feilmeldingUtils';
 import DateInput from '../../../komponenter/Skjema/DateInput';
 import { Ressurs, RessursStatus } from '../../../typer/ressurs';
 
@@ -36,7 +37,7 @@ const SettPåVentForm: React.FC<{
     const { request } = useApp();
 
     const [laster, settLaster] = useState(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
     const [settPåVent, settSettPåVent] = useState<SettPåVent>({
         årsaker: status?.årsaker || [],
         frist: status?.frist,
@@ -86,7 +87,7 @@ const SettPåVentForm: React.FC<{
                 }
                 hentBehandling.rerun();
             } else {
-                settFeilmelding(response.frontendFeilmelding);
+                settFeilmelding(feiletRessursTilFeilmelding(response));
             }
         });
     };

--- a/src/frontend/Sider/Behandling/SettPåVent/TaAvVentModal.tsx
+++ b/src/frontend/Sider/Behandling/SettPåVent/TaAvVentModal.tsx
@@ -80,7 +80,7 @@ const TaAvVentModal: React.FC<{
                     value={kommentar}
                     onChange={(e) => settKommentar(e.target.value)}
                 />
-                <Feilmelding variant="alert">{feilmelding}</Feilmelding>
+                <Feilmelding feil={feilmelding} />
             </FlexColumn>
         </ModalWrapper>
     );

--- a/src/frontend/Sider/Behandling/SettPåVent/TaAvVentModal.tsx
+++ b/src/frontend/Sider/Behandling/SettPåVent/TaAvVentModal.tsx
@@ -7,6 +7,7 @@ import { Textarea } from '@navikt/ds-react';
 import { useApp } from '../../../context/AppContext';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
+import { Feil, feiletRessursTilFeilmelding } from '../../../komponenter/Feil/feilmeldingUtils';
 import { ModalWrapper } from '../../../komponenter/Modal/ModalWrapper';
 import { FlexColumn } from '../../../komponenter/Visningskomponenter/Flex';
 import { RessursStatus } from '../../../typer/ressurs';
@@ -25,7 +26,7 @@ const TaAvVentModal: React.FC<{
     const navigate = useNavigate();
 
     const [kommentar, settKommentar] = useState('');
-    const [feilmelding, settFeilmelding] = useState('');
+    const [feilmelding, settFeilmelding] = useState<Feil>();
     const [laster, settLaster] = useState(false);
 
     const taAvVent = (skalTilordnesRessurs: boolean) => {
@@ -42,7 +43,7 @@ const TaAvVentModal: React.FC<{
                     navigate('/');
                 }
             } else {
-                settFeilmelding(resp.frontendFeilmelding);
+                settFeilmelding(feiletRessursTilFeilmelding(resp));
             }
         });
     };

--- a/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
@@ -29,5 +29,5 @@ export const EksternOmrutingBehandling = () => {
         );
     }, [eksternBehandlingId, navigate, request]);
 
-    return <Feilmelding variant="alert">{feilmelding}</Feilmelding>;
+    return <Feilmelding feil={feilmelding} />;
 };

--- a/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { useApp } from '../../context/AppContext';
 import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
+import { Feil, feiletRessursTilFeilmelding } from '../../komponenter/Feil/feilmeldingUtils';
 import { Behandling } from '../../typer/behandling/behandling';
 import { RessursStatus } from '../../typer/ressurs';
 
@@ -15,7 +16,7 @@ export const EksternOmrutingBehandling = () => {
     const { request } = useApp();
     const { eksternBehandlingId } = useParams<{ eksternBehandlingId: string }>();
 
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
 
     useEffect(() => {
         request<Behandling, null>(`/api/sak/behandling/ekstern/${eksternBehandlingId}`).then(
@@ -23,7 +24,7 @@ export const EksternOmrutingBehandling = () => {
                 if (resultat.status === RessursStatus.SUKSESS) {
                     navigate(`/behandling/${resultat.data.id}`);
                 } else {
-                    settFeilmelding(resultat.frontendFeilmelding);
+                    settFeilmelding(feiletRessursTilFeilmelding(resultat));
                 }
             }
         );

--- a/src/frontend/Sider/EksternOmruting/EksternOmrutingSaksoversikt.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmrutingSaksoversikt.tsx
@@ -4,6 +4,7 @@ import { useNavigate, useParams } from 'react-router-dom';
 
 import { useApp } from '../../context/AppContext';
 import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
+import { Feil, feiletRessursTilFeilmelding } from '../../komponenter/Feil/feilmeldingUtils';
 import { Søkeresultat } from '../../komponenter/PersonSøk';
 import { RessursStatus } from '../../typer/ressurs';
 
@@ -15,7 +16,7 @@ export const EksternOmrutingSaksoversikt = () => {
     const { request } = useApp();
     const { eksternFagsakId } = useParams<{ eksternFagsakId: string }>();
 
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
 
     useEffect(() => {
         request<Søkeresultat, null>(`/api/sak/sok/person/fagsak-ekstern/${eksternFagsakId}`).then(
@@ -23,7 +24,7 @@ export const EksternOmrutingSaksoversikt = () => {
                 if (resultat.status === RessursStatus.SUKSESS) {
                     navigate(`/person/${resultat.data.fagsakPersonId}`);
                 } else {
-                    settFeilmelding(resultat.frontendFeilmelding);
+                    settFeilmelding(feiletRessursTilFeilmelding(resultat));
                 }
             }
         );

--- a/src/frontend/Sider/EksternOmruting/EksternOmrutingSaksoversikt.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmrutingSaksoversikt.tsx
@@ -29,5 +29,5 @@ export const EksternOmrutingSaksoversikt = () => {
         );
     }, [eksternFagsakId, navigate, request]);
 
-    return <Feilmelding variant="alert">{feilmelding}</Feilmelding>;
+    return <Feilmelding feil={feilmelding} />;
 };

--- a/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
@@ -186,8 +186,8 @@ const JournalføringSide: React.FC<Props> = ({ journalResponse, oppgaveId }) => 
                                 settFeilmelding={settFeilmelding}
                             />
                         </section>
-                        <Feilmelding>{feilmelding}</Feilmelding>
-                        <Feilmelding>{innsendingsfeil}</Feilmelding>
+                        <Feilmelding feil={feilmelding} />
+                        <Feilmelding feil={innsendingsfeil} />
                         <HStack gap="4" justify="end">
                             <Button
                                 size={'small'}

--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -36,7 +36,7 @@ const OppgavebenkContainer = () => {
             <DataViewer response={{ oppgaver: oppgaveRessurs }}>
                 {({ oppgaver }) => <Oppgavetabell oppgaverResponse={oppgaver} />}
             </DataViewer>
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </Container>
     );
 };

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKlageBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKlageBehandling.tsx
@@ -4,6 +4,11 @@ import { Button, HStack, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../../context/AppContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import {
+    Feil,
+    feiletRessursTilFeilmelding,
+    lagFeilmelding,
+} from '../../../../komponenter/Feil/feilmeldingUtils';
 import DateInput from '../../../../komponenter/Skjema/DateInput';
 import { RessursStatus } from '../../../../typer/ressurs';
 
@@ -25,14 +30,16 @@ const OpprettKlageBehandling: React.FC<Props> = ({
     const { request } = useApp();
     const [klageMottattDato, settKlageMottattDato] = useState('');
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
 
     const opprett = () => {
         if (laster) {
             return;
         }
         if (!klageMottattDato) {
-            settFeilmelding('Må sette dato for klage mottatt');
+            settFeilmelding(
+                lagFeilmelding('Må sette dato for klage mottatt', RessursStatus.FUNKSJONELL_FEIL)
+            );
             return;
         }
         settLaster(true);
@@ -43,7 +50,7 @@ const OpprettKlageBehandling: React.FC<Props> = ({
                 hentKlagebehandlinger();
                 lukkModal();
             } else {
-                settFeilmelding(response.frontendFeilmelding);
+                settFeilmelding(feiletRessursTilFeilmelding(response));
                 settLaster(false);
             }
         });

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKlageBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKlageBehandling.tsx
@@ -65,7 +65,7 @@ const OpprettKlageBehandling: React.FC<Props> = ({
                     Lagre
                 </Button>
             </HStack>
-            <Feilmelding variant={'alert'}>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </VStack>
     );
 };

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettOrdinærBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettOrdinærBehandling.tsx
@@ -7,6 +7,11 @@ import { Button, HStack, Select, VStack } from '@navikt/ds-react';
 import BarnTilRevurdering, { BarnTilRevurderingResponse } from './BarnTilRevurdering';
 import { useApp } from '../../../../context/AppContext';
 import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import {
+    Feil,
+    feiletRessursTilFeilmelding,
+    lagFeilmelding,
+} from '../../../../komponenter/Feil/feilmeldingUtils';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { BehandlingÅrsak } from '../../../../typer/behandling/behandlingÅrsak';
 import { byggTomRessurs, Ressurs, RessursStatus } from '../../../../typer/ressurs';
@@ -53,7 +58,7 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
     const [valgteBarn, settValgteBarn] = useState<string[]>([]);
 
     const [laster, settLaster] = useState<boolean>(false);
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil>();
 
     const kanVelgeÅrsakUtenBrev = useFlag(Toggle.BEHANDLING_ÅRSAK_UTEN_BREV);
 
@@ -63,7 +68,7 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
         }
         settLaster(true);
         if (!årsak) {
-            settFeilmelding('Mangler årsak');
+            settFeilmelding(lagFeilmelding('Mangler årsak'));
             settLaster(false);
             return;
         }
@@ -76,7 +81,7 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
                 hentBehandlinger();
                 lukkModal();
             } else {
-                settFeilmelding(response.frontendFeilmelding);
+                settFeilmelding(feiletRessursTilFeilmelding(response));
                 settLaster(false);
             }
         });

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettOrdinærBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettOrdinærBehandling.tsx
@@ -131,7 +131,7 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
                     Lagre
                 </Button>
             </HStack>
-            <Feilmelding variant={'alert'}>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </VStack>
     );
 };

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaveliste.tsx
@@ -120,7 +120,7 @@ const Oppgaveliste: React.FC<{
                     ))}
                 </Table.Body>
             </Tabell>
-            <Feilmelding variant="alert">{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
         </FlexColumn>
     );
 };

--- a/src/frontend/context/InngangsvilkårContext.ts
+++ b/src/frontend/context/InngangsvilkårContext.ts
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react';
 
 import constate from 'constate';
 
+import { Feil, lagFeilmelding } from '../komponenter/Feil/feilmeldingUtils';
 import { Stønadsperiode } from '../Sider/Behandling/Inngangsvilkår/typer/stønadsperiode';
 import {
     Aktivitet,
@@ -11,7 +12,10 @@ import {
     Målgruppe,
     MålgruppeType,
 } from '../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe';
-import { Vilkårperioder } from '../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
+import {
+    StønadsperiodeStatus,
+    Vilkårperioder,
+} from '../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
 
 interface UseInngangsvilkår {
     målgrupper: Målgruppe[];
@@ -22,9 +26,13 @@ interface UseInngangsvilkår {
     oppdaterAktivitet: (oppdatertPeriode: Aktivitet) => void;
     slettVilkårperiode: (type: MålgruppeType | AktivitetType, id: string) => void;
     stønadsperioder: Stønadsperiode[];
-    stønadsperiodeFeil: string | undefined;
-    settStønadsperiodeFeil: (feilmelding: string | undefined) => void;
+    stønadsperiodeFeil: Feil | undefined;
+    settStønadsperiodeFeil: (feilmelding: Feil | undefined) => void;
     oppdaterStønadsperioder: (oppdaterteStønadsperioder: Stønadsperiode[]) => void;
+    oppdatertStønadsperiodeFeil: (
+        status: StønadsperiodeStatus,
+        stønadsperiodeFeil?: string
+    ) => void;
 }
 
 interface Props {
@@ -38,7 +46,7 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
         const [aktiviteter, settAktiviteter] = useState<Aktivitet[]>(vilkårperioder.aktiviteter);
         const [stønadsperioder, settStønadsperioder] =
             useState<Stønadsperiode[]>(hentedeStønadsperioder);
-        const [stønadsperiodeFeil, settStønadsperiodeFeil] = useState<string>();
+        const [stønadsperiodeFeil, settStønadsperiodeFeil] = useState<Feil>();
 
         useEffect(() => {
             settStønadsperioder(hentedeStønadsperioder);
@@ -78,6 +86,17 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             );
         };
 
+        const oppdatertStønadsperiodeFeil = (
+            status: StønadsperiodeStatus,
+            stønadsperiodeFeil?: string
+        ) => {
+            if (status === StønadsperiodeStatus.Ok) {
+                settStønadsperiodeFeil(undefined);
+            } else if (stønadsperiodeFeil) {
+                settStønadsperiodeFeil(lagFeilmelding(stønadsperiodeFeil));
+            }
+        };
+
         return {
             målgrupper,
             leggTilMålgruppe,
@@ -91,6 +110,7 @@ export const [InngangsvilkårProvider, useInngangsvilkår] = constate(
             settStønadsperiodeFeil,
             oppdaterStønadsperioder: (oppdaterteStønadsperioder: Stønadsperiode[]) =>
                 settStønadsperioder(oppdaterteStønadsperioder),
+            oppdatertStønadsperiodeFeil,
         };
     }
 );

--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, Button, List, Textarea, VStack } from '@navikt/ds-react';
+import { Alert, BodyShort, Button, List, Textarea, VStack } from '@navikt/ds-react';
 
 import { MalStruktur, Valg, Valgfelt } from './typer';
 import { FeilIDelmal, FeilIDelmalType, useBrevFeilContext } from '../../context/BrevFeilContext';
@@ -81,14 +81,14 @@ const FeilmeldingBrev = () => {
     const { manglendeBrevVariabler, manglendeValgfelt } = useBrevFeilContext();
     return (
         (manglendeBrevVariabler.length > 0 || manglendeValgfelt.length > 0) && (
-            <Feilmelding variant="alert" size={'small'}>
+            <Alert size="small" variant="warning">
                 Kan ikke gå videre, følgende felter mangler fra brev:
                 <ListeMedMangler
                     tittel={'Felt som mangler verdi'}
                     mangler={manglendeBrevVariabler}
                 />
                 <ListeMedMangler tittel={'Valg som mangler verdi'} mangler={manglendeValgfelt} />
-            </Feilmelding>
+            </Alert>
         )
     );
 };

--- a/src/frontend/komponenter/Brev/Brevknapp.tsx
+++ b/src/frontend/komponenter/Brev/Brevknapp.tsx
@@ -71,7 +71,7 @@ export const Brevknapp = ({
             <Knapp onClick={trykkPåKnapp} disabled={laster} size="small">
                 {tittel}
             </Knapp>
-            <Feilmelding>{feilmelding}</Feilmelding>
+            <Feilmelding feil={feilmelding} />
             <FeilmeldingBrev />
         </VStack>
     );

--- a/src/frontend/komponenter/DataViewer.tsx
+++ b/src/frontend/komponenter/DataViewer.tsx
@@ -1,7 +1,5 @@
 import React, { ReactElement, ReactNode } from 'react';
 
-import { Alert } from '@navikt/ds-react';
-
 import SystemetLaster from './SystemetLaster/SystemetLaster';
 import {
     erFeilressurs,
@@ -10,6 +8,8 @@ import {
     RessursStatus,
     RessursSuksess,
 } from '../typer/ressurs';
+import { Feilmelding } from './Feil/Feilmelding';
+import { feiletRessursTilFeilmelding } from './Feil/feilmeldingUtils';
 
 /**
  * Input: { behandling: Ressurss<Behandling>, personopslyninger: Ressurss<IPersonopplysninger> }
@@ -46,9 +46,7 @@ function DataViewer<T extends Record<string, unknown>>(
         return (
             <>
                 {responses.filter(erFeilressurs).map((feilet, index) => (
-                    <Alert key={index} variant={'error'}>
-                        {feilet.frontendFeilmelding}
-                    </Alert>
+                    <Feilmelding key={index} feil={feiletRessursTilFeilmelding(feilet)} />
                 ))}
             </>
         );

--- a/src/frontend/komponenter/Feil/Feilmelding.tsx
+++ b/src/frontend/komponenter/Feil/Feilmelding.tsx
@@ -1,34 +1,39 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 
-import { Alert, ErrorMessage } from '@navikt/ds-react';
+import { Alert, BodyShort, CopyButton, Detail, HStack, Label } from '@navikt/ds-react';
+
+import { Feil, finnFeilmeldingVariant } from './feilmeldingUtils';
 
 interface Props {
-    children: ReactNode | undefined;
-    variant?: 'inline' | 'alert';
-    size?: 'small' | 'medium';
+    feil: Feil | string | undefined;
 }
 
 export const Feilmelding = React.forwardRef<HTMLDivElement | HTMLParagraphElement, Props>(
-    function Feilmelding({ children, variant, size }, ref) {
-        if (!children) {
+    function Feilmelding({ feil }, ref) {
+        if (!feil) {
             return null;
         }
 
-        switch (variant) {
-            case 'alert':
-                return (
-                    <Alert ref={ref} variant="error" size={size}>
-                        {children}
-                    </Alert>
-                );
-
-            case 'inline':
-            default:
-                return (
-                    <ErrorMessage ref={ref} size={size}>
-                        {children}
-                    </ErrorMessage>
-                );
+        if (typeof feil === 'string') {
+            return (
+                <Alert variant="warning" size="small" ref={ref}>
+                    {feil}
+                </Alert>
+            );
         }
+
+        return (
+            <Alert variant={finnFeilmeldingVariant(feil.status)} size="small" ref={ref} fullWidth>
+                {feil.tittel && <Label size="small">{feil.tittel}</Label>}
+
+                <BodyShort size="small">{feil.feilmelding}</BodyShort>
+                <HStack align="center">
+                    {feil.feilkode && <Detail>Feilkode: {feil.feilkode}</Detail>}
+                    {feil.feilmeldingMedFeilkode && (
+                        <CopyButton copyText={feil.feilmeldingMedFeilkode} size="small" />
+                    )}
+                </HStack>
+            </Alert>
+        );
     }
 );

--- a/src/frontend/komponenter/Feil/feilmeldingUtils.ts
+++ b/src/frontend/komponenter/Feil/feilmeldingUtils.ts
@@ -1,0 +1,42 @@
+import { RessursFeilet, RessursStatus, RessursStatusFeilet } from '../../typer/ressurs';
+
+export interface Feil {
+    feilmelding: string;
+    tittel?: string;
+    status?: RessursStatusFeilet;
+    feilkode?: string;
+    feilmeldingMedFeilkode?: string;
+}
+
+export const feiletRessursTilFeilmelding = (
+    feiletRessurs: RessursFeilet,
+    tittel?: string
+): Feil => ({
+    feilmelding: feiletRessurs.frontendFeilmeldingUtenFeilkode || feiletRessurs.frontendFeilmelding,
+    tittel: tittel,
+    status: feiletRessurs.status,
+    feilkode: feiletRessurs.feilkode,
+    feilmeldingMedFeilkode: feiletRessurs.frontendFeilmelding,
+});
+
+export const lagFeilmelding = (
+    feilmelding: string,
+    tittel?: string,
+    ressursStatus?: RessursStatusFeilet
+) => ({
+    feilmelding: feilmelding,
+    tittel: tittel,
+    status: ressursStatus,
+});
+
+export const finnFeilmeldingVariant = (status: RessursStatus | undefined): 'error' | 'warning' => {
+    switch (status) {
+        case RessursStatus.FEILET:
+        case RessursStatus.IKKE_TILGANG:
+            return 'error';
+
+        case RessursStatus.FUNKSJONELL_FEIL:
+        default:
+            return 'warning';
+    }
+};

--- a/src/frontend/komponenter/Feil/feilmeldingUtils.ts
+++ b/src/frontend/komponenter/Feil/feilmeldingUtils.ts
@@ -40,3 +40,10 @@ export const finnFeilmeldingVariant = (status: RessursStatus | undefined): 'erro
             return 'warning';
     }
 };
+
+export const erFeil = (feil: unknown): feil is Feil => {
+    if (typeof feil === 'object' && feil && 'feilmelding' in feil) {
+        return true;
+    }
+    return false;
+};

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -81,7 +81,8 @@ export const StegKnapp: FC<{
     }
 
     return (
-        <VStack align={'start'}>
+        <VStack align="start" gap="4">
+            <Feilmelding feil={feilmelding} />
             {behandling.steg === steg && erStegRedigerbart && (
                 <Button variant="primary" size="small" onClick={gåTilNesteSteg}>
                     {children}
@@ -92,7 +93,6 @@ export const StegKnapp: FC<{
                     Rediger steg
                 </Button>
             )}
-            <Feilmelding>{feilmelding}</Feilmelding>
         </VStack>
     );
 };

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -10,6 +10,7 @@ import { FanePath } from '../../Sider/Behandling/faner';
 import { Steg, stegErEtterAnnetSteg } from '../../typer/behandling/steg';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../typer/ressurs';
 import { Feilmelding } from '../Feil/Feilmelding';
+import { feiletRessursTilFeilmelding, Feil, lagFeilmelding } from '../Feil/feilmeldingUtils';
 
 const feilmeldingUlagretData = 'Har ulagret data, vennligst ferdigstill';
 
@@ -29,10 +30,10 @@ export const StegKnapp: FC<{
 
     const { behandling, behandlingErRedigerbar, hentBehandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
-    const [feilmelding, settFeilmelding] = useState<string>();
+    const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
 
     useEffect(() => {
-        if (!harUlagradeKomponenter && feilmelding === feilmeldingUlagretData) {
+        if (!harUlagradeKomponenter && feilmelding?.feilmelding === feilmeldingUlagretData) {
             settFeilmelding(undefined);
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -46,14 +47,14 @@ export const StegKnapp: FC<{
             if (res.status === RessursStatus.SUKSESS) {
                 hentBehandling.rerun();
             } else {
-                settFeilmelding(`Kunne ikke redigere steg: ${res.frontendFeilmelding}`);
+                settFeilmelding(feiletRessursTilFeilmelding(res, 'Kunne ikke redigere steg'));
             }
         });
     };
 
     const gåTilNesteSteg = () => {
         if (validerUlagedeKomponenter && harUlagradeKomponenter) {
-            settFeilmelding(feilmeldingUlagretData);
+            settFeilmelding(lagFeilmelding(feilmeldingUlagretData, 'Kunne ikke gå til neste steg'));
             return;
         }
         settFeilmelding(undefined);
@@ -71,7 +72,7 @@ export const StegKnapp: FC<{
                 hentBehandling.rerun();
                 navigate(`/behandling/${behandling.id}/${nesteFane}`);
             } else {
-                settFeilmelding(`Kunne ikke gå til neste steg: ${res.frontendFeilmelding}`);
+                settFeilmelding(feiletRessursTilFeilmelding(res, 'Kunne ikke gå til neste steg'));
             }
         });
     };

--- a/src/frontend/typer/ressurs.ts
+++ b/src/frontend/typer/ressurs.ts
@@ -21,16 +21,12 @@ type RessursLaster = {
     status: RessursStatus.HENTER;
 };
 
-type FeilMelding = {
+export type RessursFeilet = {
     frontendFeilmelding: string;
     frontendFeilmeldingUtenFeilkode: string | undefined;
     feilkode: string | undefined;
+    status: RessursStatusFeilet;
 };
-
-export type RessursFeilet =
-    | (FeilMelding & { status: RessursStatus.IKKE_TILGANG })
-    | (FeilMelding & { status: RessursStatus.FEILET })
-    | (FeilMelding & { status: RessursStatus.FUNKSJONELL_FEIL });
 
 export type Ressurs<T> =
     | { status: RessursStatus.IKKE_HENTET }

--- a/src/frontend/typer/ressurs.ts
+++ b/src/frontend/typer/ressurs.ts
@@ -7,6 +7,11 @@ export enum RessursStatus {
     FUNKSJONELL_FEIL = 'FUNKSJONELL_FEIL',
 }
 
+export type RessursStatusFeilet =
+    | RessursStatus.FEILET
+    | RessursStatus.FUNKSJONELL_FEIL
+    | RessursStatus.IKKE_TILGANG;
+
 export type RessursSuksess<T> = {
     data: T;
     status: RessursStatus.SUKSESS;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
[Favro-kort](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24221)

Har endret på `<Feilmelding/>` slik at den enten kun tar inn en feil av følgende typer: 
- `undefined` - returnerer null (som før)
- `string` - returnerer teksten i en alert av typen "warning" (oransje) fordi denne brukes dersom man vil kaste en feil i frontend. Disse feilene er gjerne noe saksbehandler kan rette opp i selv og da trenger de ikke være så dramatisk.
- , `Feil` - Denne returnerer en litt mer strukturert feilmelding hvor feilkoden er mindre og hele feilmeldingen kan kopieres.

Hvis man trenger å sende inn en string, men ønsker å ha error (rød) feilmelding så kan bruke funksjonen `lagFeilmelding()` og sende med statusen `RessursStatus.Feilet`.

Se commit for commit!!! ⚠️ 
1. Oppdateringene som var nødvendig i selve feilmelding-komponenten
2. Endre `<Feilmelding>{children}</Feilmelding` til  `<Feilmelding feil={children} />` siden feilen ikke lenger tas i mot som children
3. Smått
4. Endre typene til feilmeldinger til `Feil` for de stedene feilen kommer av api-kall (her er det noe kombo, så noen ganger legges kun en string inn i Feil)
5. Smått
6. Vi oppdaterte stønadsperiodefeil mange steder så for å gjøre det enklere flyttet jeg det til en funksjon i contexten som brukte `Feil`

Eksempel feilmelding som kun er string: 

|Før|Etter|
|-----|----|
|<img width="748" alt="image" src="https://github.com/user-attachments/assets/e3b38137-9867-43dc-8c0d-1c47f235c9d0" />|<img width="1227" alt="image" src="https://github.com/user-attachments/assets/c18df0d5-c13e-4662-9a80-abe6208ef98f" />|

Eksempel feilmelding fra api med feilkode:
<img width="794" alt="image" src="https://github.com/user-attachments/assets/7e5e4504-16ce-4edf-aa43-2f2dba22287f" />
