### PR TITLE
Marker endring og vis aktivitetid

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Aktivitet.tsx
@@ -4,7 +4,7 @@ import { BriefcaseIcon, PlusCircleIcon } from '@navikt/aksel-icons';
 import { Button, Label } from '@navikt/ds-react';
 
 import { AktivitetHjelpetekst } from './AktivitetHjelpetekst';
-import { AktivitetKort } from './AktivitetKort';
+import { AktivitetKort } from './AktivitetKortLesevisning/AktivitetKort';
 import { EndreAktivitet } from './EndreAktivitet';
 import RegisterAktiviteter from './RegisterAktivteter';
 import { useApp } from '../../../../context/AppContext';

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKort.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKort.tsx
@@ -5,6 +5,7 @@ import { styled } from 'styled-components';
 import { PencilIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button, Label, VStack } from '@navikt/ds-react';
 
+import { AktivitetkortFooter } from './AktivitetKortFooter';
 import { useSteg } from '../../../../../context/StegContext';
 import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
 import { Celle } from '../../../../../komponenter/Visningskomponenter/Celle';
@@ -55,6 +56,12 @@ export const AktivitetKort: React.FC<{
                         icon={<PencilIcon />}
                     />
                 )
+            }
+            footer={
+                <AktivitetkortFooter
+                    aktivitet={aktivitet}
+                    aktivitetFraRegister={aktivitetFraRegister}
+                />
             }
         >
             <CelleContainer>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKort.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKort.tsx
@@ -5,18 +5,18 @@ import { styled } from 'styled-components';
 import { PencilIcon } from '@navikt/aksel-icons';
 import { BodyShort, Button, Label, VStack } from '@navikt/ds-react';
 
