### PR TITLE
✨ Legg til muligheten for å velge aktivitet i inngangsvilkår for boutgifter

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårBoutgifter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/Delvilkår/AktivitetDelvilkårBoutgifter.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { JaNeiVurdering } from '../../../Vilkårvurdering/JaNeiVurdering';
+import { SvarJaNei } from '../../typer/vilkårperiode/vilkårperiode';
+import { EndreAktivitetFormBoutgifter } from '../EndreAktivitetBoutgifter';
+import { skalVurdereLønnet } from '../utilsBoutgifter';
+
+const Container = styled.div`
+    display: flex;
+    gap: 2rem;
+`;
+
+export const AktivitetDelvilkårBoutgfiter: React.FC<{
+    aktivitetForm: EndreAktivitetFormBoutgifter;
+    oppdaterLønnet: (svar: SvarJaNei) => void;
+    readOnly: boolean;
+}> = ({ aktivitetForm, oppdaterLønnet, readOnly }) => {
+    if (aktivitetForm.type === '') return null;
+
+    if (!skalVurdereLønnet(aktivitetForm.type)) return null;
+
+    return (
+        <Container>
+            <JaNeiVurdering
+                label="Mottar bruker ordinær lønn i tiltaket?"
+                readOnly={readOnly}
+                svar={aktivitetForm.svarLønnet}
+                oppdaterSvar={oppdaterLønnet}
+            />
+        </Container>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitet.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
 
 import { EndreAktivitetBarnetilsyn } from './EndreAktivitetBarnetilsyn';
+import { EndreAktivitetBoutgfiter } from './EndreAktivitetBoutgifter';
 import { EndreAktivitetLæremidler } from './EndreAktivitetLæremidler';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { Aktivitet } from '../typer/vilkårperiode/aktivitet';
 import { AktivitetBarnetilsyn } from '../typer/vilkårperiode/aktivitetBarnetilsyn';
+import { AktivitetBoutgifter } from '../typer/vilkårperiode/aktivitetBoutgifter';
 import { AktivitetLæremidler } from '../typer/vilkårperiode/aktivitetLæremidler';
 
 export const EndreAktivitet: React.FC<{
@@ -28,6 +30,14 @@ export const EndreAktivitet: React.FC<{
             return (
                 <EndreAktivitetLæremidler
                     aktivitet={aktivitet as AktivitetLæremidler}
+                    aktivitetFraRegister={aktivitetFraRegister}
+                    avbrytRedigering={avbrytRedigering}
+                />
+            );
+        case Stønadstype.BOUTGIFTER:
+            return (
+                <EndreAktivitetBoutgfiter
+                    aktivitet={aktivitet as AktivitetBoutgifter}
                     aktivitetFraRegister={aktivitetFraRegister}
                     avbrytRedigering={avbrytRedigering}
                 />

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBoutgifter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetBoutgifter.tsx
@@ -1,0 +1,229 @@
+import React, { useState } from 'react';
+
+import styled from 'styled-components';
+
+import { Button, HStack, VStack } from '@navikt/ds-react';
+
+import { AktivitetDelvilkårBoutgfiter } from './Delvilkår/AktivitetDelvilkårBoutgifter';
+import { DetaljerRegisterAktivitet } from './DetaljerRegisterAktivitet';
+import { valgbareAktivitetTyper } from './utilsAktivitet';
+import {
+    finnBegrunnelseGrunnerAktivitet,
+    mapEksisterendeAktivitet,
+    mapFaktaOgSvarTilRequest,
+    nyAktivitet,
+    resettAktivitet,
+} from './utilsBoutgifter';
+import { AktivitetValidering, validerAktivitet } from './valideringAktivitetBoutgifter';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
+import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
+import { useLagreVilkårperiode } from '../../../../hooks/useLagreVilkårperiode';
+import { useRevurderingAvPerioder } from '../../../../hooks/useRevurderingAvPerioder';
+import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { feiletRessursTilFeilmelding, Feil } from '../../../../komponenter/Feil/feilmeldingUtils';
+import TextField from '../../../../komponenter/Skjema/TextField';
+import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
+import { Registeraktivitet } from '../../../../typer/registeraktivitet';
+import { RessursStatus } from '../../../../typer/ressurs';
+import { Periode } from '../../../../utils/periode';
+import { harTallverdi, tilHeltall } from '../../../../utils/tall';
+import { Aktivitet, AktivitetType } from '../typer/vilkårperiode/aktivitet';
+import { AktivitetBoutgifter } from '../typer/vilkårperiode/aktivitetBoutgifter';
+import { KildeVilkårsperiode, SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
+import Begrunnelse from '../Vilkårperioder/Begrunnelse/Begrunnelse';
+import { EndreTypeOgDatoer } from '../Vilkårperioder/EndreTypeOgDatoer';
+import SlettVilkårperiode from '../Vilkårperioder/SlettVilkårperiodeModal';
+import VilkårperiodeKortBase from '../Vilkårperioder/VilkårperiodeKort/VilkårperiodeKortBase';
+
+const FeltContainer = styled.div`
+    flex-grow: 1;
+    display: flex;
+    gap: 1rem;
+    flex-wrap: wrap;
+
+    align-self: start;
+    align-items: start;
+`;
+
+export interface EndreAktivitetFormBoutgifter extends Periode {
+    type: AktivitetType | '';
+    aktivitetsdager: number | undefined;
+    svarLønnet: SvarJaNei | undefined;
+    begrunnelse?: string;
+    kildeId?: string;
+}
+
+const initaliserForm = (
+    eksisterendeAktivitet?: AktivitetBoutgifter,
+    aktivitetFraRegister?: Registeraktivitet
+): EndreAktivitetFormBoutgifter => {
+    return eksisterendeAktivitet === undefined
+        ? nyAktivitet(aktivitetFraRegister)
+        : mapEksisterendeAktivitet(eksisterendeAktivitet);
+};
+
+export const EndreAktivitetBoutgfiter: React.FC<{
+    aktivitet?: AktivitetBoutgifter;
+    aktivitetFraRegister?: Registeraktivitet;
+    avbrytRedigering: () => void;
+}> = ({ aktivitet, avbrytRedigering, aktivitetFraRegister }) => {
+    const { behandling, behandlingFakta } = useBehandling();
+    const { oppdaterAktivitet, leggTilAktivitet, oppdatertStønadsperiodeFeil } =
+        useInngangsvilkår();
+    const { lagreVilkårperiode } = useLagreVilkårperiode();
+
+    const [form, settForm] = useState<EndreAktivitetFormBoutgifter>(
+        initaliserForm(aktivitet, aktivitetFraRegister)
+    );
+
+    const [laster, settLaster] = useState<boolean>(false);
+    const [feilmelding, settFeilmelding] = useState<Feil>();
+    const [vilkårsperiodeFeil, settVilkårsperiodeFeil] =
+        useState<FormErrors<AktivitetValidering>>();
+
+    const validerForm = (): boolean => {
+        const vilkårsperiodeFeil = validerAktivitet(form, aktivitet, behandling.revurderFra);
+        settVilkårsperiodeFeil(vilkårsperiodeFeil);
+
+        return isValid(vilkårsperiodeFeil);
+    };
+
+    const nyRadLeggesTil = aktivitet === undefined;
+
+    const lagre = () => {
+        if (laster) return;
+        settFeilmelding(undefined);
+
+        const kanSendeInn = validerForm();
+
+        if (kanSendeInn) {
+            settLaster(true);
+
+            const response = lagreVilkårperiode<Aktivitet>(
+                behandling.id,
+                form,
+                mapFaktaOgSvarTilRequest(form),
+                aktivitet?.id
+            );
+
+            return response
+                .then((res) => {
+                    if (res.status === RessursStatus.SUKSESS) {
+                        if (nyRadLeggesTil) {
+                            leggTilAktivitet(res.data.periode);
+                        } else {
+                            oppdaterAktivitet(res.data.periode);
+                        }
+
+                        oppdatertStønadsperiodeFeil(
+                            res.data.stønadsperiodeStatus,
+                            res.data.stønadsperiodeFeil
+                        );
+
+                        avbrytRedigering();
+                    } else {
+                        settFeilmelding(
+                            feiletRessursTilFeilmelding(res, 'Feilet legg til periode')
+                        );
+                    }
+                })
+                .finally(() => settLaster(false));
+        }
+    };
+
+    const oppdaterForm = (key: keyof AktivitetBoutgifter, nyVerdi: string) => {
+        settForm((prevState) => ({ ...prevState, [key]: nyVerdi }));
+    };
+
+    const oppdaterType = (type: AktivitetType) => {
+        settForm((prevState) =>
+            resettAktivitet(type, prevState, behandlingFakta.søknadMottattTidspunkt)
+        );
+    };
+
+    const { alleFelterKanEndres, kanSlettePeriode } = useRevurderingAvPerioder({
+        periodeFom: aktivitet?.fom,
+        periodeTom: aktivitet?.tom,
+        nyRadLeggesTil: nyRadLeggesTil,
+    });
+
+    const delvilkårSomKreverBegrunnelse = finnBegrunnelseGrunnerAktivitet(
+        form.type,
+        form.svarLønnet
+    );
+
+    const aktivitetErBruktFraSystem = form.kildeId !== undefined;
+
+    return (
+        <VilkårperiodeKortBase vilkårperiode={aktivitet} redigeres>
+            <VStack gap={'4'}>
+                <FeltContainer>
+                    <EndreTypeOgDatoer
+                        form={form}
+                        oppdaterTypeIForm={oppdaterType}
+                        oppdaterPeriode={oppdaterForm}
+                        typeOptions={valgbareAktivitetTyper(Stønadstype.BOUTGIFTER)}
+                        formFeil={vilkårsperiodeFeil}
+                        alleFelterKanEndres={alleFelterKanEndres}
+                        kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}
+                    />
+                    {form.type !== AktivitetType.INGEN_AKTIVITET && (
+                        <FeilmeldingMaksBredde $maxWidth={140}>
+                            <TextField
+                                erLesevisning={aktivitet?.kilde === KildeVilkårsperiode.SYSTEM}
+                                label="Aktivitetsdager"
+                                value={
+                                    harTallverdi(form.aktivitetsdager) ? form.aktivitetsdager : ''
+                                }
+                                onChange={(event) =>
+                                    settForm((prevState) => ({
+                                        ...prevState,
+                                        aktivitetsdager: tilHeltall(event.target.value),
+                                    }))
+                                }
+                                size="small"
+                                error={vilkårsperiodeFeil?.aktivitetsdager}
+                                autoComplete="off"
+                                readOnly={!alleFelterKanEndres}
+                            />
+                        </FeilmeldingMaksBredde>
+                    )}
+                </FeltContainer>
+                <DetaljerRegisterAktivitet aktivitetFraRegister={aktivitetFraRegister} />
+            </VStack>
+
+            <AktivitetDelvilkårBoutgfiter
+                aktivitetForm={form}
+                readOnly={!alleFelterKanEndres}
+                oppdaterLønnet={(svar) =>
+                    settForm((prevState) => ({ ...prevState, svarLønnet: svar }))
+                }
+            />
+
+            <Begrunnelse
+                begrunnelse={form?.begrunnelse || ''}
+                oppdaterBegrunnelse={(nyBegrunnelse) => oppdaterForm('begrunnelse', nyBegrunnelse)}
+                delvilkårSomKreverBegrunnelse={delvilkårSomKreverBegrunnelse}
+                feil={vilkårsperiodeFeil?.begrunnelse}
+            />
+            <HStack gap="4">
+                <Button size="xsmall" onClick={lagre}>
+                    Lagre
+                </Button>
+                <Button onClick={avbrytRedigering} variant="secondary" size="xsmall">
+                    Avbryt
+                </Button>
+                {aktivitet !== undefined && kanSlettePeriode && (
+                    <SlettVilkårperiode
+                        avbrytRedigering={avbrytRedigering}
+                        vilkårperiode={aktivitet}
+                    />
+                )}
+            </HStack>
+
+            <Feilmelding feil={feilmelding} />
+        </VilkårperiodeKortBase>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsBoutgifter.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsBoutgifter.ts
@@ -1,0 +1,137 @@
+import { EndreAktivitetFormBoutgifter } from './EndreAktivitetBoutgifter';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
+import { Registeraktivitet } from '../../../../typer/registeraktivitet';
+import { dagensDato, førsteDagIMånederForut } from '../../../../utils/dato';
+import { Periode } from '../../../../utils/periode';
+import { harTallverdi } from '../../../../utils/tall';
+import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
+import {
+    AktivitetBoutgifter,
+    AktivitetBoutgifterFaktaOgSvar,
+} from '../typer/vilkårperiode/aktivitetBoutgifter';
+import { SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
+import { BegrunnelseGrunner } from '../Vilkårperioder/Begrunnelse/utils';
+
+export const nyAktivitet = (
+    aktivitetFraRegister: Registeraktivitet | undefined
+): EndreAktivitetFormBoutgifter =>
+    aktivitetFraRegister ? nyAktivitetFraRegister(aktivitetFraRegister) : nyTomAktivitet();
+
+export const mapEksisterendeAktivitet = (
+    eksisterendeAktivitet: AktivitetBoutgifter
+): EndreAktivitetFormBoutgifter => ({
+    ...eksisterendeAktivitet,
+    aktivitetsdager: eksisterendeAktivitet.faktaOgVurderinger.aktivitetsdager,
+    svarLønnet: eksisterendeAktivitet.faktaOgVurderinger.lønnet?.svar,
+});
+
+/**
+ * Prefyller aktivtetsdager med 5 dager hvis det gjelder utdanning då feltet mangler fra arena
+ * Ellers brukes antallDagerPerUke
+ */
+const aktivitetsdagerFraRegister = (aktivitetFraRegister: Registeraktivitet) =>
+    aktivitetFraRegister.erUtdanning ? 5 : aktivitetFraRegister.antallDagerPerUke;
+
+function nyAktivitetFraRegister(
+    aktivitetFraRegister: Registeraktivitet
+): EndreAktivitetFormBoutgifter {
+    return {
+        type: aktivitetFraRegister.erUtdanning ? AktivitetType.UTDANNING : AktivitetType.TILTAK,
+        fom: aktivitetFraRegister.fom || '',
+        tom: aktivitetFraRegister.tom || '',
+        aktivitetsdager: aktivitetsdagerFraRegister(aktivitetFraRegister),
+        svarLønnet: undefined,
+        kildeId: aktivitetFraRegister.id,
+    };
+}
+
+function nyTomAktivitet(): EndreAktivitetFormBoutgifter {
+    return {
+        type: '',
+        fom: '',
+        tom: '',
+        aktivitetsdager: undefined,
+        svarLønnet: undefined,
+    };
+}
+
+export const skalVurdereLønnet = (type: AktivitetType | '') => type === AktivitetType.TILTAK;
+
+export const resettAktivitet = (
+    nyType: AktivitetType,
+    eksisterendeAktivitetForm: EndreAktivitetFormBoutgifter,
+    søknadMottattTidspunkt?: string
+): EndreAktivitetFormBoutgifter => {
+    const { fom, tom } = resetPeriode(nyType, eksisterendeAktivitetForm, søknadMottattTidspunkt);
+
+    return {
+        ...eksisterendeAktivitetForm,
+        type: nyType,
+        fom: fom,
+        tom: tom,
+        aktivitetsdager: resetAktivitetsdager(nyType, eksisterendeAktivitetForm),
+        svarLønnet: undefined,
+    };
+};
+
+const resetPeriode = (
+    nyType: string,
+    eksisterendeForm: EndreAktivitetFormBoutgifter,
+    søknadMottattTidspunkt?: string
+): Periode => {
+    if (nyType === AktivitetType.INGEN_AKTIVITET) {
+        return {
+            fom: førsteDagIMånederForut(
+                ingenMålgruppeAktivitetAntallMndBakITiden[Stønadstype.BOUTGIFTER],
+                søknadMottattTidspunkt
+            ),
+            tom: dagensDato(),
+        };
+    }
+
+    if (eksisterendeForm.type === AktivitetType.INGEN_AKTIVITET) {
+        // Resetter datoer om de forrige var satt automatisk
+        return { fom: '', tom: '' };
+    }
+
+    return { fom: eksisterendeForm.fom, tom: eksisterendeForm.tom };
+};
+
+const resetAktivitetsdager = (
+    nyType: AktivitetType,
+    eksisterendeForm: EndreAktivitetFormBoutgifter
+) => {
+    if (nyType === AktivitetType.INGEN_AKTIVITET) {
+        return undefined;
+    } else if (!harTallverdi(eksisterendeForm.aktivitetsdager)) {
+        return 5;
+    }
+
+    return eksisterendeForm.aktivitetsdager;
+};
+
+export const finnBegrunnelseGrunnerAktivitet = (
+    type: AktivitetType | '',
+    svarLønnet: SvarJaNei | undefined
+) => {
+    const delvilkårSomMåBegrunnes = [];
+
+    if (svarLønnet === SvarJaNei.JA) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.LØNNET);
+    }
+
+    if (type === AktivitetType.INGEN_AKTIVITET) {
+        delvilkårSomMåBegrunnes.push(BegrunnelseGrunner.INGEN_AKTIVITET);
+    }
+
+    return delvilkårSomMåBegrunnes;
+};
+
+export const mapFaktaOgSvarTilRequest = (
+    aktivitetForm: EndreAktivitetFormBoutgifter
+): AktivitetBoutgifterFaktaOgSvar => ({
+    '@type': 'AKTIVITET_BOUTGIFTER',
+    aktivitetsdager: aktivitetForm.aktivitetsdager,
+    svarLønnet: aktivitetForm.svarLønnet,
+});

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetBoutgifter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetBoutgifter.tsx
@@ -1,0 +1,60 @@
+import { EndreAktivitetFormBoutgifter } from './EndreAktivitetBoutgifter';
+import { finnBegrunnelseGrunnerAktivitet } from './utilsBoutgifter';
+import { FormErrors } from '../../../../hooks/felles/useFormState';
+import { Periode, validerPeriode } from '../../../../utils/periode';
+import { harTallverdi } from '../../../../utils/tall';
+import { harIkkeVerdi } from '../../../../utils/utils';
+import { Aktivitet, AktivitetType } from '../typer/vilkårperiode/aktivitet';
+
+export interface AktivitetValidering extends Periode {
+    type: AktivitetType | '';
+    aktivitetsdager?: number;
+    begrunnelse?: string;
+}
+
+export const validerAktivitet = (
+    endretAktivitet: EndreAktivitetFormBoutgifter,
+    lagretAktivitet?: Aktivitet | undefined,
+    revurderesFraDato?: string
+): FormErrors<AktivitetValidering> => {
+    const feil: FormErrors<AktivitetValidering> = {
+        fom: undefined,
+        tom: undefined,
+        type: undefined,
+        aktivitetsdager: undefined,
+        begrunnelse: undefined,
+    };
+
+    if (endretAktivitet.type === '') {
+        return { ...feil, type: 'Må velges' };
+    }
+
+    const periodeValidering = validerPeriode(endretAktivitet, lagretAktivitet, revurderesFraDato);
+
+    if (periodeValidering) {
+        return {
+            ...feil,
+            ...periodeValidering,
+        };
+    }
+
+    if (
+        endretAktivitet.type !== AktivitetType.INGEN_AKTIVITET &&
+        !aktivitetsdagerErGyldigTall(endretAktivitet.aktivitetsdager)
+    ) {
+        return { ...feil, aktivitetsdager: 'Aktivitetsdager må være et tall mellom 1 og 5' };
+    }
+
+    const obligatoriskeBegrunnelser = finnBegrunnelseGrunnerAktivitet(
+        endretAktivitet.type,
+        endretAktivitet.svarLønnet
+    );
+
+    if (obligatoriskeBegrunnelser.length > 0 && harIkkeVerdi(endretAktivitet.begrunnelse))
+        return { ...feil, begrunnelse: 'Begrunnelse er obligatorisk' };
+
+    return feil;
+};
+
+const aktivitetsdagerErGyldigTall = (aktivitetsdager: number | undefined): boolean =>
+    harTallverdi(aktivitetsdager) && aktivitetsdager >= 1 && aktivitetsdager <= 5;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet.ts
@@ -4,12 +4,17 @@ import {
     AktivitetBarnetilsynFaktaOgVurderinger,
 } from './aktivitetBarnetilsyn';
 import {
+    AktivitetBoutgifter,
+    AktivitetBoutgifterFaktaOgSvar,
+    AktivitetBoutgifterFaktaOgVurderinger,
+} from './aktivitetBoutgifter';
+import {
     AktivitetLæremidler,
     AktivitetLæremidlerFaktaOgSvar,
     AktivitetLæremidlerFaktaOgVurderinger,
 } from './aktivitetLæremidler';
 
-export type Aktivitet = AktivitetBarnetilsyn | AktivitetLæremidler;
+export type Aktivitet = AktivitetBarnetilsyn | AktivitetLæremidler | AktivitetBoutgifter;
 
 export enum AktivitetType {
     TILTAK = 'TILTAK',
@@ -27,6 +32,10 @@ export const AktivitetTypeTilTekst: Record<AktivitetType, string> = {
 
 export type AktivitetFaktaOgVurderinger =
     | AktivitetBarnetilsynFaktaOgVurderinger
-    | AktivitetLæremidlerFaktaOgVurderinger;
+    | AktivitetLæremidlerFaktaOgVurderinger
+    | AktivitetBoutgifterFaktaOgVurderinger;
 
-export type AktivitetFaktaOgSvar = AktivitetBarnetilsynFaktaOgSvar | AktivitetLæremidlerFaktaOgSvar;
+export type AktivitetFaktaOgSvar =
+    | AktivitetBarnetilsynFaktaOgSvar
+    | AktivitetLæremidlerFaktaOgSvar
+    | AktivitetBoutgifterFaktaOgSvar;

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetBoutgifter.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetBoutgifter.ts
@@ -1,0 +1,18 @@
+import { VilkårPeriodeAktivitet, SvarJaNei, Vurdering } from './vilkårperiode';
+
+export interface AktivitetBoutgifter extends VilkårPeriodeAktivitet {
+    kildeId?: string;
+    faktaOgVurderinger: AktivitetBoutgifterFaktaOgVurderinger;
+}
+
+export interface AktivitetBoutgifterFaktaOgVurderinger {
+    '@type': 'AKTIVITET_BOUTGIFTER';
+    aktivitetsdager: number | undefined;
+    lønnet: Vurdering | undefined;
+}
+
+export interface AktivitetBoutgifterFaktaOgSvar {
+    '@type': 'AKTIVITET_BOUTGIFTER';
+    aktivitetsdager: number | undefined;
+    svarLønnet: SvarJaNei | undefined;
+}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne velge aktivitet i inngangsvilkår for boutgifter

Nesten en blåkopi av tilsyn barn. 
- Har fjernet "reel arbeidssøker" som mulig aktivitet. 
- Beholder "aktivitetsdager" da det ikke er landet om dette skal med
- Kunne laget mere generelle komponenter som går på tvers av tilsyn barn og boutgifter, men velger å kopiere for å gjøre oss mere fleksible på endringer i den ene stønaden uten at det trenger å påvirke den andre