### PR TITLE
✨ Ta i bruk måned-år velger som dropdown på utgifter

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -230,8 +230,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                             settDetFinnesUlagredeEndringer(true);
                             settFeilmeldinger((prevState) => ({ ...prevState, fom: undefined }));
                         }}
-                        antallÅrFrem={3}
-                        antallÅrTilbake={3}
+                        antallÅrFrem={1}
+                        antallÅrTilbake={1}
                     />
                 ) : (
                     <MonthInput
@@ -261,8 +261,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                             settDetFinnesUlagredeEndringer(true);
                             settFeilmeldinger((prevState) => ({ ...prevState, tom: undefined }));
                         }}
-                        antallÅrFrem={3}
-                        antallÅrTilbake={3}
+                        antallÅrFrem={2}
+                        antallÅrTilbake={1}
                     />
                 ) : (
                     <MonthInput

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -255,7 +255,6 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                         size="small"
                         årMånedInitiell={tom}
                         feilmelding={feilmeldinger.tom}
-                        lesevisning={!props.alleFelterKanRedigeres}
                         onEndret={(dato) => {
                             settTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
                             settDetFinnesUlagredeEndringer(true);

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useId, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -22,6 +23,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
 import { Skillelinje } from '../../../komponenter/Skillelinje';
 import MonthInput from '../../../komponenter/Skjema/MonthInput';
+import { MånedÅrVelger } from '../../../komponenter/Skjema/MånedÅrVelger/MånedÅrVelger';
 import TextField from '../../../komponenter/Skjema/TextField';
 import { SmallWarningTag } from '../../../komponenter/Tags';
 import { FeilmeldingMaksBredde } from '../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
@@ -30,6 +32,7 @@ import { BegrunnelseRegel, Regler, Svaralternativ } from '../../../typer/regel';
 import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
 import { tilFørsteDagenIMåneden, tilSisteDagenIMåneden } from '../../../utils/dato';
 import { harTallverdi, tilHeltall } from '../../../utils/tall';
+import { Toggle } from '../../../utils/toggles';
 import { fjernSpaces } from '../../../utils/utils';
 import { Delvilkår, RedigerbareVilkårfelter, Vilkår, Vurdering } from '../vilkår';
 
@@ -76,6 +79,7 @@ type EndreVilkårProps = {
 export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     const { nullstillUlagretKomponent, settUlagretKomponent } = useApp();
     const { behandling } = useBehandling();
+    const skalBrukeMånedÅrVelger = useFlag(Toggle.SKAL_BRUKE_MANED_AR_VELGER);
 
     const [detFinnesUlagredeEndringer, settDetFinnesUlagredeEndringer] = useState<boolean>(false);
     const [komponentId] = useId();
@@ -214,31 +218,65 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     const EndrePerioder = (
         <HStack gap="4" align="start">
             <FeilmeldingMaksBredde $maxWidth={152}>
-                <MonthInput
-                    label="Fra"
-                    size="small"
-                    value={fom}
-                    feil={feilmeldinger.fom}
-                    readOnly={!props.alleFelterKanRedigeres}
-                    onChange={(dato) => {
-                        settFom(dato ? tilFørsteDagenIMåneden(dato) : undefined);
-                        settDetFinnesUlagredeEndringer(true);
-                        settFeilmeldinger((prevState) => ({ ...prevState, fom: undefined }));
-                    }}
-                />
+                {skalBrukeMånedÅrVelger ? (
+                    <MånedÅrVelger
+                        label="Fra"
+                        size="small"
+                        årMånedInitiell={fom}
+                        feilmelding={feilmeldinger.fom}
+                        lesevisning={!props.alleFelterKanRedigeres}
+                        onEndret={(dato) => {
+                            settFom(dato ? tilFørsteDagenIMåneden(dato) : undefined);
+                            settDetFinnesUlagredeEndringer(true);
+                            settFeilmeldinger((prevState) => ({ ...prevState, fom: undefined }));
+                        }}
+                        antallÅrFrem={3}
+                        antallÅrTilbake={3}
+                    />
+                ) : (
+                    <MonthInput
+                        label="Fra"
+                        size="small"
+                        value={fom}
+                        feil={feilmeldinger.fom}
+                        readOnly={!props.alleFelterKanRedigeres}
+                        onChange={(dato) => {
+                            settFom(dato ? tilFørsteDagenIMåneden(dato) : undefined);
+                            settDetFinnesUlagredeEndringer(true);
+                            settFeilmeldinger((prevState) => ({ ...prevState, fom: undefined }));
+                        }}
+                    />
+                )}
             </FeilmeldingMaksBredde>
             <FeilmeldingMaksBredde $maxWidth={152}>
-                <MonthInput
-                    label="Til"
-                    size="small"
-                    value={tom}
-                    feil={feilmeldinger.tom}
-                    onChange={(dato) => {
-                        settTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
-                        settDetFinnesUlagredeEndringer(true);
-                        settFeilmeldinger((prevState) => ({ ...prevState, tom: undefined }));
-                    }}
-                />
+                {skalBrukeMånedÅrVelger ? (
+                    <MånedÅrVelger
+                        label="Til"
+                        size="small"
+                        årMånedInitiell={tom}
+                        feilmelding={feilmeldinger.tom}
+                        lesevisning={!props.alleFelterKanRedigeres}
+                        onEndret={(dato) => {
+                            settTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
+                            settDetFinnesUlagredeEndringer(true);
+                            settFeilmeldinger((prevState) => ({ ...prevState, tom: undefined }));
+                        }}
+                        antallÅrFrem={3}
+                        antallÅrTilbake={3}
+                    />
+                ) : (
+                    <MonthInput
+                        label="Til"
+                        size="small"
+                        value={tom}
+                        feil={feilmeldinger.tom}
+                        onChange={(dato) => {
+                            settTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
+                            settDetFinnesUlagredeEndringer(true);
+                            settFeilmeldinger((prevState) => ({ ...prevState, tom: undefined }));
+                        }}
+                    />
+                )}
             </FeilmeldingMaksBredde>
             <FeilmeldingMaksBredde $maxWidth={180}>
                 <TextField

--- a/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedVelger.tsx
+++ b/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedVelger.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Select from '../Select';
+import { Select } from '@navikt/ds-react';
 
 export type FamilieSelectSize = 'small' | 'medium';
 
@@ -38,8 +38,6 @@ const MånedVelger: React.FC<MånedProps> = ({
 }) => {
     return (
         <Select
-            erLesevisning={lesevisning}
-            lesevisningVerdi={måned ? månedValg.find((mnd) => mnd.mndNr === måned)?.verdi : ''}
             value={måned}
             className={className}
             onChange={(event) => {
@@ -50,6 +48,7 @@ const MånedVelger: React.FC<MånedProps> = ({
             label={'Måned'}
             hideLabel
             size={size}
+            readOnly={lesevisning}
         >
             <option value="">Måned</option>
             {månedValg.map((mnd) => (

--- a/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedVelger.tsx
+++ b/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedVelger.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import Select from '../Select';
+
+export type FamilieSelectSize = 'small' | 'medium';
+
+interface MånedProps {
+    måned: string | undefined;
+    settMåned: (måned: string) => void;
+    lesevisning?: boolean;
+    disabled?: boolean;
+    className?: string;
+    size?: FamilieSelectSize;
+}
+
+const månedValg = [
+    { mndNr: '01', verdi: 'Januar' },
+    { mndNr: '02', verdi: 'Februar' },
+    { mndNr: '03', verdi: 'Mars' },
+    { mndNr: '04', verdi: 'April' },
+    { mndNr: '05', verdi: 'Mai' },
+    { mndNr: '06', verdi: 'Juni' },
+    { mndNr: '07', verdi: 'Juli' },
+    { mndNr: '08', verdi: 'August' },
+    { mndNr: '09', verdi: 'September' },
+    { mndNr: '10', verdi: 'Oktober' },
+    { mndNr: '11', verdi: 'November' },
+    { mndNr: '12', verdi: 'Desember' },
+];
+
+const MånedVelger: React.FC<MånedProps> = ({
+    måned,
+    settMåned,
+    lesevisning = false,
+    disabled = false,
+    className,
+    size,
+}) => {
+    return (
+        <Select
+            erLesevisning={lesevisning}
+            lesevisningVerdi={måned ? månedValg.find((mnd) => mnd.mndNr === måned)?.verdi : ''}
+            value={måned}
+            className={className}
+            onChange={(event) => {
+                event.persist();
+                settMåned(event.target.value);
+            }}
+            disabled={disabled}
+            label={'Måned'}
+            hideLabel
+            size={size}
+        >
+            <option value="">Måned</option>
+            {månedValg.map((mnd) => (
+                <option value={mnd.mndNr} key={mnd.mndNr}>
+                    {mnd.verdi}
+                </option>
+            ))}
+        </Select>
+    );
+};
+
+export default MånedVelger;

--- a/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedÅrVelger.tsx
@@ -1,5 +1,6 @@
 import React, { DependencyList, useEffect, useRef, useState } from 'react';
 
+import { PadlockLockedFillIcon } from '@navikt/aksel-icons';
 import { ErrorMessage, HStack, Label, VStack } from '@navikt/ds-react';
 
 import MånedVelger from './MånedVelger';
@@ -48,9 +49,12 @@ export const MånedÅrVelger: React.FC<Props> = ({
     return (
         <VStack gap="2" className={className} style={lesevisning ? { minWidth: '140px' } : {}}>
             {label && (
-                <Label size="small" htmlFor="regdatoTil">
-                    {label}
-                </Label>
+                <HStack gap="1" wrap={false}>
+                    {lesevisning && <PadlockLockedFillIcon />}
+                    <Label size="small" htmlFor="regdatoTil">
+                        {label}
+                    </Label>
+                </HStack>
             )}
             <HStack gap="1" wrap={false}>
                 <MånedVelger

--- a/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedÅrVelger.tsx
@@ -1,0 +1,93 @@
+import React, { DependencyList, useEffect, useRef, useState } from 'react';
+
+import styled from 'styled-components';
+
+import { ErrorMessage } from '@navikt/ds-react';
+
+import MånedVelger from './MånedVelger';
+import { Årvelger } from './ÅrVelger';
+
+interface Props {
+    className?: string;
+    label?: string;
+    årMånedInitiell?: string;
+    onEndret: (årMåned?: string) => void;
+    antallÅrTilbake: number;
+    antallÅrFrem: number;
+    feilmelding?: string | null;
+    lesevisning?: boolean;
+    disabled?: boolean;
+    size?: 'medium' | 'small';
+}
+
+const DatolabelStyle = styled.label`
+    margin-bottom: 0.5em;
+`;
+
+const FlexDiv = styled.div`
+    display: flex;
+    gap: 0.25rem;
+`;
+
+export const MånedÅrVelger: React.FC<Props> = ({
+    className,
+    label,
+    årMånedInitiell,
+    onEndret,
+    antallÅrTilbake = 10,
+    antallÅrFrem = 4,
+    feilmelding,
+    lesevisning = false,
+    disabled = false,
+    size,
+}) => {
+    const [år, settÅr] = useState(
+        årMånedInitiell ? parseInt(årMånedInitiell.split('-')[0], 10) : undefined
+    );
+    const [måned, settMåned] = useState(
+        årMånedInitiell ? årMånedInitiell.split('-')[1] : undefined
+    );
+
+    useEffectNotInitialRender(() => {
+        if (år && måned) {
+            onEndret(`${år}-${måned}`);
+        } else {
+            onEndret(undefined);
+        }
+    }, [år, måned]);
+
+    return (
+        <div className={className} style={lesevisning ? { minWidth: '140px' } : {}}>
+            {label && <DatolabelStyle htmlFor="regdatoTil">{label}</DatolabelStyle>}
+            <FlexDiv>
+                <MånedVelger
+                    måned={måned}
+                    settMåned={settMåned}
+                    lesevisning={lesevisning}
+                    disabled={disabled}
+                    size={size}
+                />
+                <Årvelger
+                    år={år}
+                    settÅr={settÅr}
+                    antallÅrTilbake={antallÅrTilbake}
+                    antallÅrFrem={antallÅrFrem}
+                    lesevisning={lesevisning}
+                    disabled={disabled}
+                    size={size}
+                />
+            </FlexDiv>
+            <ErrorMessage>{feilmelding}</ErrorMessage>
+        </div>
+    );
+};
+
+export const useEffectNotInitialRender = (func: () => void, deps?: DependencyList): void => {
+    const hasRendered = useRef(false);
+
+    useEffect(() => {
+        if (hasRendered.current) func();
+        else hasRendered.current = true;
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, deps);
+};

--- a/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedÅrVelger.tsx
+++ b/src/frontend/komponenter/Skjema/MånedÅrVelger/MånedÅrVelger.tsx
@@ -1,8 +1,6 @@
 import React, { DependencyList, useEffect, useRef, useState } from 'react';
 
-import styled from 'styled-components';
-
-import { ErrorMessage } from '@navikt/ds-react';
+import { ErrorMessage, HStack, Label, VStack } from '@navikt/ds-react';
 
 import MånedVelger from './MånedVelger';
 import { Årvelger } from './ÅrVelger';
@@ -20,15 +18,6 @@ interface Props {
     size?: 'medium' | 'small';
 }
 
-const DatolabelStyle = styled.label`
-    margin-bottom: 0.5em;
-`;
-
-const FlexDiv = styled.div`
-    display: flex;
-    gap: 0.25rem;
-`;
-
 export const MånedÅrVelger: React.FC<Props> = ({
     className,
     label,
@@ -39,7 +28,7 @@ export const MånedÅrVelger: React.FC<Props> = ({
     feilmelding,
     lesevisning = false,
     disabled = false,
-    size,
+    size = 'small',
 }) => {
     const [år, settÅr] = useState(
         årMånedInitiell ? parseInt(årMånedInitiell.split('-')[0], 10) : undefined
@@ -57,9 +46,13 @@ export const MånedÅrVelger: React.FC<Props> = ({
     }, [år, måned]);
 
     return (
-        <div className={className} style={lesevisning ? { minWidth: '140px' } : {}}>
-            {label && <DatolabelStyle htmlFor="regdatoTil">{label}</DatolabelStyle>}
-            <FlexDiv>
+        <VStack gap="2" className={className} style={lesevisning ? { minWidth: '140px' } : {}}>
+            {label && (
+                <Label size="small" htmlFor="regdatoTil">
+                    {label}
+                </Label>
+            )}
+            <HStack gap="1" wrap={false}>
                 <MånedVelger
                     måned={måned}
                     settMåned={settMåned}
@@ -76,9 +69,9 @@ export const MånedÅrVelger: React.FC<Props> = ({
                     disabled={disabled}
                     size={size}
                 />
-            </FlexDiv>
+            </HStack>
             <ErrorMessage>{feilmelding}</ErrorMessage>
-        </div>
+        </VStack>
     );
 };
 

--- a/src/frontend/komponenter/Skjema/MånedÅrVelger/ÅrVelger.tsx
+++ b/src/frontend/komponenter/Skjema/MånedÅrVelger/ÅrVelger.tsx
@@ -1,0 +1,61 @@
+import React from 'react';
+
+import Select from '../Select';
+
+interface ÅrProps {
+    år: number | undefined;
+    settÅr: (år: number) => void;
+    antallÅrFrem: number;
+    antallÅrTilbake: number;
+    lesevisning?: boolean;
+    disabled?: boolean;
+    className?: string;
+    size?: 'medium' | 'small';
+}
+
+const lagÅrOptions = (år: number | undefined, antallÅrFrem: number, antallÅrTilbake: number) => {
+    const gjeldendeÅr = new Date().getFullYear();
+    const start = år ? Math.min(år, gjeldendeÅr - antallÅrTilbake) : gjeldendeÅr - antallÅrTilbake;
+    const slutt = år ? Math.max(år, gjeldendeÅr + antallÅrFrem) : gjeldendeÅr + antallÅrFrem;
+    return range(start, slutt + 1).map((år) => (
+        <option value={år} key={år}>
+            {år}
+        </option>
+    ));
+};
+
+const range = (start: number, end: number): number[] =>
+    Array.from({ length: end - start }, (_, k) => k + start);
+
+export const Årvelger: React.FC<ÅrProps> = ({
+    år,
+    settÅr,
+    antallÅrFrem,
+    antallÅrTilbake,
+    lesevisning = false,
+    disabled = false,
+    className,
+    size,
+}) => {
+    const årOptions = lagÅrOptions(år, antallÅrFrem, antallÅrTilbake);
+
+    return (
+        <Select
+            lesevisningVerdi={år ? år.toString() : ''}
+            value={år}
+            onChange={(event) => {
+                event.persist();
+                settÅr(parseInt(event.target.value));
+            }}
+            erLesevisning={lesevisning}
+            disabled={disabled}
+            label={'År'}
+            hideLabel
+            className={className}
+            size={size}
+        >
+            <option value="">År</option>
+            {årOptions}
+        </Select>
+    );
+};

--- a/src/frontend/komponenter/Skjema/MånedÅrVelger/ÅrVelger.tsx
+++ b/src/frontend/komponenter/Skjema/MånedÅrVelger/ÅrVelger.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import Select from '../Select';
+import { Select } from '@navikt/ds-react';
 
 interface ÅrProps {
     år: number | undefined;
@@ -41,18 +41,17 @@ export const Årvelger: React.FC<ÅrProps> = ({
 
     return (
         <Select
-            lesevisningVerdi={år ? år.toString() : ''}
             value={år}
             onChange={(event) => {
                 event.persist();
                 settÅr(parseInt(event.target.value));
             }}
-            erLesevisning={lesevisning}
             disabled={disabled}
             label={'År'}
             hideLabel
             className={className}
             size={size}
+            readOnly={lesevisning}
         >
             <option value="">År</option>
             {årOptions}

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -21,4 +21,5 @@ export enum Toggle {
      * features-under-utvikling
      */
     KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN = 'sak.kan-bruke-vedtaksperioder-tilsyn-barn',
+    SKAL_BRUKE_MANED_AR_VELGER = 'sak.skal-bruke-maned-ar-velger',
 }

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -21,5 +21,5 @@ export enum Toggle {
      * features-under-utvikling
      */
     KAN_BRUKE_VEDTAKSPERIODER_TILSYN_BARN = 'sak.kan-bruke-vedtaksperioder-tilsyn-barn',
-    SKAL_BRUKE_MANED_AR_VELGER = 'sak.skal-bruke-maned-ar-velger',
+    SKAL_BRUKE_MANED_AR_VELGER = 'sak.frontend.skal-bruke-maned-ar-velger',
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Teste ut å velge dato for utgifter med dropdowns for å gjøre det tydligere at det er snakk om hele måneder og ikke spesifikke datoer. Brukes kun dersom toggle er på for at Tone+flere skal få teste det før vi faktisk går for dette.

⚠️ Har ikke gjort spesielt mye tilpasninger annet enn å kopiere fra EF fordi det ikke er sikkert at vi ønsker å beholde dette. Første commit er ren kopi, resten er et par tilpasninger for at stylingen skal matche det vi har ellers. Kan være ting som er kopiert med som ikke er nødvendig.

<img width="1052" alt="image" src="https://github.com/user-attachments/assets/e908ab96-6f38-4474-aba2-6cfb56bd63b7" />