-import { FaktaOgDelvilkårVisning } from './Delvilkår/FaktaOgDelvilkårVisning';
-import { useSteg } from '../../../../context/StegContext';
-import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
-import { Celle } from '../../../../komponenter/Visningskomponenter/Celle';
-import { Registeraktivitet } from '../../../../typer/registeraktivitet';
-import { formaterIsoPeriode } from '../../../../utils/dato';
-import { Aktivitet } from '../typer/vilkårperiode/aktivitet';
+import { useSteg } from '../../../../../context/StegContext';
+import { useRevurderingAvPerioder } from '../../../../../hooks/useRevurderingAvPerioder';
+import { Celle } from '../../../../../komponenter/Visningskomponenter/Celle';
+import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
+import { formaterIsoPeriode } from '../../../../../utils/dato';
+import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
 import {
     VilkårPeriodeResultat,
     vilkårperiodeTypeTilTekst,
-} from '../typer/vilkårperiode/vilkårperiode';
-import VilkårperiodeKortBase from '../Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase';
+} from '../../typer/vilkårperiode/vilkårperiode';
+import VilkårperiodeKortBase from '../../Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase';
+import { FaktaOgDelvilkårVisning } from '../Delvilkår/FaktaOgDelvilkårVisning';
 
 const CelleContainer = styled.div`
     flex-grow: 1;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKortFooter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKortFooter.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { HStack, Tag } from '@navikt/ds-react';
+import { Detail, HStack } from '@navikt/ds-react';
 
 import { AktivitetUlikRegisterVarsel } from './AktivitetUlikRegisterVarsel';
 import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
@@ -16,11 +16,9 @@ export const AktivitetkortFooter: React.FC<{
                 aktivitet={aktivitet}
                 aktivitetFraRegister={aktivitetFraRegister}
             />
-            {aktivitet.kildeId && (
-                <Tag variant="alt2" size="small" style={{ marginLeft: 'auto' }}>
-                    {aktivitet.kildeId}
-                </Tag>
-            )}
+            <Detail style={{ marginLeft: 'auto' }}>
+                {aktivitet.kildeId ? `ID: ${aktivitet.kildeId}` : 'Lagt til manuelt'}
+            </Detail>
         </HStack>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKortFooter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKortFooter.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+import { HStack, Tag } from '@navikt/ds-react';
+
+import { UlikheterVarselEndring } from './UlikheterVarselAktivitet';
+import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
+import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
+
+export const AktivitetkortFooter: React.FC<{
+    aktivitet: Aktivitet;
+    aktivitetFraRegister: Registeraktivitet | undefined;
+}> = ({ aktivitet, aktivitetFraRegister }) => {
+    return (
+        <HStack justify="space-between" width="100%">
+            <UlikheterVarselEndring
+                aktivitet={aktivitet}
+                aktivitetFraRegister={aktivitetFraRegister}
+            />
+            {aktivitet.kildeId && (
+                <Tag variant="alt2" size="small" style={{ marginLeft: 'auto' }}>
+                    {aktivitet.kildeId}
+                </Tag>
+            )}
+        </HStack>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKortFooter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKortFooter.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { HStack, Tag } from '@navikt/ds-react';
 
-import { UlikheterVarselEndring } from './UlikheterVarselAktivitet';
+import { AktivitetUlikRegisterVarsel } from './AktivitetUlikRegisterVarsel';
 import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
 import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
 
@@ -12,7 +12,7 @@ export const AktivitetkortFooter: React.FC<{
 }> = ({ aktivitet, aktivitetFraRegister }) => {
     return (
         <HStack justify="space-between" width="100%">
-            <UlikheterVarselEndring
+            <AktivitetUlikRegisterVarsel
                 aktivitet={aktivitet}
                 aktivitetFraRegister={aktivitetFraRegister}
             />

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetUlikRegisterVarsel.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetUlikRegisterVarsel.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
-import { Tag } from '@navikt/ds-react';
+import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
+import { Tag, VStack } from '@navikt/ds-react';
 
 import { finnForskjellerMellomAktivitetOgRegisteraktivitet } from './aktivitetKortUtils';
 import { useBehandling } from '../../../../../context/BehandlingContext';
@@ -13,15 +14,7 @@ export const AktivitetUlikRegisterVarsel: React.FC<{
     aktivitetFraRegister: Registeraktivitet | undefined;
 }> = ({ aktivitet, aktivitetFraRegister }) => {
     const { behandling } = useBehandling();
-    if (behandling.status === BehandlingStatus.FERDIGSTILT) return null;
-
-    if (!aktivitetFraRegister) {
-        return (
-            <Tag size="small" variant="info" style={{ alignSelf: 'start' }}>
-                Opplysninger om aktivitet lagt til manuelt
-            </Tag>
-        );
-    }
+    if (behandling.status === BehandlingStatus.FERDIGSTILT || !aktivitetFraRegister) return null;
 
     const forskjeller = finnForskjellerMellomAktivitetOgRegisteraktivitet(
         aktivitet,
@@ -30,9 +23,16 @@ export const AktivitetUlikRegisterVarsel: React.FC<{
 
     if (forskjeller.length > 0) {
         return (
-            <Tag size="small" variant="warning" style={{ alignSelf: 'start' }}>
-                Opplysninger om aktivitet som er ulik Arena: {forskjeller.join(', ')}
-            </Tag>
+            <VStack gap="4">
+                <Tag
+                    icon={<ExclamationmarkTriangleIcon />}
+                    size="small"
+                    variant="warning"
+                    style={{ alignSelf: 'start' }}
+                >
+                    Opplysninger om aktivitet som er ulik Arena: {forskjeller.join(', ')}
+                </Tag>
+            </VStack>
         );
     }
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetUlikRegisterVarsel.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetUlikRegisterVarsel.tsx
@@ -2,10 +2,7 @@ import React from 'react';
 
 import { Tag } from '@navikt/ds-react';
 
-import {
-    finnForskjellerMellomRegisterOgAktivitet as finnForskjellerMellomAktivitetOgRegisteraktivitet,
-    keysMedMuligeUlikheterTilTekst,
-} from './aktivitetKortUtils';
+import { finnForskjellerMellomAktivitetOgRegisteraktivitet } from './aktivitetKortUtils';
 import { useBehandling } from '../../../../../context/BehandlingContext';
 import { BehandlingStatus } from '../../../../../typer/behandling/behandlingStatus';
 import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
@@ -34,8 +31,7 @@ export const AktivitetUlikRegisterVarsel: React.FC<{
     if (forskjeller.length > 0) {
         return (
             <Tag size="small" variant="warning" style={{ alignSelf: 'start' }}>
-                Opplysninger om aktivitet som er ulik Arena:{' '}
-                {forskjeller.map((key) => keysMedMuligeUlikheterTilTekst[key]).join(', ')}
+                Opplysninger om aktivitet som er ulik Arena: {forskjeller.join(', ')}
             </Tag>
         );
     }

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetUlikRegisterVarsel.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetUlikRegisterVarsel.tsx
@@ -11,7 +11,7 @@ import { BehandlingStatus } from '../../../../../typer/behandling/behandlingStat
 import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
 import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
 
-export const UlikheterVarselEndring: React.FC<{
+export const AktivitetUlikRegisterVarsel: React.FC<{
     aktivitet: Aktivitet;
     aktivitetFraRegister: Registeraktivitet | undefined;
 }> = ({ aktivitet, aktivitetFraRegister }) => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/UlikheterVarselAktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/UlikheterVarselAktivitet.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { Tag } from '@navikt/ds-react';
+
+import {
+    finnForskjellerMellomRegisterOgAktivitet as finnForskjellerMellomAktivitetOgRegisteraktivitet,
+    keysMedMuligeUlikheterTilTekst,
+} from './aktivitetKortUtils';
+import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
+import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
+
+export const UlikheterVarselEndring: React.FC<{
+    aktivitet: Aktivitet;
+    aktivitetFraRegister: Registeraktivitet | undefined;
+}> = ({ aktivitet, aktivitetFraRegister }) => {
+    if (!aktivitetFraRegister) {
+        return (
+            <Tag size="small" variant="info" style={{ alignSelf: 'start' }}>
+                Opplysninger om aktivitet lagt til manuelt
+            </Tag>
+        );
+    }
+
+    const forskjeller = finnForskjellerMellomAktivitetOgRegisteraktivitet(
+        aktivitet,
+        aktivitetFraRegister
+    );
+
+    if (forskjeller.length > 0) {
+        return (
+            <Tag size="small" variant="warning" style={{ alignSelf: 'start' }}>
+                Opplysninger om aktivitet ikke likt som Arena:{' '}
+                {forskjeller.map((key) => keysMedMuligeUlikheterTilTekst[key]).join(', ')}
+            </Tag>
+        );
+    }
+
+    return null;
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/UlikheterVarselAktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/UlikheterVarselAktivitet.tsx
@@ -6,6 +6,8 @@ import {
     finnForskjellerMellomRegisterOgAktivitet as finnForskjellerMellomAktivitetOgRegisteraktivitet,
     keysMedMuligeUlikheterTilTekst,
 } from './aktivitetKortUtils';
+import { useBehandling } from '../../../../../context/BehandlingContext';
+import { BehandlingStatus } from '../../../../../typer/behandling/behandlingStatus';
 import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
 import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
 
@@ -13,6 +15,9 @@ export const UlikheterVarselEndring: React.FC<{
     aktivitet: Aktivitet;
     aktivitetFraRegister: Registeraktivitet | undefined;
 }> = ({ aktivitet, aktivitetFraRegister }) => {
+    const { behandling } = useBehandling();
+    if (behandling.status === BehandlingStatus.FERDIGSTILT) return null;
+
     if (!aktivitetFraRegister) {
         return (
             <Tag size="small" variant="info" style={{ alignSelf: 'start' }}>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/UlikheterVarselAktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/UlikheterVarselAktivitet.tsx
@@ -34,7 +34,7 @@ export const UlikheterVarselEndring: React.FC<{
     if (forskjeller.length > 0) {
         return (
             <Tag size="small" variant="warning" style={{ alignSelf: 'start' }}>
-                Opplysninger om aktivitet ikke likt som Arena:{' '}
+                Opplysninger om aktivitet som er ulik Arena:{' '}
                 {forskjeller.map((key) => keysMedMuligeUlikheterTilTekst[key]).join(', ')}
             </Tag>
         );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/aktivitetKortUtils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/aktivitetKortUtils.ts
@@ -3,57 +3,39 @@ import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
 
 // Beskriver felter som kan være ulike mellom en aktivitet og en registeraktivitet
 enum KeysMedMuligeUlikheter {
-    fom = 'fom',
-    tom = 'tom',
+    fom = 'startdato',
+    tom = 'sluttdato',
     prosent = 'prosent',
     aktivitetsdager = 'aktivitetsdager',
 }
 
-const KeysMedMuligeUlikheterTilRegisteraktivitetKey: Record<
-    KeysMedMuligeUlikheter,
-    keyof Registeraktivitet
-> = {
-    fom: 'fom',
-    tom: 'tom',
-    prosent: 'prosentDeltakelse',
-    aktivitetsdager: 'antallDagerPerUke',
-};
-
-export const keysMedMuligeUlikheterTilTekst: Record<KeysMedMuligeUlikheter, string> = {
-    fom: 'startdato',
-    tom: 'sluttdato',
-    prosent: 'prosent',
-    aktivitetsdager: 'aktivitetsdager',
-};
-
-// Finner forskjeller mellom en aktivitet og en registeraktivitet
-// Fellesfelter (fom og tom) ligger direkte på aktiviteten, mens detaljer ligger i faktaOgVurderinger
-export const finnForskjellerMellomRegisterOgAktivitet = (
+export const finnForskjellerMellomAktivitetOgRegisteraktivitet = (
     aktivitet: Aktivitet,
     registerAktivitet: Registeraktivitet
 ): KeysMedMuligeUlikheter[] => {
     const forskjeller: KeysMedMuligeUlikheter[] = [];
 
-    Object.keys(KeysMedMuligeUlikheter).forEach((key) => {
-        const keyIRegisteraktivitet =
-            KeysMedMuligeUlikheterTilRegisteraktivitetKey[key as KeysMedMuligeUlikheter];
+    if (aktivitet.fom !== registerAktivitet.fom) {
+        forskjeller.push(KeysMedMuligeUlikheter.fom);
+    }
 
-        if (key in aktivitet && key in registerAktivitet) {
-            if (aktivitet[key as keyof Aktivitet] !== registerAktivitet[keyIRegisteraktivitet]) {
-                forskjeller.push(key as KeysMedMuligeUlikheter);
-            }
-        } else if (
-            key in aktivitet.faktaOgVurderinger &&
-            keyIRegisteraktivitet in registerAktivitet
-        ) {
-            if (
-                aktivitet.faktaOgVurderinger[key as keyof Aktivitet['faktaOgVurderinger']] !==
-                registerAktivitet[keyIRegisteraktivitet]
-            ) {
-                forskjeller.push(key as KeysMedMuligeUlikheter);
-            }
-        }
-    });
+    if (aktivitet.tom !== registerAktivitet.tom) {
+        forskjeller.push(KeysMedMuligeUlikheter.tom);
+    }
+
+    if (
+        'prosent' in aktivitet.faktaOgVurderinger &&
+        aktivitet.faktaOgVurderinger.prosent !== registerAktivitet.prosentDeltakelse
+    ) {
+        forskjeller.push(KeysMedMuligeUlikheter.prosent);
+    }
+
+    if (
+        'aktivitetsdager' in aktivitet.faktaOgVurderinger &&
+        aktivitet.faktaOgVurderinger.aktivitetsdager !== registerAktivitet.antallDagerPerUke
+    ) {
+        forskjeller.push(KeysMedMuligeUlikheter.aktivitetsdager);
+    }
 
     return forskjeller;
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/aktivitetKortUtils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/aktivitetKortUtils.ts
@@ -1,0 +1,59 @@
+import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
+import { Aktivitet } from '../../typer/vilkårperiode/aktivitet';
+
+// Beskriver felter som kan være ulike mellom en aktivitet og en registeraktivitet
+enum KeysMedMuligeUlikheter {
+    fom = 'fom',
+    tom = 'tom',
+    prosent = 'prosent',
+    aktivitetsdager = 'aktivitetsdager',
+}
+
+const KeysMedMuligeUlikheterTilRegisteraktivitetKey: Record<
+    KeysMedMuligeUlikheter,
+    keyof Registeraktivitet
+> = {
+    fom: 'fom',
+    tom: 'tom',
+    prosent: 'prosentDeltakelse',
+    aktivitetsdager: 'antallDagerPerUke',
+};
+
+export const keysMedMuligeUlikheterTilTekst: Record<KeysMedMuligeUlikheter, string> = {
+    fom: 'startdato',
+    tom: 'sluttdato',
+    prosent: 'prosent',
+    aktivitetsdager: 'aktivitetsdager',
+};
+
+// Finner forskjeller mellom en aktivitet og en registeraktivitet
+// Fellesfelter (fom og tom) ligger direkte på aktiviteten, mens detaljer ligger i faktaOgVurderinger
+export const finnForskjellerMellomRegisterOgAktivitet = (
+    aktivitet: Aktivitet,
+    registerAktivitet: Registeraktivitet
+): KeysMedMuligeUlikheter[] => {
+    const forskjeller: KeysMedMuligeUlikheter[] = [];
+
+    Object.keys(KeysMedMuligeUlikheter).forEach((key) => {
+        const keyIRegisteraktivitet =
+            KeysMedMuligeUlikheterTilRegisteraktivitetKey[key as KeysMedMuligeUlikheter];
+
+        if (key in aktivitet && key in registerAktivitet) {
+            if (aktivitet[key as keyof Aktivitet] !== registerAktivitet[keyIRegisteraktivitet]) {
+                forskjeller.push(key as KeysMedMuligeUlikheter);
+            }
+        } else if (
+            key in aktivitet.faktaOgVurderinger &&
+            keyIRegisteraktivitet in registerAktivitet
+        ) {
+            if (
+                aktivitet.faktaOgVurderinger[key as keyof Aktivitet['faktaOgVurderinger']] !==
+                registerAktivitet[keyIRegisteraktivitet]
+            ) {
+                forskjeller.push(key as KeysMedMuligeUlikheter);
+            }
+        }
+    });
+
+    return forskjeller;
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
@@ -4,27 +4,22 @@ import { CheckmarkIcon } from '@navikt/aksel-icons';
 import { Button, Tag } from '@navikt/ds-react';
 
 import { useBehandling } from '../../../../context/BehandlingContext';
-import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../../context/StegContext';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
-import { Aktivitet } from '../typer/vilkårperiode/aktivitet';
 import { kanRegisterperiodeBrukes } from '../Vilkårperioder/vilkårperiodeUtil';
-
-const erAktivitetLagtTil = (aktiviteter: Aktivitet[], registerAktivitet: Registeraktivitet) =>
-    aktiviteter.some((aktivitet) => registerAktivitet.id === aktivitet.kildeId);
 
 export function BrukAktivitetKnapp({
     registerAktivitet,
     leggTilAktivitetFraRegister,
+    harBruktAktivitet,
 }: {
     registerAktivitet: Registeraktivitet;
     leggTilAktivitetFraRegister: (registerAktivitet: Registeraktivitet) => void;
+    harBruktAktivitet: boolean;
 }) {
-    const { aktiviteter } = useInngangsvilkår();
     const { erStegRedigerbart } = useSteg();
     const { behandling } = useBehandling();
 
-    const harBruktAktivitet = erAktivitetLagtTil(aktiviteter, registerAktivitet);
     const aktivitetKanBrukes = kanRegisterperiodeBrukes(registerAktivitet, behandling.revurderFra);
 
     if (harBruktAktivitet) {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteterTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteterTabell.tsx
@@ -2,10 +2,12 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Table } from '@navikt/ds-react';
+import { Table, Tag } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
 import { BrukAktivitetKnapp } from './BrukAktivitetKnapp';
+import { erRegisterAktivitetBrukt } from './utilsAktivitet';
+import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { formaterNullableIsoDato } from '../../../../utils/dato';
 import { formaterEnumVerdi } from '../../../../utils/tekstformatering';
@@ -22,6 +24,8 @@ const RegisterAktiviteterTabell: React.FC<{
     registerAktivitet: Registeraktivitet[];
     leggTilAktivitetFraRegister: (aktivitet: Registeraktivitet) => void;
 }> = ({ registerAktivitet, leggTilAktivitetFraRegister }) => {
+    const { aktiviteter } = useInngangsvilkår();
+
     const utledVisningstekstForAktivitetType = (aktivtet: Registeraktivitet) => {
         const aktivtetType = aktivtet.erUtdanning ? AktivitetType.UTDANNING : AktivitetType.TILTAK;
         return AktivitetTypeTilTekst[aktivtetType];
@@ -39,11 +43,14 @@ const RegisterAktiviteterTabell: React.FC<{
                     <Table.HeaderCell scope="col">Sluttdato</Table.HeaderCell>
                     <Table.HeaderCell scope="col">Aktivitetsdager</Table.HeaderCell>
                     <Table.HeaderCell scope="col">Prosent</Table.HeaderCell>
-                    <Table.HeaderCell scope="col"></Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Id</Table.HeaderCell>
+                    <Table.HeaderCell scope="col" />
                 </Table.Row>
             </Table.Header>
             <Table.Body>
                 {registerAktivitet.map((aktivitet) => {
+                    const erAktivitetBrukt = erRegisterAktivitetBrukt(aktiviteter, aktivitet);
+
                     return (
                         <Table.Row key={aktivitet.id}>
                             <Table.DataCell>
@@ -63,9 +70,19 @@ const RegisterAktiviteterTabell: React.FC<{
                             <Table.DataCell>{aktivitet.antallDagerPerUke ?? '-'}</Table.DataCell>
                             <Table.DataCell>{aktivitet.prosentDeltakelse ?? '-'}</Table.DataCell>
                             <Table.DataCell>
+                                {erAktivitetBrukt ? (
+                                    <Tag size="small" variant="alt2">
+                                        {aktivitet.id}
+                                    </Tag>
+                                ) : (
+                                    aktivitet.id
+                                )}
+                            </Table.DataCell>
+                            <Table.DataCell>
                                 <BrukAktivitetKnapp
                                     registerAktivitet={aktivitet}
                                     leggTilAktivitetFraRegister={leggTilAktivitetFraRegister}
+                                    harBruktAktivitet={erAktivitetBrukt}
                                 />
                             </Table.DataCell>
                         </Table.Row>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteterTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteterTabell.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import { styled } from 'styled-components';
 
-import { Table, Tag } from '@navikt/ds-react';
+import { Table } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
 import { BrukAktivitetKnapp } from './BrukAktivitetKnapp';
@@ -69,15 +69,7 @@ const RegisterAktiviteterTabell: React.FC<{
                             </Table.DataCell>
                             <Table.DataCell>{aktivitet.antallDagerPerUke ?? '-'}</Table.DataCell>
                             <Table.DataCell>{aktivitet.prosentDeltakelse ?? '-'}</Table.DataCell>
-                            <Table.DataCell>
-                                {erAktivitetBrukt ? (
-                                    <Tag size="small" variant="alt2">
-                                        {aktivitet.id}
-                                    </Tag>
-                                ) : (
-                                    aktivitet.id
-                                )}
-                            </Table.DataCell>
+                            <Table.DataCell>{aktivitet.id}</Table.DataCell>
                             <Table.DataCell>
                                 <BrukAktivitetKnapp
                                     registerAktivitet={aktivitet}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet.ts
@@ -1,6 +1,7 @@
 import { SelectOption } from '../../../../komponenter/Skjema/SelectMedOptions';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
-import { AktivitetType, AktivitetTypeTilTekst } from '../typer/vilkårperiode/aktivitet';
+import { Registeraktivitet } from '../../../../typer/registeraktivitet';
+import { Aktivitet, AktivitetType, AktivitetTypeTilTekst } from '../typer/vilkårperiode/aktivitet';
 
 export const aktivitetTypeTilTekst = (type: AktivitetType | '') => {
     if (type === '') return type;
@@ -39,3 +40,8 @@ export const finnRelevanteAktivitetTyperForStønad = (stønadstype: Stønadstype
             return [AktivitetType.TILTAK, AktivitetType.UTDANNING, AktivitetType.INGEN_AKTIVITET];
     }
 };
+
+export const erRegisterAktivitetBrukt = (
+    aktiviteter: Aktivitet[],
+    registerAktivitet: Registeraktivitet
+) => aktiviteter.some((aktivitet) => registerAktivitet.id === aktivitet.kildeId);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/OppsummertVilkårsvurdering.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/OppsummertVilkårsvurdering.tsx
@@ -24,6 +24,7 @@ const Container = styled.div`
     gap: 1rem;
     border-left: 3px solid ${AGray200};
     padding-left: 1rem;
