### PR TITLE
Læremidler vedtaksperioder revurdering tidligere perioder

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
@@ -2,7 +2,7 @@ import React, { FC } from 'react';
 
 import styled from 'styled-components';
 
-import { BodyShort, Label } from '@navikt/ds-react';
+import { Alert, BodyShort, Label } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 import '@navikt/ds-css';
 
@@ -17,7 +17,7 @@ const Container = styled.div`
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: repeat(6, max-content);
+    grid-template-columns: repeat(7, max-content);
     gap: 0.4rem 2rem;
 `;
 
@@ -32,6 +32,7 @@ export const Beregningsresultat: FC<{ beregningsresultat: BeregningsresultatLær
             <Label>Prosent</Label>
             <Label>Månedsbeløp</Label>
             <Label>Stønadsbeløp</Label>
+            <div></div>
             {beregningsresultat.perioder.map((periode, indeks) => (
                 <React.Fragment key={indeks}>
                     <BodyShort size="small">
@@ -42,6 +43,13 @@ export const Beregningsresultat: FC<{ beregningsresultat: BeregningsresultatLær
                     <BodyShort size="small">{periode.studieprosent}%</BodyShort>
                     <BodyShort size="small">{periode.beløp} kr</BodyShort>
                     <BodyShort size="small">{periode.stønadsbeløp} kr</BodyShort>
+                    <div>
+                        {periode.delAvTidligereUtbetaling && (
+                            <Alert variant="info" size={'small'} inline>
+                                Treffer allerede utbetalt mnd
+                            </Alert>
+                        )}
+                    </div>
                 </React.Fragment>
             ))}
         </Grid>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
@@ -32,7 +32,7 @@ export const Beregningsresultat: FC<{ beregningsresultat: BeregningsresultatLær
             <Label>Prosent</Label>
             <Label>Månedsbeløp</Label>
             <Label>Stønadsbeløp</Label>
-            <div></div>
+            <div />
             {beregningsresultat.perioder.map((periode, indeks) => (
                 <React.Fragment key={indeks}>
                     <BodyShort size="small">

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellLæremidler.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellLæremidler.ts
@@ -20,6 +20,7 @@ const lagBeregningstabell = (beregningsresultat?: BeregningsresultatLæremidler)
                 <thead>
                     <tr>
                         <th style="width: 270px; word-wrap: break-word; ${borderStylingCompact}">Periode</th>
+                        <th style="width: 120px; ${borderStylingCompact}">Antall måneder</th>
                         <th style="width: 70px; word-wrap: break-word; ${borderStylingCompact}">Sats</th>
                         <th style="width: 80px; word-wrap: break-word; ${borderStylingCompact}">Beløp</th>
                     </tr>
@@ -43,8 +44,9 @@ const lagRaderForVedtak = (beregningsresultat?: BeregningsresultatLæremidler): 
 
             return `<tr style="text-align: right;">
                         <td style="text-align: left; ${borderStylingCompact}">${datoperiode}</td>
+                        <td style="${borderStyling}">${periode.antallMåneder}</td>
                         <td style="${borderStyling}">${satsPerMåned} kr</td>
-                        <td style="${borderStyling}">${stjernmerktRad}${stønadsbeløp} kr</td>
+                        <td style="${borderStyling}">${stønadsbeløp} kr${stjernmerktRad}</td>
                     </tr>`;
         })
         .join('');

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellLæremidler.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellLæremidler.ts
@@ -20,8 +20,8 @@ const lagBeregningstabell = (beregningsresultat?: BeregningsresultatLæremidler)
                 <thead>
                     <tr>
                         <th style="width: 270px; word-wrap: break-word; ${borderStylingCompact}">Periode</th>
-                        <th style="width: 70px; word-wrap: break-word; ${borderStylingCompact}">Fast sats</th>
-                        <th style="width: 110px; word-wrap: break-word; ${borderStylingCompact}">Beløpet du får</th>
+                        <th style="width: 70px; word-wrap: break-word; ${borderStylingCompact}">Sats</th>
+                        <th style="width: 80px; word-wrap: break-word; ${borderStylingCompact}">Beløp</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -39,11 +39,12 @@ const lagRaderForVedtak = (beregningsresultat?: BeregningsresultatLæremidler): 
             const datoperiode = formaterTektligIsoPeriode(periode.fom, periode.tom);
             const satsPerMåned = formaterTallMedTusenSkille(periode.beløp);
             const stønadsbeløp = formaterTallMedTusenSkille(periode.stønadsbeløp);
+            const stjernmerktRad = periode.delAvTidligereUtbetaling ? '*' : '';
 
             return `<tr style="text-align: right;">
                         <td style="text-align: left; ${borderStylingCompact}">${datoperiode}</td>
                         <td style="${borderStyling}">${satsPerMåned} kr</td>
-                        <td style="${borderStyling}">${stønadsbeløp} kr</td>
+                        <td style="${borderStyling}">${stjernmerktRad}${stønadsbeløp} kr</td>
                     </tr>`;
         })
         .join('');

--- a/src/frontend/typer/vedtak/vedtakLæremidler.ts
+++ b/src/frontend/typer/vedtak/vedtakLæremidler.ts
@@ -46,6 +46,7 @@ interface BeregningsresultatForPeriode {
     utbetalingsdato: string;
     målgruppe: MålgruppeType;
     aktivitet: AktivitetType;
+    delAvTidligereUtbetaling: boolean;
 }
 
 export type AvslåLæremidlerRequest = {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
> Gitt at jeg står i en revurdering av Læremidler
> Når jeg reberegner en periode som allerede er utbetalt
> Så skal jeg på vedtak og beregningssiden få et varsel om at den beregnede perioden treffer en allerede utbetalt måned

Når man revurderer og legger til en periode i en allerede løpende måned så er det ønskelig å markere den måneden at det er en del av en allerede utbetalt måned. Den skal markeres for å gjøre det tydelig og at man i vedtaksbrevet skal kunne skrive en tekst om endringen.
* Uendret beløp
* Lavere beløp
* Høyere beløp

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24527

* https://github.com/navikt/tilleggsstonader-sak/pull/621

![image](https://github.com/user-attachments/assets/f3c4334c-ce9f-4ea1-9ec3-a01cc0c0a58e)

![image](https://github.com/user-attachments/assets/69f60b2b-2aee-4a66-b946-5377a81d18a0)

