### PR TITLE
♻️ Fjern "V2" fra endepunktene for beregn og innvilgelse tilsyn barn

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -85,7 +85,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({
     const lagreVedtak = () => {
         if (beregningsresultat.status === RessursStatus.SUKSESS && erVedtaksperioderBeregnet) {
             return request<null, InnvilgeBarnetilsynRequest>(
-                `/api/sak/vedtak/tilsyn-barn/${behandling.id}/innvilgelseV2`,
+                `/api/sak/vedtak/tilsyn-barn/${behandling.id}/innvilgelse`,
                 'POST',
                 {
                     vedtaksperioder: vedtaksperioder,
@@ -117,7 +117,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({
         if (kanSendeInn) {
             settBeregningsresultat(byggHenterRessurs());
             request<BeregningsresultatTilsynBarn, BeregnBarnetilsynRequest>(
-                `/api/sak/vedtak/tilsyn-barn/${behandling.id}/beregnV2`,
+                `/api/sak/vedtak/tilsyn-barn/${behandling.id}/beregn`,
                 'POST',
                 { vedtaksperioder: vedtaksperioder }
             ).then((result) => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Rydder opp etter migreringen til vedtaksperioder. Målet er å kunne fjerne V2 endepunktene fra backend. `/innvilgelse` og `/innvilgelseV2` har nå samme logikk backend. `/beregn` og `/beregnV2` har også samme logikk backend.