### PR TITLE
Bruk feilmelding-komponent for å vise feilmelding - foreslå vedtaksperiode

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -10,6 +10,7 @@ import { useSteg } from '../../../../../context/StegContext';
 import { FormErrors, isValid } from '../../../../../hooks/felles/useFormState';
 import { useMapById } from '../../../../../hooks/useMapById';
 import DataViewer from '../../../../../komponenter/DataViewer';
+import { Feil } from '../../../../../komponenter/Feil/feilmeldingUtils';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
 import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
@@ -68,7 +69,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({
 
     const [vedtaksperiodeFeil, settVedtaksperiodeFeil] =
         useState<FormErrors<VedtaksperiodeTilsynBarn>[]>();
-    const [foreslåPeriodeFeil, settForeslåPeriodeFeil] = useState<string>();
+    const [foreslåPeriodeFeil, settForeslåPeriodeFeil] = useState<Feil>();
 
     const [beregningsresultat, settBeregningsresultat] =
         useState(byggTomRessurs<BeregningsresultatTilsynBarn>());

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Vedtaksperioder.tsx
@@ -4,12 +4,17 @@ import styled from 'styled-components';
 import { v4 as uuid } from 'uuid';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
-import { Alert, Button, Heading, HStack, Label, VStack } from '@navikt/ds-react';
+import { Button, Heading, HStack, Label, VStack } from '@navikt/ds-react';
 
 import { useApp } from '../../../../../context/AppContext';
 import { useSteg } from '../../../../../context/StegContext';
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { UlagretKomponent } from '../../../../../hooks/useUlagredeKomponenter';
+import { Feilmelding } from '../../../../../komponenter/Feil/Feilmelding';
+import {
+    Feil,
+    feiletRessursTilFeilmelding,
+} from '../../../../../komponenter/Feil/feilmeldingUtils';
 import { VedtaksperiodeTilsynBarn } from '../../../../../typer/vedtak/vedtakTilsynBarn';
 import { tomVedtaksperiode } from '../VedtakBarnetilsynUtils';
 import { VedtaksperiodeRad } from './VedtaksperiodeRad';
@@ -35,8 +40,8 @@ interface Props {
     settVedtaksperioderFeil: React.Dispatch<
         React.SetStateAction<FormErrors<VedtaksperiodeTilsynBarn>[] | undefined>
     >;
-    foreslåPeriodeFeil?: string;
-    settForeslåPeriodeFeil: React.Dispatch<string | undefined>;
+    foreslåPeriodeFeil?: Feil;
+    settForeslåPeriodeFeil: React.Dispatch<Feil | undefined>;
 }
 
 export const Vedtaksperioder: React.FC<Props> = ({
@@ -103,7 +108,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                 settVedtaksperioder(perioder);
                 settForeslåPeriodeFeil(undefined);
             } else {
-                settForeslåPeriodeFeil(res.frontendFeilmelding);
+                settForeslåPeriodeFeil(feiletRessursTilFeilmelding(res));
             }
         });
     };
@@ -158,11 +163,7 @@ export const Vedtaksperioder: React.FC<Props> = ({
                             Foreslå vedtaksperioder
                         </Button>
                     </HStack>
-                    {foreslåPeriodeFeil && (
-                        <Alert variant="error" title="Klarte ikke å preutfylle periode">
-                            {foreslåPeriodeFeil}
-                        </Alert>
-                    )}
+                    <Feilmelding feil={foreslåPeriodeFeil} />
                 </>
             )}
         </VStack>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tar i bruk den nye `Feilmelding` komponenten for å vise frem feilmelding. Da får den warning i stedet for error og kopieringsknappen

Etter: 
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/db63930b-8c31-4b1e-96fc-b1c8417b52bb" />

Før: 
<img width="1092" alt="image" src="https://github.com/user-attachments/assets/3b84be81-e03a-4ad5-a7ed-fc71edc0789d" />
