### PR TITLE
Fjern InnvilgelseTilsynBarnRequestV2

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -18,7 +18,7 @@ import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '../../../../..
 import {
     BeregnBarnetilsynRequest,
     BeregningsresultatTilsynBarn,
-    InnvilgeBarnetilsynRequestV2,
+    InnvilgeBarnetilsynRequest,
     InnvilgelseBarnetilsyn,
     validerVedtaksperioder,
     VedtaksperiodeTilsynBarn,
@@ -84,7 +84,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({
 
     const lagreVedtak = () => {
         if (beregningsresultat.status === RessursStatus.SUKSESS && erVedtaksperioderBeregnet) {
-            return request<null, InnvilgeBarnetilsynRequestV2>(
+            return request<null, InnvilgeBarnetilsynRequest>(
                 `/api/sak/vedtak/tilsyn-barn/${behandling.id}/innvilgelseV2`,
                 'POST',
                 {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/utils.ts
@@ -1,6 +1,0 @@
-import { TypeVedtak } from '../../../../typer/vedtak/vedtak';
-import { InnvilgeBarnetilsynRequest } from '../../../../typer/vedtak/vedtakTilsynBarn';
-
-export const lagVedtakRequest = (): InnvilgeBarnetilsynRequest => {
-    return { type: TypeVedtak.INNVILGELSE };
-};

--- a/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
+++ b/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
@@ -18,10 +18,6 @@ export const vedtakErOpphør = (vedtak: VedtakBarnetilsyn): vedtak is OpphørBar
     vedtak.type === TypeVedtak.OPPHØR;
 
 export type InnvilgeBarnetilsynRequest = {
-    type: TypeVedtak.INNVILGELSE;
-};
-
-export type InnvilgeBarnetilsynRequestV2 = {
     vedtaksperioder: VedtaksperiodeTilsynBarn[];
     begrunnelse?: string;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Rydd opp etter overgang til vedtaksperioder for tilsyn barn. Renamer `InnvilgelseTilsynBarnRequestV2` til `InnvilgelseTilsynBarnRequest` og fjerner gammel `InnvilgelseTilsynBarnRequest`.