### PR TITLE
✨ Legg til mulighet til å registere faste utgifter for boutgifter

### DIFF
--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Boutgifter/FasteUtgifter.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Boutgifter/FasteUtgifter.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+
+import { useVilkår } from '../../../../context/VilkårContext';
+import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
+import { Regler } from '../../../../typer/regel';
+import { StønadsvilkårType } from '../../vilkår';
+import { NyttVilkår } from '../../Vilkårvurdering/NyttVilkår';
+import { lagTomtDelvilkårsett, tomVurdering } from '../../Vilkårvurdering/utils';
+import { VisEllerEndreVilkår } from '../../Vilkårvurdering/VisEllerEndreVilkår';
+
+interface Props {
+    vilkårsregler: Regler;
+}
+
+const FasteUtgifter: React.FC<Props> = ({ vilkårsregler }) => {
+    const { vilkårsvurdering } = useVilkår();
+    const vilkårsett = vilkårsvurdering.vilkårsett.filter(
+        (v) => v.vilkårType === StønadsvilkårType.FASTE_UTGIFTER
+    );
+
+    return (
+        <VilkårPanel
+            tittel={'Faste utgifter'}
+            paragraflenker={[]}
+            rundskrivlenke={[]}
+            forskriftlenker={[]}
+        >
+            {vilkårsett.map((vilkår) => (
+                <VisEllerEndreVilkår key={vilkår.id} regler={vilkårsregler} vilkår={vilkår} />
+            ))}
+            <NyttVilkår
+                vilkårtype={StønadsvilkårType.FASTE_UTGIFTER}
+                vilkårsregler={vilkårsregler}
+                lagTomtDelvilkårsett={() =>
+                    lagTomtDelvilkårsett(vilkårsregler, (regelId) => tomVurdering(regelId))
+                }
+            />
+        </VilkårPanel>
+    );
+};
+
+export default FasteUtgifter;

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -4,6 +4,7 @@ import { styled } from 'styled-components';
 
 import { VStack } from '@navikt/ds-react';
 
+import FasteUtgifter from './Boutgifter/FasteUtgifter';
 import PassBarn from './PassBarn/PassBarn';
 import { VarselBarnUnder2År } from './PassBarn/VarselBarnUnder2år';
 import { useBehandling } from '../../../context/BehandlingContext';
@@ -17,16 +18,16 @@ import { Steg } from '../../../typer/behandling/steg';
 import { FanePath } from '../faner';
 import { VarselRevurderFraDatoMangler } from '../Felles/VarselRevurderFraDatoMangler';
 import { OppsummeringVilkårperioder } from '../OppsummeringVilkår/OppsummeringVilkårperioder';
-import { StønadsvilkårType, Vilkårtype } from '../vilkår';
 import MidlertidigOvernatting from './Boutgifter/MidlertidigOvernatting';
