### PR TITLE
Oppsummering vilkår i fanen for stønadsvilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetBarnetilsyn.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetBarnetilsyn.ts
@@ -1,9 +1,6 @@
-import { AktivitetType } from './aktivitet';
-import { SvarJaNei, VilkårPeriode, Vurdering } from './vilkårperiode';
+import { VilkårPeriodeAktivitet, SvarJaNei, Vurdering } from './vilkårperiode';
 
-export interface AktivitetBarnetilsyn extends VilkårPeriode {
-    id: string;
-    type: AktivitetType;
+export interface AktivitetBarnetilsyn extends VilkårPeriodeAktivitet {
     kildeId?: string;
     faktaOgVurderinger: AktivitetBarnetilsynFaktaOgVurderinger;
 }

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler.ts
@@ -1,8 +1,7 @@
 import { AktivitetType } from './aktivitet';
-import { SvarJaNei, VilkårPeriode, Vurdering } from './vilkårperiode';
+import { VilkårPeriodeAktivitet, SvarJaNei, Vurdering } from './vilkårperiode';
 
-export interface AktivitetLæremidler extends VilkårPeriode {
-    id: string;
+export interface AktivitetLæremidler extends VilkårPeriodeAktivitet {
     type: AktivitetTypeLæremidler;
     kildeId?: string;
     faktaOgVurderinger: AktivitetLæremidlerFaktaOgVurderinger;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -3,7 +3,6 @@ import { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions
 import { Stønadstype } from '../../../../../typer/behandling/behandlingTema';
 
 export interface Målgruppe extends VilkårPeriode {
-    id: string;
     type: MålgruppeType;
     faktaOgVurderinger: MålgruppeVurderinger;
 }

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
@@ -66,6 +66,10 @@ export interface VilkårPeriode extends Periode {
     forrigeVilkårperiodeId?: string;
 }
 
+export interface VilkårPeriodeAktivitet extends VilkårPeriode {
+    type: AktivitetType;
+}
+
 export enum VilkårPeriodeResultat {
     OPPFYLT = 'OPPFYLT',
     IKKE_OPPFYLT = 'IKKE_OPPFYLT',

--- a/src/frontend/Sider/Behandling/OppsummeringVilkår/OppsummeringVilkårperioder.tsx
+++ b/src/frontend/Sider/Behandling/OppsummeringVilkår/OppsummeringVilkårperioder.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+
+import { Box, Heading, HGrid, VStack } from '@navikt/ds-react';
+
+import { OppsummeringAktiviteter, OppsummeringMålgrupper } from './VilkårOppsummeringRad';
+import { useVilkårperioder } from '../../../hooks/useVilkårperioder';
+import DataViewer from '../../../komponenter/DataViewer';
+
+export const OppsummeringVilkårperioder: React.FC<{ behandlingId: string }> = ({
+    behandlingId,
+}) => {
+    const { vilkårperioderResponse } = useVilkårperioder(behandlingId);
+
+    return (
+        <Box background="surface-selected" padding={'4'}>
+            <DataViewer response={{ vilkårperioderResponse }}>
+                {({ vilkårperioderResponse }) => (
+                    <VStack gap={'6'}>
+                        <HGrid columns={'125px auto'}>
+                            <Heading size="small">Aktivitet</Heading>
+                            <VStack gap={'2'}>
+                                <OppsummeringAktiviteter
+                                    aktiviteter={vilkårperioderResponse.vilkårperioder.aktiviteter}
+                                />
+                            </VStack>
+                        </HGrid>
+                        <HGrid columns={'125px auto'}>
+                            <Heading size="small">Målgruppe</Heading>
+                            <VStack gap={'2'}>
+                                <OppsummeringMålgrupper
+                                    målgrupper={vilkårperioderResponse.vilkårperioder.målgrupper}
+                                />
+                            </VStack>
+                        </HGrid>
+                    </VStack>
+                )}
+            </DataViewer>
+        </Box>
+    );
+};

--- a/src/frontend/Sider/Behandling/OppsummeringVilkår/OppsummeringVilkårperioderOgVilkår.tsx
+++ b/src/frontend/Sider/Behandling/OppsummeringVilkår/OppsummeringVilkårperioderOgVilkår.tsx
@@ -2,18 +2,17 @@ import React, { useEffect } from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, HGrid, HStack, VStack } from '@navikt/ds-react';
+import { BodyShort, HGrid, VStack } from '@navikt/ds-react';
 
+import {
+    OppsummeringAktiviteter,
+    OppsummeringMålgrupper,
+    VilkårOppsummeringRad,
+} from './VilkårOppsummeringRad';
 import { useHentVilkårsvurdering } from '../../../hooks/useHentVilkårsvurdering';
 import { useVilkårperioder } from '../../../hooks/useVilkårperioder';
 import DataViewer from '../../../komponenter/DataViewer';
-import { VilkårsresultatIkon } from '../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
 import { BehandlingFaktaTilsynBarn } from '../../../typer/behandling/behandlingFakta/behandlingFakta';
-import { formaterNullablePeriode } from '../../../utils/dato';
-import { aktivitetTypeTilTekst } from '../Inngangsvilkår/Aktivitet/utilsAktivitet';
-import { målgruppeTypeTilTekst } from '../Inngangsvilkår/typer/vilkårperiode/målgruppe';
-import { VilkårPeriodeResultat } from '../Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
-import { Vilkårsresultat } from '../vilkår';
 
 const StyledHGrid = styled(HGrid).withConfig({
     shouldForwardProp: (prop) => prop !== 'bottomBorder',
@@ -46,36 +45,24 @@ export const OppsummeringVilkårperioderOgVilkår: React.FC<{ behandlingId: stri
                     <StyledHGrid bottomBorder columns={'125px auto'}>
                         <BodyShort size={'small'}>Aktivitet</BodyShort>
                         <VStack gap={'2'}>
-                            {vilkårperioderResponse.vilkårperioder.aktiviteter.map((aktivitet) => (
-                                <InfoRad
-                                    key={aktivitet.id}
-                                    resultat={aktivitet.resultat}
-                                    fom={aktivitet.fom}
-                                    tom={aktivitet.tom}
-                                    gjelder={aktivitetTypeTilTekst(aktivitet.type)}
-                                />
-                            ))}
+                            <OppsummeringAktiviteter
+                                aktiviteter={vilkårperioderResponse.vilkårperioder.aktiviteter}
+                            />
                         </VStack>
                     </StyledHGrid>
                     <StyledHGrid bottomBorder columns={'125px auto'}>
                         <BodyShort size={'small'}>Målgruppe</BodyShort>
                         <VStack gap={'2'}>
-                            {vilkårperioderResponse.vilkårperioder.målgrupper.map((målgruppe) => (
-                                <InfoRad
-                                    key={målgruppe.id}
-                                    resultat={målgruppe.resultat}
-                                    fom={målgruppe.fom}
-                                    tom={målgruppe.tom}
-                                    gjelder={målgruppeTypeTilTekst(målgruppe.type)}
-                                />
-                            ))}
+                            <OppsummeringMålgrupper
+                                målgrupper={vilkårperioderResponse.vilkårperioder.målgrupper}
+                            />
                         </VStack>
                     </StyledHGrid>
                     <StyledHGrid columns={'125px auto'}>
                         <BodyShort size={'small'}>Pass av barn</BodyShort>
                         <VStack gap={'2'}>
                             {vilkårsvurdering.vilkårsett.map((vilkår) => (
-                                <InfoRad
+                                <VilkårOppsummeringRad
                                     key={vilkår.id}
                                     resultat={vilkår.resultat}
                                     fom={vilkår.fom}
@@ -91,23 +78,5 @@ export const OppsummeringVilkårperioderOgVilkår: React.FC<{ behandlingId: stri
                 </VStack>
             )}
         </DataViewer>
-    );
-};
-
-interface InfoRadProps {
-    resultat: VilkårPeriodeResultat | Vilkårsresultat;
-    fom?: string;
-    tom?: string;
-    gjelder?: string;
-}
-
-const InfoRad: React.FC<InfoRadProps> = ({ resultat, fom, tom, gjelder }) => {
-    return (
-        <HStack gap={'2'} align={'center'}>
-            <VilkårsresultatIkon vilkårsresultat={resultat} height={18} width={18} />
-            <BodyShort
-                size={'small'}
-            >{`${formaterNullablePeriode(fom, tom)}: ${gjelder}`}</BodyShort>
-        </HStack>
     );
 };

--- a/src/frontend/Sider/Behandling/OppsummeringVilkår/OppsummeringVilkårperioderOgVilkår.tsx
+++ b/src/frontend/Sider/Behandling/OppsummeringVilkår/OppsummeringVilkårperioderOgVilkår.tsx
@@ -4,16 +4,16 @@ import styled from 'styled-components';
 
 import { BodyShort, HGrid, HStack, VStack } from '@navikt/ds-react';
 
-import { useHentVilkårsvurdering } from '../../../../../hooks/useHentVilkårsvurdering';
-import { useVilkårperioder } from '../../../../../hooks/useVilkårperioder';
-import DataViewer from '../../../../../komponenter/DataViewer';
-import { VilkårsresultatIkon } from '../../../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
-import { BehandlingFaktaTilsynBarn } from '../../../../../typer/behandling/behandlingFakta/behandlingFakta';
-import { formaterNullablePeriode } from '../../../../../utils/dato';
-import { aktivitetTypeTilTekst } from '../../../Inngangsvilkår/Aktivitet/utilsAktivitet';
-import { målgruppeTypeTilTekst } from '../../../Inngangsvilkår/typer/vilkårperiode/målgruppe';
-import { VilkårPeriodeResultat } from '../../../Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
-import { Vilkårsresultat } from '../../../vilkår';
+import { useHentVilkårsvurdering } from '../../../hooks/useHentVilkårsvurdering';
+import { useVilkårperioder } from '../../../hooks/useVilkårperioder';
+import DataViewer from '../../../komponenter/DataViewer';
+import { VilkårsresultatIkon } from '../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
+import { BehandlingFaktaTilsynBarn } from '../../../typer/behandling/behandlingFakta/behandlingFakta';
+import { formaterNullablePeriode } from '../../../utils/dato';
+import { aktivitetTypeTilTekst } from '../Inngangsvilkår/Aktivitet/utilsAktivitet';
+import { målgruppeTypeTilTekst } from '../Inngangsvilkår/typer/vilkårperiode/målgruppe';
+import { VilkårPeriodeResultat } from '../Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
+import { Vilkårsresultat } from '../vilkår';
 
 const StyledHGrid = styled(HGrid).withConfig({
     shouldForwardProp: (prop) => prop !== 'bottomBorder',
@@ -22,7 +22,9 @@ const StyledHGrid = styled(HGrid).withConfig({
     ${(props) => props.bottomBorder && `border-bottom: solid 1px white;`}
 `;
 
-export const BehandlingInfo: React.FC<{ behandlingId: string }> = ({ behandlingId }) => {
+export const OppsummeringVilkårperioderOgVilkår: React.FC<{ behandlingId: string }> = ({
+    behandlingId,
+}) => {
     const { vilkårperioderResponse } = useVilkårperioder(behandlingId);
     const { hentVilkårsvurdering, vilkårsvurdering } = useHentVilkårsvurdering();
 

--- a/src/frontend/Sider/Behandling/OppsummeringVilkår/VilkårOppsummeringRad.tsx
+++ b/src/frontend/Sider/Behandling/OppsummeringVilkår/VilkårOppsummeringRad.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import { BodyShort, HStack } from '@navikt/ds-react';
+
+import { VilkårsresultatIkon } from '../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
+import { formaterNullablePeriode } from '../../../utils/dato';
+import { aktivitetTypeTilTekst } from '../Inngangsvilkår/Aktivitet/utilsAktivitet';
+import { Målgruppe, målgruppeTypeTilTekst } from '../Inngangsvilkår/typer/vilkårperiode/målgruppe';
+import {
+    VilkårPeriodeAktivitet,
+    VilkårPeriodeResultat,
+} from '../Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
+import { Vilkårsresultat } from '../vilkår';
+
+interface VilkårOppsummeringRadProps {
+    resultat: VilkårPeriodeResultat | Vilkårsresultat;
+    fom?: string;
+    tom?: string;
+    gjelder?: string;
+}
+
+export const VilkårOppsummeringRad: React.FC<VilkårOppsummeringRadProps> = ({
+    resultat,
+    fom,
+    tom,
+    gjelder,
+}) => {
+    return (
+        <HStack gap={'2'} align={'center'}>
+            <VilkårsresultatIkon vilkårsresultat={resultat} height={18} width={18} />
+            <BodyShort
+                size={'small'}
+            >{`${formaterNullablePeriode(fom, tom)}: ${gjelder}`}</BodyShort>
+        </HStack>
+    );
+};
+
+export const OppsummeringAktiviteter = ({
+    aktiviteter,
+}: {
+    aktiviteter: VilkårPeriodeAktivitet[];
+}) => {
+    return aktiviteter.map((aktivitet) => (
+        <VilkårOppsummeringRad
+            key={aktivitet.id}
+            resultat={aktivitet.resultat}
+            fom={aktivitet.fom}
+            tom={aktivitet.tom}
+            gjelder={aktivitetTypeTilTekst(aktivitet.type)}
+        />
+    ));
+};
+
+export const OppsummeringMålgrupper = ({ målgrupper }: { målgrupper: Målgruppe[] }) => {
+    return målgrupper.map((målgruppe) => (
+        <VilkårOppsummeringRad
+            key={målgruppe.id}
+            resultat={målgruppe.resultat}
+            fom={målgruppe.fom}
+            tom={målgruppe.tom}
+            gjelder={målgruppeTypeTilTekst(målgruppe.type)}
+        />
+    ));
+};

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -19,6 +19,7 @@ import { Steg } from '../../../typer/behandling/steg';
 import { Toggle } from '../../../utils/toggles';
 import { FanePath } from '../faner';
 import { VarselRevurderFraDatoMangler } from '../Felles/VarselRevurderFraDatoMangler';
+import { OppsummeringVilkårperioder } from '../OppsummeringVilkår/OppsummeringVilkårperioder';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
     margin: 2rem;
@@ -42,6 +43,7 @@ const Stønadsvilkår = () => {
     return (
         <Container>
             <VarselRevurderFraDatoMangler />
+            <OppsummeringVilkårperioder behandlingId={behandling.id} />
             <DataViewer
                 response={{
                     regler,

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsynV2.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsynV2.tsx
@@ -8,6 +8,7 @@ import { useApp } from '../../../../../context/AppContext';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { FormErrors, isValid } from '../../../../../hooks/felles/useFormState';
+import { useMapById } from '../../../../../hooks/useMapById';
 import DataViewer from '../../../../../komponenter/DataViewer';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
@@ -23,9 +24,8 @@ import {
 } from '../../../../../typer/vedtak/vedtakTilsynBarn';
 import { FanePath } from '../../../faner';
 import { lenkerBeregningTilsynBarn } from '../../../lenker';
+import { OppsummeringVilkårperioderOgVilkår } from '../../../OppsummeringVilkår/OppsummeringVilkårperioderOgVilkår';
 import { initialiserVedtaksperioder } from '../VedtakBarnetilsynUtils';
-import { BehandlingInfo } from './BehandlingInfo';
-import { useMapById } from '../../../../../hooks/useMapById';
 
 interface Props {
     lagretVedtak?: InnvilgelseBarnetilsyn;
@@ -126,7 +126,7 @@ export const InnvilgeBarnetilsynV2: React.FC<Props> = ({
         <>
             <Panel tittel="Beregning" ekstraHeading={<HeadingBeregning />}>
                 <VStack gap={'8'}>
-                    <BehandlingInfo behandlingId={behandling.id} />
+                    <OppsummeringVilkårperioderOgVilkår behandlingId={behandling.id} />
                     <Vedtaksperioder
                         vedtaksperioder={vedtaksperioder}
                         lagredeVedtaksperioder={lagredeVedtaksperioder}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Flytter og bryter ut oppsummering av vilkår på vedtakssiden for tilsyn barn for å kunne gjenbruke på fanen for stønadsvilkår

Legger den ikke bak feature toggle då den kan vises før vi legger ut dette i prod

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24497

![image](https://github.com/user-attachments/assets/cbe47875-2e22-4a6d-8624-ea2ca2449a8d)
