### PR TITLE
Skal ikke vise bruk-knapp på aktiviteter/ytelser som slutter før revurder fra dato

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
@@ -3,6 +3,8 @@ import React from 'react';
 import { CheckmarkIcon } from '@navikt/aksel-icons';
 import { Button, Tag } from '@navikt/ds-react';
 
+import { kanRegisterAktivitetBrukes } from './utilsAktivitet';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../../context/StegContext';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
@@ -20,7 +22,13 @@ export function BrukAktivitetKnapp({
 }) {
     const { aktiviteter } = useInngangsvilkår();
     const { erStegRedigerbart } = useSteg();
+    const { behandling } = useBehandling();
+
     const harBruktAktivitet = erAktivitetLagtTil(aktiviteter, registerAktivitet);
+    const aktivitetKanBrukes = kanRegisterAktivitetBrukes(
+        registerAktivitet,
+        behandling.revurderFra
+    );
 
     if (harBruktAktivitet) {
         return (
@@ -33,7 +41,7 @@ export function BrukAktivitetKnapp({
                 Brukt
             </Tag>
         );
-    } else if (erStegRedigerbart) {
+    } else if (erStegRedigerbart && aktivitetKanBrukes) {
         return (
             <Button size="xsmall" onClick={() => leggTilAktivitetFraRegister(registerAktivitet)}>
                 Bruk

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
@@ -3,12 +3,12 @@ import React from 'react';
 import { CheckmarkIcon } from '@navikt/aksel-icons';
 import { Button, Tag } from '@navikt/ds-react';
 
-import { kanRegisterAktivitetBrukes } from './utilsAktivitet';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../../context/StegContext';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { Aktivitet } from '../typer/vilkårperiode/aktivitet';
+import { kanRegisterperiodeBrukes } from '../Vilkårperioder/vilkårperiodeUtil';
 
 const erAktivitetLagtTil = (aktiviteter: Aktivitet[], registerAktivitet: Registeraktivitet) =>
     aktiviteter.some((aktivitet) => registerAktivitet.id === aktivitet.kildeId);
@@ -25,10 +25,7 @@ export function BrukAktivitetKnapp({
     const { behandling } = useBehandling();
 
     const harBruktAktivitet = erAktivitetLagtTil(aktiviteter, registerAktivitet);
-    const aktivitetKanBrukes = kanRegisterAktivitetBrukes(
-        registerAktivitet,
-        behandling.revurderFra
-    );
+    const aktivitetKanBrukes = kanRegisterperiodeBrukes(registerAktivitet, behandling.revurderFra);
 
     if (harBruktAktivitet) {
         return (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
@@ -1,5 +1,7 @@
 import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
+import { Registeraktivitet } from '../../../../typer/registeraktivitet';
+import { erDatoEtterEllerLik } from '../../../../utils/dato';
 import { AktivitetType, AktivitetTypeTilTekst } from '../typer/vilkårperiode/aktivitet';
 
 export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
@@ -38,4 +40,15 @@ export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype
         case Stønadstype.BOUTGIFTER:
             return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_AKTIVITET];
     }
+};
+
+/**
+ * En aktivitet kan alltid brukes i en førstegangsbehandling
+ * Hvis det er en revurdering kan den kun brukes dersom aktiviteten er etter datoen det revurderes fra.
+ */
+export const kanRegisterAktivitetBrukes = (aktivitet: Registeraktivitet, revurderFra?: string) => {
+    if (!revurderFra) return true;
+    if (!aktivitet.fom) return false;
+
+    return erDatoEtterEllerLik(revurderFra, aktivitet.fom);
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
@@ -1,7 +1,7 @@
 import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
-import { erDatoEtterEllerLik } from '../../../../utils/dato';
+import { datoErIPeriodeInklusivSlutt, erDatoEtterEllerLik } from '../../../../utils/dato';
 import { AktivitetType, AktivitetTypeTilTekst } from '../typer/vilkårperiode/aktivitet';
 
 export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
@@ -44,11 +44,15 @@ export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype
 
 /**
  * En aktivitet kan alltid brukes i en førstegangsbehandling
- * Hvis det er en revurdering kan den kun brukes dersom aktiviteten er etter datoen det revurderes fra.
+ * Hvis det er en revurdering kan den kun brukes dersom det revurderes eller eller i aktivitetens periode
+ * OBS: Man vil ikke kunne lagre den brukte aktiviteten som en vilkårperiode uten å endre fom-datoen til minst revurder fra.
  */
 export const kanRegisterAktivitetBrukes = (aktivitet: Registeraktivitet, revurderFra?: string) => {
     if (!revurderFra) return true;
     if (!aktivitet.fom) return false;
 
-    return erDatoEtterEllerLik(revurderFra, aktivitet.fom);
+    return (
+        erDatoEtterEllerLik(revurderFra, aktivitet.fom) ||
+        (aktivitet.tom && datoErIPeriodeInklusivSlutt(revurderFra, aktivitet.fom, aktivitet.tom))
+    );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
@@ -1,7 +1,5 @@
 import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
-import { Registeraktivitet } from '../../../../typer/registeraktivitet';
-import { datoErIPeriodeInklusivSlutt, erDatoEtterEllerLik } from '../../../../utils/dato';
 import { AktivitetType, AktivitetTypeTilTekst } from '../typer/vilkårperiode/aktivitet';
 
 export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
@@ -40,19 +38,4 @@ export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype
         case Stønadstype.BOUTGIFTER:
             return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_AKTIVITET];
     }
-};
-
-/**
- * En aktivitet kan alltid brukes i en førstegangsbehandling
- * Hvis det er en revurdering kan den kun brukes dersom det revurderes eller eller i aktivitetens periode
- * OBS: Man vil ikke kunne lagre den brukte aktiviteten som en vilkårperiode uten å endre fom-datoen til minst revurder fra.
- */
-export const kanRegisterAktivitetBrukes = (aktivitet: Registeraktivitet, revurderFra?: string) => {
-    if (!revurderFra) return true;
-    if (!aktivitet.fom) return false;
-
-    return (
-        erDatoEtterEllerLik(revurderFra, aktivitet.fom) ||
-        (aktivitet.tom && datoErIPeriodeInklusivSlutt(revurderFra, aktivitet.fom, aktivitet.tom))
-    );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
@@ -5,10 +5,10 @@ import styled from 'styled-components';
 import { Button, Table } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
-import { utledYtelseTekst } from './utils';
+import { kanRegisterYtelseBrukes, utledYtelseTekst } from './utils';
 import { useSteg } from '../../../../context/StegContext';
 import { formaterIsoDato, formaterNullableIsoDato } from '../../../../utils/dato';
-import { SubtypeYtelseGrunnlag, YtelseGrunnlagPeriode } from '../typer/vilkårperiode/vilkårperiode';
+import { YtelseGrunnlagPeriode } from '../typer/vilkårperiode/vilkårperiode';
 
 const HvitTabell = styled(Table)`
     background: white;
@@ -41,15 +41,11 @@ const RegisterYtelserTabell: React.FC<{
                             <Table.DataCell>{formaterIsoDato(ytelse.fom)}</Table.DataCell>
                             <Table.DataCell>{formaterNullableIsoDato(ytelse.tom)}</Table.DataCell>
                             <Table.DataCell>
-                                {erStegRedigerbart &&
-                                    ytelse.subtype !== SubtypeYtelseGrunnlag.AAP_FERDIG_AVKLART && (
-                                        <Button
-                                            size="xsmall"
-                                            onClick={() => lagRadForPeriode(ytelse)}
-                                        >
-                                            Bruk
-                                        </Button>
-                                    )}
+                                {erStegRedigerbart && kanRegisterYtelseBrukes(ytelse) && (
+                                    <Button size="xsmall" onClick={() => lagRadForPeriode(ytelse)}>
+                                        Bruk
+                                    </Button>
+                                )}
                             </Table.DataCell>
                         </Table.Row>
                     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -22,6 +22,7 @@ import {
     YtelseGrunnlagPeriode,
 } from '../typer/vilkårperiode/vilkårperiode';
 import { BegrunnelseGrunner } from '../Vilkårperioder/Begrunnelse/utils';
+import { kanRegisterperiodeBrukes } from '../Vilkårperioder/vilkårperiodeUtil';
 
 export type MålgrupperMedMedlemskapsvurdering =
     | MålgruppeType.NEDSATT_ARBEIDSEVNE
@@ -188,4 +189,13 @@ export const mapFaktaOgSvarTilRequest = (
 
 export const utledYtelseTekst = (periode: YtelseGrunnlagPeriode): string => {
     return `${registerYtelseTilTekstStorForbokstav[periode.type]}${periode.subtype === SubtypeYtelseGrunnlag.AAP_FERDIG_AVKLART ? ' (Ferdig avklart)' : ''}`;
+};
+
+export const kanRegisterYtelseBrukes = (
+    ytelse: YtelseGrunnlagPeriode,
+    revurderFra?: string
+): boolean => {
+    if (ytelse.subtype === SubtypeYtelseGrunnlag.AAP_FERDIG_AVKLART) return false;
+
+    return kanRegisterperiodeBrukes(ytelse, revurderFra);
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/vilkårperiodeUtil.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/vilkårperiodeUtil.ts
@@ -1,0 +1,18 @@
+import { Registeraktivitet } from '../../../../typer/registeraktivitet';
+import { erDatoFørEllerLik } from '../../../../utils/dato';
+import { YtelseGrunnlagPeriode } from '../typer/vilkårperiode/vilkårperiode';
+
+/**
+ * Brukes for å vite om en ytelse/aktivitet hentet fra register kan brukes i en behandling
+ * Den kan alltid brukes i en førstegangsbehandling
+ * Hvis det er en revurdering kan den kun brukes dersom det revurderes i eller før perioden som er hentet
+ */
+export const kanRegisterperiodeBrukes = (
+    registerPeriode: YtelseGrunnlagPeriode | Registeraktivitet,
+    revurderFra?: string
+) => {
+    if (!revurderFra) return true;
+    if (!registerPeriode.fom) return false;
+
+    return !registerPeriode.tom || erDatoFørEllerLik(revurderFra, registerPeriode.tom);
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
I [pr 613 i sak](https://github.com/navikt/tilleggsstonader-sak/pull/613) blir det lagt inn at man henter aktiviteter og ytelser helt fra første registrerte vilkårperiode. Da man ikke vil kunne lagre ned vilkårsperioder som starter før revurder fra er det dumt å gi de tilbudet. 

Knappen fjernes nå dersom man revurderer etter at en aktivitet eller ytelse er ferdig. Dvs. at man kan bruke en periode hvis man revurderer midt i perioden, men man vil ikke kunne lagre ned med mindre man endrer på "fom" datoen. Dette gjør at man kan beholde kildeId-en på aktiviteter fremfor å manuelt legge inn uten denne koblingen