+    height: 100%;
 `;
 
 export const informasjonForFaktisktMålgruppe: Record<FaktiskMålgruppe, string> = {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase.tsx
@@ -17,8 +17,20 @@ const Container = styled.div`
     padding: 1rem;
 
     display: flex;
+    flex-direction: column;
     justify-content: space-between;
     gap: 1rem;
+`;
+
+const HovedinnholdContainer = styled.div`
+    display: grid;
+    grid-template-columns: auto 32px 230px;
+    gap: 1rem;
+    align-items: start;
+
+    .oppsummering {
+        grid-column: 3;
+    }
 `;
 
 const VenstreKolonne = styled.div`
@@ -27,23 +39,13 @@ const VenstreKolonne = styled.div`
     gap: 2rem;
 `;
 
-const KnappOgOppsummeringContainer = styled.div`
-    display: grid;
-    grid-template-columns: 32px 230px;
-    gap: 1rem;
-    align-items: start;
-
-    .oppsummering {
-        grid-column: 2;
-    }
-`;
-
 const VilkårperiodeKortBase: React.FC<{
     vilkårperiode?: Målgruppe | Aktivitet;
     redigeringKnapp?: React.ReactNode;
     children: React.ReactNode;
     redigeres?: boolean;
-}> = ({ vilkårperiode, redigeringKnapp, children, redigeres = false }) => {
+    footer?: React.ReactNode;
+}> = ({ vilkårperiode, redigeringKnapp, children, redigeres = false, footer }) => {
     const { behandling } = useBehandling();
 
     const skalViseStatus =
@@ -52,15 +54,16 @@ const VilkårperiodeKortBase: React.FC<{
     return (
         <Container>
             {skalViseStatus && <Statusbånd status={vilkårperiode.status} />}
-            <VenstreKolonne>{children}</VenstreKolonne>
-            <KnappOgOppsummeringContainer>
+            <HovedinnholdContainer>
+                <VenstreKolonne>{children}</VenstreKolonne>
                 {redigeringKnapp}
                 <OppsummertVilkårsvurdering
                     redigeres={redigeres}
                     vilkårperiode={vilkårperiode}
                     className="oppsummering"
                 />
-            </KnappOgOppsummeringContainer>
+            </HovedinnholdContainer>
+            {footer}
         </Container>
     );
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hjelpe SB og beslutter å se ulikheter mellom aktivitet i arena og lagt til i TS-sak. 

Skjules dersom behandlingen er ferdigstilt slik at man ikke viser noe på gamle behandlinger som SB ikke så da saken ble behandlet. Gjøres nå i frontend fordi det var raskeste vei til mål. En mulig videreutvikling er å ha mer detaljer om det er SB som har endret det eller om det er arena som er oppdatert, men dette bør lagres ned

Vise tag med "forskjell" fra arena aktivitet og aktivitetid dersom den er brukt: 
<img width="1252" alt="image" src="https://github.com/user-attachments/assets/f608b70a-56a9-44cc-9869-b86731c91a8f" />

Vise id-en til aktiviteten i tabellen, som tag hvis den er brukt slik at den matcher det som er på kortet: 
<img width="1214" alt="image" src="https://github.com/user-attachments/assets/8cd24297-c3cb-4e12-ba3b-a661bec314a7" />
