### PR TITLE
Lagt til visning av informasjon om annen forelder mottar stønad for b…

### DIFF
--- a/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarn.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarn.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { automatiskVurdert } from './automatiskVurdert';
 import { PassBarnLesMer } from './PassBarnLesMer';
+import { PassBarnSaksinformasjonAndreForeldre } from './PassBarnSaksinformasjonAndreForeldre';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useVilkår } from '../../../../context/VilkårContext';
 import { InlineKopiknapp } from '../../../../komponenter/Knapper/InlineKopiknapp';
@@ -37,7 +38,7 @@ const PassBarn: React.FC<Props> = ({ vilkårsregler }) => {
     return behandlingFakta.barn.map((barn) => {
         const vilkårForDetteBarnet = vilkårsett.filter((e) => e.barnId === barn.barnId);
 
-        const { navn, alder, dødsdato } = barn.registergrunnlag;
+        const { navn, alder, dødsdato, saksinformasjonAndreForeldre } = barn.registergrunnlag;
 
         return (
             <VilkårPanel
@@ -51,6 +52,9 @@ const PassBarn: React.FC<Props> = ({ vilkårsregler }) => {
                 key={barn.barnId}
             >
                 {dødsdato && <SmallErrorTag>Død ({formaterIsoDato(dødsdato)})</SmallErrorTag>}
+                <PassBarnSaksinformasjonAndreForeldre
+                    saksinformasjonAndreForeldre={saksinformasjonAndreForeldre}
+                />
                 <PassBarnLesMer />
                 {vilkårForDetteBarnet.map((vilkår) => (
                     <VisEllerEndreVilkår key={vilkår.id} regler={vilkårsregler} vilkår={vilkår} />

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarnSaksinformasjonAndreForeldre.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/PassBarn/PassBarnSaksinformasjonAndreForeldre.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+
+import { styled } from 'styled-components';
+
+import { Alert, VStack } from '@navikt/ds-react';
+
+import { SaksinformasjonAndreForeldre } from '../../../../typer/behandling/behandlingFakta/faktaBarn';
+import { formaterIsoDatoTidKort, formaterIsoPeriode } from '../../../../utils/dato';
+
+const StyledAlert = styled(Alert)`
+    max-width: 50rem;
+`;
+
+const sjekketTidspunkt = (hentetTidspunkt: string) =>
+    ` (sjekket ${formaterIsoDatoTidKort(hentetTidspunkt)})`;
+
+export const PassBarnSaksinformasjonAndreForeldre = ({
+    saksinformasjonAndreForeldre,
+}: {
+    saksinformasjonAndreForeldre: SaksinformasjonAndreForeldre | undefined;
+}) => {
+    // Tidligere behandlinger har ikke informasjonen
+    if (!saksinformasjonAndreForeldre) {
+        return null;
+    }
+    const { hentetTidspunkt, harBehandlingUnderArbeid } = saksinformasjonAndreForeldre;
+    return (
+        <VStack gap={'2'}>
+            {harBehandlingUnderArbeid && (
+                <StyledAlert variant={'warning'} size={'small'}>
+                    Annen forelder har behandling under arbeid
+                    {sjekketTidspunkt(hentetTidspunkt)}
+                </StyledAlert>
+            )}
+            <AlertVedtaksperioder saksinformasjonAndreForeldre={saksinformasjonAndreForeldre} />
+        </VStack>
+    );
+};
+
+/**
+ * Hvis ingen vedtaksperiode: Utbetales ikke tilsyn barn
+ * Hvis en vedtaksperiode: Periode vises rett etter tekst
+ * Hvis flere: Perioder vises under tekst
+ */
+const AlertVedtaksperioder = ({
+    saksinformasjonAndreForeldre,
+}: {
+    saksinformasjonAndreForeldre: SaksinformasjonAndreForeldre;
+}) => {
+    const { hentetTidspunkt, vedtaksperioderBarn } = saksinformasjonAndreForeldre;
+    if (vedtaksperioderBarn.length === 0) {
+        return (
+            <StyledAlert variant={'info'} size={'small'} inline>
+                Det utbetales ikke støtte til pass av barn til annen forelder for dette barnet
+                {sjekketTidspunkt(hentetTidspunkt)}
+            </StyledAlert>
+        );
+    }
+    return (
+        <StyledAlert variant={'warning'} size={'small'} contentMaxWidth={false}>
+            <VStack>
+                <span>
+                    Det utbetales tilsyn barn til annen forelder for dette barnet{' '}
+                    {vedtaksperioderBarn.length === 1 &&
+                        formaterIsoPeriode(vedtaksperioderBarn[0].fom, vedtaksperioderBarn[0].tom)}
+                    {sjekketTidspunkt(hentetTidspunkt)}
+                </span>
+                {vedtaksperioderBarn.length > 1 &&
+                    vedtaksperioderBarn.map((periode, index) => (
+                        <span key={index}>{formaterIsoPeriode(periode.fom, periode.tom)}</span>
+                    ))}
+            </VStack>
+        </StyledAlert>
+    );
+};

--- a/src/frontend/typer/behandling/behandlingFakta/faktaBarn.ts
+++ b/src/frontend/typer/behandling/behandlingFakta/faktaBarn.ts
@@ -1,3 +1,4 @@
+import { Periode } from '../../../utils/periode';
 import { JaNei } from '../../common';
 
 export interface FaktaBarn {
@@ -13,6 +14,13 @@ interface RegistergrunnlagBarn {
     fødselsdato?: string;
     dødsdato?: string;
     alder?: number;
+    saksinformasjonAndreForeldre?: SaksinformasjonAndreForeldre;
+}
+
+export interface SaksinformasjonAndreForeldre {
+    hentetTidspunkt: string;
+    harBehandlingUnderArbeid: boolean;
+    vedtaksperioderBarn: Periode[];
 }
 
 interface SøknadsgrunnlagBarn {


### PR DESCRIPTION
…arnet på vilkår av barn

### Hvorfor er denne endringen nødvendig? ✨
Det er ønskelig å vise informasjon om annen forelder mottar stønad for å unngå at saksbehandler må sjekke opp dette i registeret

En del av https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-21936

* https://github.com/navikt/tilleggsstonader-sak/pull/631

## Hvis ingen utbetaling
![image](https://github.com/user-attachments/assets/f2d4d73e-09c0-4cbb-bd5e-ebacfdb4c7eb)

## Hvis en utbetalingsperiode
![image](https://github.com/user-attachments/assets/92c0440d-abbb-45bf-aecb-24150dadadeb)

## Hvis flere vedtaksperioder
![image](https://github.com/user-attachments/assets/0c622ea8-3ab7-4426-a2ac-e468ae921ed6)
