### PR TITLE
Støtte for å kunne legge inn flere hjemler ved oppretthold vurdering

### DIFF
--- a/src/frontend/Sider/Klage/Steg/Formkrav/EndreFormkravVurderinger.tsx
+++ b/src/frontend/Sider/Klage/Steg/Formkrav/EndreFormkravVurderinger.tsx
@@ -208,7 +208,7 @@ export const EndreFormkravVurderinger: React.FC<IProps> = ({
                         <>
                             <Textarea
                                 label={'Begrunnelse (intern)'}
-                                value={vurderinger.saksbehandlerBegrunnelse}
+                                value={vurderinger.saksbehandlerBegrunnelse || ''}
                                 onChange={(e) => {
                                     settIkkePersistertKomponent('formkravVilkår');
                                     settOppdaterteVurderinger((prevState: IFormkravVilkår) => {
@@ -234,7 +234,7 @@ export const EndreFormkravVurderinger: React.FC<IProps> = ({
                                         </HjelpeTekst>
                                     </FlexRow>
                                 }
-                                value={vurderinger.brevtekst}
+                                value={vurderinger.brevtekst || ''}
                                 onChange={(e) => {
                                     settIkkePersistertKomponent('formkravVilkår');
                                     settOppdaterteVurderinger((prevState: IFormkravVilkår) => {

--- a/src/frontend/Sider/Klage/Steg/Vurdering/HjemmelVelger.tsx
+++ b/src/frontend/Sider/Klage/Steg/Vurdering/HjemmelVelger.tsx
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction } from 'react';
 
 import styled from 'styled-components';
 
-import { Heading, Select } from '@navikt/ds-react';
+import { Heading, UNSAFE_Combobox } from '@navikt/ds-react';
 
 import { alleHjemlerTilVisningstekst, Hjemmel } from './hjemmel';
 import { Vurderingsfelter } from './vurderingsfelter';
@@ -18,41 +18,52 @@ const HjemmelInnholdStyled = styled.div`
 `;
 
 interface IHjemmel {
-    settHjemmel: Dispatch<SetStateAction<Vurderingsfelter>>;
-    hjemmelValgt?: Hjemmel;
+    settHjemler: Dispatch<SetStateAction<Vurderingsfelter>>;
+    hjemler?: Hjemmel[];
     endring: (komponentId: string) => void;
 }
 
-export const HjemmelVelger: React.FC<IHjemmel> = ({ settHjemmel, hjemmelValgt, endring }) => {
+const hjemlerTilOptions = (hjemler: Hjemmel[] | undefined) =>
+    hjemler?.map((hjemmel) => ({
+        value: hjemmel,
+        label: alleHjemlerTilVisningstekst[hjemmel as Hjemmel],
+    })) ?? [];
+
+export const HjemmelVelger: React.FC<IHjemmel> = ({ settHjemler, hjemler, endring }) => {
+    const options = hjemlerTilOptions(Object.keys(alleHjemlerTilVisningstekst) as Hjemmel[]);
+    const selectedOptions = hjemlerTilOptions(hjemler);
+    const onToggleSelected = (option: string, isSelected: boolean) => {
+        endring('hjemmel');
+        settHjemler((prevState) => {
+            if (isSelected) {
+                return {
+                    ...prevState,
+                    hjemler: [...(prevState.hjemler || []), option as Hjemmel],
+                };
+            } else {
+                return {
+                    ...prevState,
+                    hjemler: (prevState.hjemler || []).filter((hjemmel) => hjemmel !== option),
+                };
+            }
+        });
+    };
+
     return (
         <HjemmelStyled>
             <Heading spacing size="medium" level="5">
                 Hjemmel
             </Heading>
             <HjemmelInnholdStyled>
-                <Select
-                    value={hjemmelValgt}
+                <UNSAFE_Combobox
                     label=""
-                    size="medium"
-                    onChange={(e) => {
-                        endring(e.target.value);
-                        settHjemmel(
-                            (tidligereTilstand: Vurderingsfelter) =>
-                                ({
-                                    ...tidligereTilstand,
-                                    hjemmel: e.target.value,
-                                }) as Vurderingsfelter
-                        );
-                    }}
                     hideLabel
-                >
-                    <option value={''}>Velg</option>
-                    {Object.keys(alleHjemlerTilVisningstekst).map((hjemmel: string) => (
-                        <option value={hjemmel as Hjemmel} key={hjemmel}>
-                            {alleHjemlerTilVisningstekst[hjemmel as Hjemmel]}
-                        </option>
-                    ))}
-                </Select>
+                    size="medium"
+                    options={options}
+                    selectedOptions={selectedOptions}
+                    onToggleSelected={onToggleSelected}
+                    isMultiSelect={true}
+                />
             </HjemmelInnholdStyled>
         </HjemmelStyled>
     );

--- a/src/frontend/Sider/Klage/Steg/Vurdering/HjemmelVelger.tsx
+++ b/src/frontend/Sider/Klage/Steg/Vurdering/HjemmelVelger.tsx
@@ -3,7 +3,7 @@ import { Dispatch, SetStateAction } from 'react';
 
 import styled from 'styled-components';
 
-import { Heading, UNSAFE_Combobox } from '@navikt/ds-react';
+import { UNSAFE_Combobox } from '@navikt/ds-react';
 
 import { alleHjemlerTilVisningstekst, Hjemmel } from './hjemmel';
 import { Vurderingsfelter } from './vurderingsfelter';
@@ -14,7 +14,7 @@ const HjemmelStyled = styled.div`
 
 const HjemmelInnholdStyled = styled.div`
     display: block;
-    width: 18rem;
+    width: 23rem;
 `;
 
 interface IHjemmel {
@@ -51,18 +51,19 @@ export const HjemmelVelger: React.FC<IHjemmel> = ({ settHjemler, hjemler, endrin
 
     return (
         <HjemmelStyled>
-            <Heading spacing size="medium" level="5">
-                Hjemmel
-            </Heading>
             <HjemmelInnholdStyled>
                 <UNSAFE_Combobox
-                    label=""
-                    hideLabel
+                    label="Hjemler"
+                    description={'Velg inntil 2 hjemler som klagen kan knyttes til'}
                     size="medium"
                     options={options}
                     selectedOptions={selectedOptions}
                     onToggleSelected={onToggleSelected}
                     isMultiSelect={true}
+                    maxSelected={{
+                        limit: 2,
+                        message: `2 av maks 2 er valgt`,
+                    }}
                 />
             </HjemmelInnholdStyled>
         </HjemmelStyled>

--- a/src/frontend/Sider/Klage/Steg/Vurdering/Vedtak.tsx
+++ b/src/frontend/Sider/Klage/Steg/Vurdering/Vedtak.tsx
@@ -38,7 +38,7 @@ export const Vedtak: React.FC<IVedtak> = ({
                     ...tidligereTilstand,
                     vedtak: nyttValg,
                     årsak: undefined,
-                    hjemmel: undefined,
+                    hjemler: undefined,
                 }) as Vurderingsfelter
         );
     };

--- a/src/frontend/Sider/Klage/Steg/Vurdering/Vurdering.tsx
+++ b/src/frontend/Sider/Klage/Steg/Vurdering/Vurdering.tsx
@@ -177,14 +177,16 @@ export const Vurdering: React.FC<{ behandlingId: string }> = ({ behandlingId }) 
                                 {oppdatertVurdering.vedtak == VedtakValg.OPPRETTHOLD_VEDTAK && (
                                     <>
                                         <HjemmelVelger
-                                            settHjemmel={settOppdatertVurdering}
-                                            hjemmelValgt={oppdatertVurdering.hjemmel}
+                                            settHjemler={settOppdatertVurdering}
+                                            hjemler={oppdatertVurdering.hjemler}
                                             endring={settIkkePersistertKomponent}
                                         />
                                         <FritekstFeltWrapper>
                                             <EnsligTextArea
                                                 label="Innstilling til Nav Klageinstans (kommer med i brev til bruker)"
-                                                value={oppdatertVurdering.innstillingKlageinstans}
+                                                value={
+                                                    oppdatertVurdering.innstillingKlageinstans || ''
+                                                }
                                                 onChange={(e) => {
                                                     settIkkePersistertKomponent(e.target.value);
                                                     settOppdatertVurdering((tidligereTilstand) => ({

--- a/src/frontend/Sider/Klage/Steg/Vurdering/VurderingLesemodus.tsx
+++ b/src/frontend/Sider/Klage/Steg/Vurdering/VurderingLesemodus.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 
 import styled from 'styled-components';
 
-import { BodyLong, BodyShort, Heading } from '@navikt/ds-react';
+import { BodyLong, BodyShort, Heading, List } from '@navikt/ds-react';
 
 import { alleHjemlerTilVisningstekst } from './hjemmel';
 import { VedtakValg, vedtakValgTilTekst, årsakValgTilTekst } from './vurderingValg';
@@ -60,7 +60,7 @@ const OmgjørVedtak: React.FC<{ vurdering: OmgjøringDto }> = ({ vurdering }) =>
 };
 
 const OpprettholdVedtak: React.FC<{ vurdering: OpprettholdelseDto }> = ({ vurdering }) => {
-    const { vedtak, hjemmel, innstillingKlageinstans, interntNotat } = vurdering;
+    const { vedtak, hjemler, innstillingKlageinstans, interntNotat } = vurdering;
     return (
         <Container>
             <Avsnitt>
@@ -71,9 +71,13 @@ const OpprettholdVedtak: React.FC<{ vurdering: OpprettholdelseDto }> = ({ vurder
             </Avsnitt>
             <Avsnitt>
                 <Heading level="1" size="medium">
-                    Årsak
+                    Hjemler
                 </Heading>
-                <BodyShort>{alleHjemlerTilVisningstekst[hjemmel]}</BodyShort>
+                <List>
+                    {hjemler.map((hjemmel) => (
+                        <List.Item key={hjemmel}>{alleHjemlerTilVisningstekst[hjemmel]}</List.Item>
+                    ))}
+                </List>
             </Avsnitt>
             <Avsnitt>
                 <Heading level="1" size="medium">

--- a/src/frontend/Sider/Klage/Steg/Vurdering/vurderingsfelter.ts
+++ b/src/frontend/Sider/Klage/Steg/Vurdering/vurderingsfelter.ts
@@ -7,7 +7,7 @@ export interface Vurderingsfelter {
     vedtak?: VedtakValg;
     årsak?: ÅrsakOmgjøring;
     begrunnelseOmgjøring?: string;
-    hjemmel?: Hjemmel;
+    hjemler?: Hjemmel[];
     innstillingKlageinstans?: string;
     interntNotat?: string;
 }
@@ -19,8 +19,8 @@ export function erNødvendigeFelterUtfylt(vurderinsfelter: Vurderingsfelter): bo
         const { årsak, begrunnelseOmgjøring } = vurderinsfelter;
         return harVerdi(årsak) && harVerdi(begrunnelseOmgjøring);
     } else {
-        const { innstillingKlageinstans, hjemmel } = vurderinsfelter;
-        return harVerdi(innstillingKlageinstans) && harVerdi(hjemmel);
+        const { innstillingKlageinstans, hjemler } = vurderinsfelter;
+        return harVerdi(innstillingKlageinstans) && !!hjemler && hjemler.length > 0;
     }
 }
 
@@ -31,7 +31,7 @@ export function tilVurderingDto(vurderinger: Vurderingsfelter, behandlingId: str
     return vurderinger.vedtak === VedtakValg.OPPRETTHOLD_VEDTAK
         ? lagOpprettholdelseDto(
               behandlingId,
-              vurderinger.hjemmel!,
+              vurderinger.hjemler!,
               vurderinger.innstillingKlageinstans!,
               vurderinger.interntNotat!
           )

--- a/src/frontend/Sider/Klage/hooks/useVurdering.ts
+++ b/src/frontend/Sider/Klage/hooks/useVurdering.ts
@@ -28,7 +28,7 @@ export interface OmgjøringDto {
 export interface OpprettholdelseDto {
     behandlingId: string;
     vedtak: VedtakValg.OPPRETTHOLD_VEDTAK;
-    hjemmel: Hjemmel;
+    hjemler: Hjemmel[];
     innstillingKlageinstans: string;
     interntNotat: string;
 }
@@ -48,14 +48,14 @@ export function lagOmgjøringDto(
 
 export function lagOpprettholdelseDto(
     behandlingId: string,
-    hjemmel: Hjemmel,
+    hjemler: Hjemmel[],
     innstillingKlageinstans: string,
     interntNotat: string
 ): OpprettholdelseDto {
     return {
         behandlingId,
         vedtak: VedtakValg.OPPRETTHOLD_VEDTAK,
-        hjemmel,
+        hjemler,
         innstillingKlageinstans,
         interntNotat,
     };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å kunne velge flere hjemler ved oppretthold vurdering

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21506

* https://github.com/navikt/tilleggsstonader-klage/pull/68

### Redigering
<img width="375" alt="image" src="https://github.com/user-attachments/assets/1b322c96-4179-44c7-8318-de41c266a6bf" />
<img width="368" alt="image" src="https://github.com/user-attachments/assets/265af60f-0ed9-4cc3-b2d5-51cbe25b5c84" />

### Lesemodus
![image](https://github.com/user-attachments/assets/70e04eb6-4bc9-4a53-9ac7-571b72c3ace9)

### Internt vedtak/blankett
<img width="416" alt="image" src="https://github.com/user-attachments/assets/2d2512bf-7951-4374-aace-770ec89ad807" />
