### PR TITLE
🦺 Valider at utgift finnes på vilkår

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -207,6 +207,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
             props.regler,
             fom,
             tom,
+            utgift,
+            erNullvedtak,
             behandling.revurderFra
         );
 
@@ -333,9 +335,11 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                     erLesevisning={false}
                     value={harTallverdi(utgift) ? utgift : ''}
                     readOnly={!props.alleFelterKanRedigeres || erNullvedtak}
+                    error={feilmeldinger.utgift}
                     onChange={(e) => {
                         settDetFinnesUlagredeEndringer(true);
                         settUtgift(tilHeltall(fjernSpaces(e.target.value)));
+                        settFeilmeldinger((prevState) => ({ ...prevState, utgift: undefined }));
                     }}
                 />
             </FeilmeldingMaksBredde>

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
@@ -7,6 +7,7 @@ export type Feilmeldinger = {
     delvilkårsvurderinger: Record<RegelId, string | undefined>;
     fom?: string;
     tom?: string;
+    utgift?: string;
 };
 
 export const ingenFeil = { delvilkårsvurderinger: {} };
@@ -21,6 +22,8 @@ export const validerVilkårsvurderinger = (
     regler: Regler,
     fom?: string,
     tom?: string,
+    utgift?: number,
+    erNullvedtak?: boolean,
     revurderesFraDato?: string
 ): Feilmeldinger => {
     const valideringsfeil: Feilmeldinger = { delvilkårsvurderinger: {} };
@@ -35,6 +38,10 @@ export const validerVilkårsvurderinger = (
             ...valideringsfeil,
             ...periodeValidering,
         };
+    }
+
+    if (!erNullvedtak && utgift == null) {
+        return { ...valideringsfeil, utgift: 'Mangler utgift' };
     }
 
     delvilkårsett


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gir bruker raskere tilbakemelding på at data mangler. Feilmeldingen kommer også i forbindelse med feltet der feilen er gjort fremfor at det kommer i en generisk feilmelding i bunn av vilkår-kortet.

<img width="1041" alt="image" src="https://github.com/user-attachments/assets/14900939-a1de-4e44-9345-0c01bb4e7cd5" />