+import { Stønadstype } from '../../../typer/behandling/behandlingTema';
 
 const Container = styled(VStack).attrs({ gap: '8' })`
     margin: 2rem;
 `;
 
 const Stønadsvilkår: React.FC<{
-    vilkårtype: Vilkårtype;
-}> = ({ vilkårtype }) => {
+    stønadstype: Stønadstype;
+}> = ({ stønadstype }) => {
     const { behandling } = useBehandling();
     const { regler, hentRegler } = useRegler();
     const { vilkårsoppsummering } = useVilkårsoppsummering(behandling.id);
@@ -53,7 +54,7 @@ const Stønadsvilkår: React.FC<{
             >
                 {({ regler, vilkårsvurdering, vilkårsoppsummering }) => (
                     <VilkårProvider hentetVilkårsvurdering={vilkårsvurdering}>
-                        {vilkårtype === StønadsvilkårType.PASS_BARN && (
+                        {stønadstype === Stønadstype.BARNETILSYN && (
                             <>
                                 {vilkårsoppsummering.visVarselKontantstøtte && (
                                     <VarselBarnUnder2År />
@@ -61,10 +62,17 @@ const Stønadsvilkår: React.FC<{
                                 <PassBarn vilkårsregler={regler.vilkårsregler.PASS_BARN.regler} />
                             </>
                         )}
-                        {vilkårtype === StønadsvilkårType.MIDLERTIDIG_OVERNATTING && (
-                            <MidlertidigOvernatting
-                                vilkårsregler={regler.vilkårsregler.MIDLERTIDIG_OVERNATTING.regler}
-                            />
+                        {stønadstype === Stønadstype.BOUTGIFTER && (
+                            <>
+                                <MidlertidigOvernatting
+                                    vilkårsregler={
+                                        regler.vilkårsregler.MIDLERTIDIG_OVERNATTING.regler
+                                    }
+                                />
+                                <FasteUtgifter
+                                    vilkårsregler={regler.vilkårsregler.FASTE_UTGIFTER.regler}
+                                />
+                            </>
                         )}
                     </VilkårProvider>
                 )}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -29,6 +29,7 @@ export const regelIdTilSpørsmål: Record<RegelId, string> = {
     UNNTAK_ALDER:
         'Har barnet behov for pass utover 4. skoleår, og er behovet tilfredsstillende dokumentert?',
     NØDVENDIGE_MERUTGIFTER: 'Har søker nødvendige merutgifter til bolig eller overnatting?',
+    RETT_TIL_BOSTØTTE: 'Har søker rett til bostøtte?',
 };
 
 export const regelIdTilSpørsmålKortversjon: Record<RegelId, string> = {
@@ -37,6 +38,7 @@ export const regelIdTilSpørsmålKortversjon: Record<RegelId, string> = {
     HAR_FULLFØRT_FJERDEKLASSE: 'Ferdig med 4. skoleår?',
     NØDVENDIGE_MERUTGIFTER: 'Har nødvendige merutgifter?',
     UNNTAK_ALDER: 'Unntak fra aldersregelen?',
+    RETT_TIL_BOSTØTTE: 'Har søker rett til bostøtte?',
 };
 
 export const hjelpetekster: Record<RegelId, string[]> = {

--- a/src/frontend/Sider/Behandling/faner.tsx
+++ b/src/frontend/Sider/Behandling/faner.tsx
@@ -17,7 +17,6 @@ import Stønadsvilkår from './Stønadsvilkår/Stønadsvilkår';
 import VedtakOgBeregningBarnetilsyn from './VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn';
 import { VedtakOgBeregningBoutgifter } from './VedtakOgBeregning/Boutgifter/VedtakOgBeregningBoutgifter';
 import VedtakOgBeregningLæremidler from './VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler';
-import { StønadsvilkårType } from './vilkår';
 import { Behandling } from '../../typer/behandling/behandling';
 import { BehandlingResultat } from '../../typer/behandling/behandlingResultat';
 import { Stønadstype, stønadstypeTilTekst } from '../../typer/behandling/behandlingTema';
@@ -160,7 +159,7 @@ const stønadsvilkårFane = (behandling: Behandling): FanerMedRouter[] => {
                 {
                     navn: faneNavnStønadsvilkår[behandling.stønadstype],
                     path: FanePath.STØNADSVILKÅR,
-                    komponent: () => <Stønadsvilkår vilkårtype={StønadsvilkårType.PASS_BARN} />,
+                    komponent: () => <Stønadsvilkår stønadstype={Stønadstype.BARNETILSYN} />,
                     ikon: <HouseHeartIcon />,
                 },
             ];
@@ -169,9 +168,7 @@ const stønadsvilkårFane = (behandling: Behandling): FanerMedRouter[] => {
                 {
                     navn: faneNavnStønadsvilkår[behandling.stønadstype],
                     path: FanePath.STØNADSVILKÅR,
-                    komponent: () => (
-                        <Stønadsvilkår vilkårtype={StønadsvilkårType.MIDLERTIDIG_OVERNATTING} />
-                    ),
+                    komponent: () => <Stønadsvilkår stønadstype={Stønadstype.BOUTGIFTER} />,
                     ikon: <HouseHeartIcon />,
                 },
             ];

--- a/src/frontend/Sider/Behandling/vilkår.ts
+++ b/src/frontend/Sider/Behandling/vilkår.ts
@@ -23,6 +23,7 @@ export enum Inngangsvilkårtype {
 
 export enum StønadsvilkårType {
     MIDLERTIDIG_OVERNATTING = 'MIDLERTIDIG_OVERNATTING',
+    FASTE_UTGIFTER = 'FASTE_UTGIFTER',
     PASS_BARN = 'PASS_BARN',
 }
 

--- a/src/frontend/typer/regel.ts
+++ b/src/frontend/typer/regel.ts
@@ -15,7 +15,7 @@ export type ReglerPassBarn =
     | 'HAR_FULLFØRT_FJERDEKLASSE'
     | 'UNNTAK_ALDER';
 
-export type ReglerBoutgifter = 'NØDVENDIGE_MERUTGIFTER';
+export type ReglerBoutgifter = 'NØDVENDIGE_MERUTGIFTER' | 'RETT_TIL_BOSTØTTE';
 
 export type SluttNode = 'SLUTT_NODE';
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Trenger å kunne registere faste utgifter for boutgifter. 

Ser det er litt endringer og design som fortsatt pågår, så kan være vi må oppdatere dette senere. Målet nå er å samle inn inputen vi trenger til beregning. 

<img width="1180" alt="image" src="https://github.com/user-attachments/assets/cd522b12-6f34-4fb9-9488-7f22f49ed1d1" />
