### PR TITLE
Tekster for utgift

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -40,7 +40,6 @@ import {
     RedigerbareVilkårfelter,
     StønadsvilkårType,
     Vilkår,
-    Vilkårtype,
     Vurdering,
 } from '../vilkår';
 
@@ -86,7 +85,7 @@ type EndreVilkårProps = {
     ) => Promise<RessursSuksess<Vilkår> | RessursFeilet>;
     slettVilkår: undefined | (() => void);
     alleFelterKanRedigeres: boolean;
-    vilkårtype: Vilkårtype;
+    vilkårtype: StønadsvilkårType;
 };
 
 export const EndreVilkår: FC<EndreVilkårProps> = (props) => {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -42,6 +42,7 @@ import {
     Vilkår,
     Vurdering,
 } from '../vilkår';
+import { vilkårTypeTilUtgiftTekst } from './tekster';
 
 const DelvilkårContainer = styled.div<{ $erUndervilkår: boolean }>`
     border-left: ${({ $erUndervilkår }) =>
@@ -327,7 +328,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
             </FeilmeldingMaksBredde>
             <FeilmeldingMaksBredde $maxWidth={180}>
                 <TextField
-                    label={erMidlertidigOvernatting ? 'Utgift' : 'Månedlig utgift'}
+                    label={vilkårTypeTilUtgiftTekst[props.vilkårtype]}
                     size="small"
                     erLesevisning={false}
                     value={harTallverdi(utgift) ? utgift : ''}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
@@ -8,10 +8,10 @@ import { useSteg } from '../../../context/StegContext';
 import { useVilkår } from '../../../context/VilkårContext';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
 import { Regler } from '../../../typer/regel';
-import { Delvilkår, RedigerbareVilkårfelter, Vilkårtype } from '../vilkår';
+import { Delvilkår, RedigerbareVilkårfelter, StønadsvilkårType } from '../vilkår';
 
 export const NyttVilkår: React.FC<{
-    vilkårtype: Vilkårtype;
+    vilkårtype: StønadsvilkårType;
     vilkårsregler: Regler;
     barnId?: string;
     lagTomtDelvilkårsett: () => Delvilkår[];

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -1,4 +1,5 @@
 import { RegelId } from '../../../typer/regel';
+import { StønadsvilkårType } from '../vilkår';
 
 export const svarIdTilTekst: Record<string, string> = {
     JA: 'Ja',
@@ -57,4 +58,11 @@ export const hjelpetekster: Record<RegelId, string[]> = {
         'Faktura fra barnehage må i tillegg inneholde eventuelle kostnader til bleier, så det er mulig å trekke dette fra.',
         'Ved privat pass så skal det vurderes om det er sannsynlig at søker har hatt utgifter til barnepass i perioden det søkes for. Avtale mellom barnepasser og søker eller A-melding kan være eksempler på dokumentasjon som godtas. Skjermbilde av betalinger via vipps eller bankutskrift godkjennes ikke. ',
     ],
+};
+
+export const vilkårTypeTilUtgiftTekst: Record<StønadsvilkårType, string> = {
+    PASS_BARN: 'Månedlig utgift',
+    MIDLERTIDIG_OVERNATTING: 'Utgift',
+    FASTE_UTGIFTER_EN_BOLIG: 'Merutgifter per måned',
+    FASTE_UTGIFTER_TO_BOLIGER: 'Merutgifter per måned',
 };

--- a/src/frontend/Sider/Behandling/vilkår.ts
+++ b/src/frontend/Sider/Behandling/vilkår.ts
@@ -39,7 +39,7 @@ export interface Vilkår {
     behandlingId: string;
     resultat: Vilkårsresultat;
     status: PeriodeStatus;
-    vilkårType: Vilkårtype;
+    vilkårType: StønadsvilkårType;
     barnId?: string;
     endretAv: string;
     endretTid: string;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker ulike tekster for "utgift" for de ulike vilkårene. For faste boutgifter er det viktig å presisere at det er merutgifter. 

Pass barn:
<img width="1155" alt="image" src="https://github.com/user-attachments/assets/69f83e55-cb6e-4d42-9134-b1337d2de01f" />

Midlertidig utgift:
<img width="1166" alt="image" src="https://github.com/user-attachments/assets/f33c8d78-d6e0-4965-88dc-b4f17bfa15ce" />

Fate utgifter:
<img width="1176" alt="image" src="https://github.com/user-attachments/assets/6bc3fa03-3e1d-4022-90fb-6dd9d3e937f4" />
