### PR TITLE
Sykepenger vurdering

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Delvilkår/FaktaOgDelvilkårVisning.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Delvilkår/FaktaOgDelvilkårVisning.tsx
@@ -6,6 +6,7 @@ import { MålgruppeVurderinger } from '../../typer/vilkårperiode/målgruppe';
 import {
     dekketAvAnnetRegelverkSvarTilTekst,
     medlemskapSvarTilTekst,
+    mottarSykepengerForFulltidsstillingSvarTilTekst,
 } from '../../Vilkårperioder/VilkårperiodeKort/tekstmapping';
 
 const FaktaOgDelvilkårVisning: React.FC<{
@@ -21,6 +22,15 @@ const FaktaOgDelvilkårVisning: React.FC<{
                     {
                         dekketAvAnnetRegelverkSvarTilTekst[
                             vurderinger.utgifterDekketAvAnnetRegelverk.svar
+                        ]
+                    }
+                </Detail>
+            )}
+            {vurderinger.mottarSykepengerForFulltidsstilling?.svar && (
+                <Detail>
+                    {
+                        mottarSykepengerForFulltidsstillingSvarTilTekst[
+                            vurderinger.mottarSykepengerForFulltidsstilling.svar
                         ]
                     }
                 </Detail>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Delvilkår/FaktaOgDelvilkårVisning.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Delvilkår/FaktaOgDelvilkårVisning.tsx
@@ -26,15 +26,16 @@ const FaktaOgDelvilkårVisning: React.FC<{
                     }
                 </Detail>
             )}
-            {vurderinger.mottarSykepengerForFulltidsstilling?.svar && (
-                <Detail>
-                    {
-                        mottarSykepengerForFulltidsstillingSvarTilTekst[
-                            vurderinger.mottarSykepengerForFulltidsstilling.svar
-                        ]
-                    }
-                </Detail>
-            )}
+            {vurderinger.mottarSykepengerForFulltidsstilling?.svar &&
+                vurderinger.mottarSykepengerForFulltidsstilling?.svar !== 'GAMMEL_MANGLER_DATA' && (
+                    <Detail>
+                        {
+                            mottarSykepengerForFulltidsstillingSvarTilTekst[
+                                vurderinger.mottarSykepengerForFulltidsstilling.svar
+                            ]
+                        }
+                    </Detail>
+                )}
         </VStack>
     );
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -58,12 +58,13 @@ const FeltContainer = styled.div`
 `;
 
 const initaliserForm = (
+    alleFelterKanEndres: boolean,
     eksisterendeMålgruppe?: Målgruppe,
     registrertYtelsePeriode?: PeriodeYtelseRegister
 ): EndreMålgruppeForm => {
     return eksisterendeMålgruppe === undefined
         ? nyMålgruppe(registrertYtelsePeriode)
-        : mapEksisterendeMålgruppe(eksisterendeMålgruppe);
+        : mapEksisterendeMålgruppe(eksisterendeMålgruppe, alleFelterKanEndres);
 };
 
 // TODO: Endre navn til EndreMålgruppe
@@ -75,9 +76,14 @@ const EndreMålgruppeRad: React.FC<{
     const { behandling, behandlingFakta } = useBehandling();
     const { oppdaterMålgruppe, leggTilMålgruppe, settStønadsperiodeFeil } = useInngangsvilkår();
     const { lagreVilkårperiode } = useLagreVilkårperiode();
+    const { alleFelterKanEndres, kanSlettePeriode } = useRevurderingAvPerioder({
+        periodeFom: målgruppe?.fom,
+        periodeTom: målgruppe?.tom,
+        nyRadLeggesTil: !målgruppe,
+    });
 
     const [form, settForm] = useState<EndreMålgruppeForm>(
-        initaliserForm(målgruppe, registerYtelsePeriode)
+        initaliserForm(alleFelterKanEndres, målgruppe, registerYtelsePeriode)
     );
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<Feil>();
@@ -153,12 +159,6 @@ const EndreMålgruppeRad: React.FC<{
         );
     };
 
-    const { alleFelterKanEndres, kanSlettePeriode } = useRevurderingAvPerioder({
-        periodeFom: målgruppe?.fom,
-        periodeTom: målgruppe?.tom,
-        nyRadLeggesTil: !målgruppe,
-    });
-
     const målgruppeTyperForStønadstype = (stønadstype: Stønadstype): SelectOption[] =>
         [Stønadstype.BARNETILSYN, Stønadstype.LÆREMIDLER, Stønadstype.BOUTGIFTER].includes(
             stønadstype
@@ -186,7 +186,7 @@ const EndreMålgruppeRad: React.FC<{
             <MålgruppeVilkår
                 målgruppeForm={form}
                 readOnly={!alleFelterKanEndres}
-                oppdaterVurderinger={(key: keyof SvarMålgruppe, nyttSvar: SvarJaNei) =>
+                oppdaterVurderinger={(key: keyof SvarMålgruppe, nyttSvar: SvarJaNei | undefined) =>
                     settForm((prevState) => ({
                         ...prevState,
                         vurderinger: { ...prevState.vurderinger, [key]: nyttSvar },

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppeRad.tsx
@@ -192,6 +192,7 @@ const EndreMålgruppeRad: React.FC<{
                         vurderinger: { ...prevState.vurderinger, [key]: nyttSvar },
                     }))
                 }
+                stønadstype={behandling.stønadstype}
             />
             {erMålgruppeSomStøttes && (
                 <Begrunnelse

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -11,6 +11,7 @@ import {
     skalVurdereDekkesAvAnnetRegelverk,
     skalVurdereMottarSykepengerForFulltidsstilling,
 } from './utils';
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { JaNeiVurdering } from '../../Vilkårvurdering/JaNeiVurdering';
 import { MålgruppeType, SvarMålgruppe } from '../typer/vilkårperiode/målgruppe';
 import { SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
@@ -26,13 +27,15 @@ const MålgruppeVilkår: React.FC<{
     målgruppeForm: EndreMålgruppeForm;
     oppdaterVurderinger: (key: keyof SvarMålgruppe, nyttSvar: SvarJaNei) => void;
     readOnly: boolean;
-}> = ({ målgruppeForm, oppdaterVurderinger, readOnly }) => {
+    stønadstype: Stønadstype;
+}> = ({ målgruppeForm, oppdaterVurderinger, readOnly, stønadstype }) => {
     if (målgruppeForm.type === '') return null;
 
     const skalVurdereMedlemskap = målgrupperHvorMedlemskapMåVurderes.includes(målgruppeForm.type);
     const skalVurdereDekketAvAnnetRegelverk = skalVurdereDekkesAvAnnetRegelverk(målgruppeForm.type);
     const skalVurdereSykepengerForFulltidsstilling = skalVurdereMottarSykepengerForFulltidsstilling(
-        målgruppeForm.type
+        målgruppeForm.type,
+        stønadstype
     );
 
     const erGjenlevendeGammeltRegelverk =

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/MålgruppeVilkår.tsx
@@ -6,7 +6,11 @@ import { Alert, BodyLong, Heading } from '@navikt/ds-react';
 
 import { EndreMålgruppeForm } from './EndreMålgruppeRad';
 import { målgruppeTilMedlemskapHjelpetekst } from './hjelpetekstVurdereMålgruppe';
-import { målgrupperHvorMedlemskapMåVurderes, skalVurdereDekkesAvAnnetRegelverk } from './utils';
+import {
+    målgrupperHvorMedlemskapMåVurderes,
+    skalVurdereDekkesAvAnnetRegelverk,
+    skalVurdereMottarSykepengerForFulltidsstilling,
+} from './utils';
 import { JaNeiVurdering } from '../../Vilkårvurdering/JaNeiVurdering';
 import { MålgruppeType, SvarMålgruppe } from '../typer/vilkårperiode/målgruppe';
 import { SvarJaNei } from '../typer/vilkårperiode/vilkårperiode';
@@ -27,6 +31,10 @@ const MålgruppeVilkår: React.FC<{
 
     const skalVurdereMedlemskap = målgrupperHvorMedlemskapMåVurderes.includes(målgruppeForm.type);
     const skalVurdereDekketAvAnnetRegelverk = skalVurdereDekkesAvAnnetRegelverk(målgruppeForm.type);
+    const skalVurdereSykepengerForFulltidsstilling = skalVurdereMottarSykepengerForFulltidsstilling(
+        målgruppeForm.type
+    );
+
     const erGjenlevendeGammeltRegelverk =
         målgruppeForm.type === MålgruppeType.GJENLEVENDE_GAMMELT_REGELVERK;
 
@@ -59,6 +67,17 @@ const MålgruppeVilkår: React.FC<{
                     oppdaterSvar={(nyttSvar: SvarJaNei) =>
                         oppdaterVurderinger('svarUtgifterDekketAvAnnetRegelverk', nyttSvar)
                     }
+                />
+            )}
+            {skalVurdereSykepengerForFulltidsstilling && (
+                <JaNeiVurdering
+                    label="Mottar søker sykepenger for fulltidsstilling?"
+                    readOnly={readOnly}
+                    svar={målgruppeForm.vurderinger.svarMottarSykepengerForFulltidsstilling}
+                    oppdaterSvar={(nyttSvar: SvarJaNei) =>
+                        oppdaterVurderinger('svarMottarSykepengerForFulltidsstilling', nyttSvar)
+                    }
+                    hjelpetekst="Med fulltidsstilling menes at søker jobber 37,5 timer eller mer i uken."
                 />
             )}
             {erGjenlevendeGammeltRegelverk && (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -36,16 +36,30 @@ export const nyMålgruppe = (
         : tomMålgruppeForm();
 };
 
-export const mapEksisterendeMålgruppe = (eksisterendeMålgruppe: Målgruppe): EndreMålgruppeForm => ({
+export const mapEksisterendeMålgruppe = (
+    eksisterendeMålgruppe: Målgruppe,
+    alleFelterKanEndres: boolean
+): EndreMålgruppeForm => ({
     ...eksisterendeMålgruppe,
     vurderinger: {
         svarMedlemskap: eksisterendeMålgruppe.faktaOgVurderinger.medlemskap?.svar,
         svarUtgifterDekketAvAnnetRegelverk:
             eksisterendeMålgruppe.faktaOgVurderinger.utgifterDekketAvAnnetRegelverk?.svar,
-        svarMottarSykepengerForFulltidsstilling:
+        svarMottarSykepengerForFulltidsstilling: nullstillGammelManglerData(
             eksisterendeMålgruppe.faktaOgVurderinger.mottarSykepengerForFulltidsstilling?.svar,
+            alleFelterKanEndres
+        ),
     },
 });
+
+const nullstillGammelManglerData = (
+    svar: SvarJaNei | undefined | 'GAMMEL_MANGLER_DATA',
+    kanRedidereAlleFelter: boolean
+): SvarJaNei | 'GAMMEL_MANGLER_DATA' | undefined => {
+    if (svar === 'GAMMEL_MANGLER_DATA' && kanRedidereAlleFelter) return undefined;
+
+    return svar;
+};
 
 const nyMålgruppeFraRegister = (
     registrertYtelsePeriode: YtelseGrunnlagPeriode

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -87,8 +87,10 @@ export const målgruppeErNedsattArbeidsevne = (målgruppeType: MålgruppeType) =
 export const skalVurdereDekkesAvAnnetRegelverk = (type: MålgruppeType) =>
     målgruppeErNedsattArbeidsevne(type);
 
-export const skalVurdereMottarSykepengerForFulltidsstilling = (type: MålgruppeType) =>
-    målgruppeErNedsattArbeidsevne(type);
+export const skalVurdereMottarSykepengerForFulltidsstilling = (
+    type: MålgruppeType,
+    stønadstype: Stønadstype
+) => stønadstype !== Stønadstype.LÆREMIDLER && type === MålgruppeType.NEDSATT_ARBEIDSEVNE;
 
 export const resettMålgruppe = (
     stønadstype: Stønadstype,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -42,6 +42,8 @@ export const mapEksisterendeMålgruppe = (eksisterendeMålgruppe: Målgruppe): E
         svarMedlemskap: eksisterendeMålgruppe.faktaOgVurderinger.medlemskap?.svar,
         svarUtgifterDekketAvAnnetRegelverk:
             eksisterendeMålgruppe.faktaOgVurderinger.utgifterDekketAvAnnetRegelverk?.svar,
+        svarMottarSykepengerForFulltidsstilling:
+            eksisterendeMålgruppe.faktaOgVurderinger.mottarSykepengerForFulltidsstilling?.svar,
     },
 });
 
@@ -66,9 +68,10 @@ const tomMålgruppeForm = (): EndreMålgruppeForm => {
     };
 };
 
-const tomVurderingerMålgruppe = {
+const tomVurderingerMålgruppe: SvarMålgruppe = {
     svarMedlemskap: undefined,
     svarUtgifterDekketAvAnnetRegelverk: undefined,
+    svarMottarSykepengerForFulltidsstilling: undefined,
 };
 
 export const målgrupperHvorMedlemskapMåVurderes = [
@@ -82,6 +85,9 @@ export const målgruppeErNedsattArbeidsevne = (målgruppeType: MålgruppeType) =
 };
 
 export const skalVurdereDekkesAvAnnetRegelverk = (type: MålgruppeType) =>
+    målgruppeErNedsattArbeidsevne(type);
+
+export const skalVurdereMottarSykepengerForFulltidsstilling = (type: MålgruppeType) =>
     målgruppeErNedsattArbeidsevne(type);
 
 export const resettMålgruppe = (
@@ -185,6 +191,8 @@ export const mapFaktaOgSvarTilRequest = (
     svarMedlemskap: målgruppeForm.vurderinger.svarMedlemskap,
     svarUtgifterDekketAvAnnetRegelverk:
         målgruppeForm.vurderinger.svarUtgifterDekketAvAnnetRegelverk,
+    svarMottarSykepengerForFulltidsstilling:
+        målgruppeForm.vurderinger.svarMottarSykepengerForFulltidsstilling,
 });
 
 export const utledYtelseTekst = (periode: YtelseGrunnlagPeriode): string => {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -52,6 +52,11 @@ export const mapEksisterendeMålgruppe = (
     },
 });
 
+/**
+ * GAMMEL_MANGLER_DATA er kun et gyldig svar dersom alle felter utenom tom er låst.
+ * Dersom alle felter (fakta og vurderinger) kan redigeres,
+ * skal svar settes til undefined slik at saksbehandler må ta stilling til vilkåret.
+ */
 const nullstillGammelManglerData = (
     svar: SvarJaNei | undefined | 'GAMMEL_MANGLER_DATA',
     kanRedidereAlleFelter: boolean

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
@@ -14,6 +14,15 @@ export const dekketAvAnnetRegelverkSvarTilTekst: Record<SvarJaNei, string | unde
     [SvarJaNei.JA_IMPLISITT]: undefined,
 };
 
+export const mottarSykepengerForFulltidsstillingSvarTilTekst: Record<
+    SvarJaNei,
+    string | undefined
+> = {
+    [SvarJaNei.JA]: 'Mottar 100% sykepenger for fulltidsstilling',
+    [SvarJaNei.NEI]: 'Mottar ikke 100% sykepenger for fulltidsstilling',
+    [SvarJaNei.JA_IMPLISITT]: undefined,
+};
+
 export const lønnetSvarTilTekst: Record<SvarJaNei, string | undefined> = {
     [SvarJaNei.JA]: 'Lønnet',
     [SvarJaNei.NEI]: 'Ikke lønnet',
@@ -54,6 +63,7 @@ export const delvilkårKeyTilTekst: Record<DelvilkårKey, string> = {
     utgifterDekketAvAnnetRegelverk: 'utgifter dekket gjennom annet regelverk',
     harUtgifter: 'har utgifter til læremidler',
     harRettTilUtstyrsstipend: 'har rett til utstyrsstipend',
+    mottarSykepengerForFulltidsstilling: 'mottar 100% sykepenger for fulltidsstilling',
 };
 
 export const formaterDelvilkårKeys = (delvilkårKeys: DelvilkårKey[]) =>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping.ts
@@ -2,16 +2,18 @@ import { DelvilkårKey } from './utils';
 import { Vilkårsresultat } from '../../../vilkår';
 import { SvarJaNei, VilkårPeriodeResultat } from '../../typer/vilkårperiode/vilkårperiode';
 
-export const medlemskapSvarTilTekst: Record<SvarJaNei, string> = {
+export const medlemskapSvarTilTekst: Record<SvarJaNei, string | undefined> = {
     [SvarJaNei.JA]: 'Medlemskap i folketrygden',
     [SvarJaNei.JA_IMPLISITT]: 'Medlemskap i folketrygden',
     [SvarJaNei.NEI]: 'Ikke medlemskap i folketrygden',
+    [SvarJaNei.NEI_IMPLISITT]: undefined,
 };
 
 export const dekketAvAnnetRegelverkSvarTilTekst: Record<SvarJaNei, string | undefined> = {
     [SvarJaNei.JA]: 'Utgifter dekkes av annet regelverk',
     [SvarJaNei.NEI]: 'Utgifter dekkes ikke av annet regelverk',
     [SvarJaNei.JA_IMPLISITT]: undefined,
+    [SvarJaNei.NEI_IMPLISITT]: undefined,
 };
 
 export const mottarSykepengerForFulltidsstillingSvarTilTekst: Record<
@@ -21,24 +23,28 @@ export const mottarSykepengerForFulltidsstillingSvarTilTekst: Record<
     [SvarJaNei.JA]: 'Mottar 100% sykepenger for fulltidsstilling',
     [SvarJaNei.NEI]: 'Mottar ikke 100% sykepenger for fulltidsstilling',
     [SvarJaNei.JA_IMPLISITT]: undefined,
+    [SvarJaNei.NEI_IMPLISITT]: 'Mottar ikke 100% sykepenger for fulltidsstilling',
 };
 
 export const lønnetSvarTilTekst: Record<SvarJaNei, string | undefined> = {
     [SvarJaNei.JA]: 'Lønnet',
     [SvarJaNei.NEI]: 'Ikke lønnet',
     [SvarJaNei.JA_IMPLISITT]: undefined,
+    [SvarJaNei.NEI_IMPLISITT]: undefined,
 };
 
 export const harUtgifterSvarTilTekst: Record<SvarJaNei, string | undefined> = {
     [SvarJaNei.JA]: 'Har utgifter',
     [SvarJaNei.NEI]: 'Har ikke utgifter',
     [SvarJaNei.JA_IMPLISITT]: undefined,
+    [SvarJaNei.NEI_IMPLISITT]: undefined,
 };
 
 export const harRettTilUtstyrsstipendSvarTilTekst: Record<SvarJaNei, string | undefined> = {
     [SvarJaNei.JA]: 'Har rett til utstyrsstipend',
     [SvarJaNei.NEI]: 'Har ikke rett til utsstyrsstipend',
     [SvarJaNei.JA_IMPLISITT]: undefined,
+    [SvarJaNei.NEI_IMPLISITT]: undefined,
 };
 
 export const VilkårperiodeResultatTilTekst: Record<VilkårPeriodeResultat, string> = {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/utils.ts
@@ -7,7 +7,8 @@ export type DelvilkårKey =
     | 'utgifterDekketAvAnnetRegelverk'
     | 'lønnet'
     | 'harUtgifter'
-    | 'harRettTilUtstyrsstipend';
+    | 'harRettTilUtstyrsstipend'
+    | 'mottarSykepengerForFulltidsstilling';
 
 export const finnDelvilkårTilOppsummering = (
     faktaOgVurderinger: MålgruppeVurderinger | AktivitetFaktaOgVurderinger,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -130,7 +130,7 @@ export interface MålgruppeVurderinger {
 export interface SvarMålgruppe {
     svarMedlemskap: SvarJaNei | undefined;
     svarUtgifterDekketAvAnnetRegelverk: SvarJaNei | undefined;
-    svarMottarSykepengerForFulltidsstilling: SvarJaNei | undefined;
+    svarMottarSykepengerForFulltidsstilling: SvarJaNei | undefined | 'GAMMEL_MANGLER_DATA';
 }
 
 export interface MålgruppeFaktaOgSvar extends SvarMålgruppe {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -124,11 +124,13 @@ export const MålgruppeTypeTilFaktiskMålgruppe: Record<MålgruppeType, FaktiskM
 export interface MålgruppeVurderinger {
     medlemskap: Vurdering | undefined;
     utgifterDekketAvAnnetRegelverk: Vurdering | undefined;
+    mottarSykepengerForFulltidsstilling: Vurdering | undefined;
 }
 
 export interface SvarMålgruppe {
     svarMedlemskap: SvarJaNei | undefined;
     svarUtgifterDekketAvAnnetRegelverk: SvarJaNei | undefined;
+    svarMottarSykepengerForFulltidsstilling: SvarJaNei | undefined;
 }
 
 export interface MålgruppeFaktaOgSvar extends SvarMålgruppe {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -1,4 +1,9 @@
-import { SvarJaNei, VilkårPeriode, Vurdering } from './vilkårperiode';
+import {
+    SvarJaNei,
+    VilkårPeriode,
+    Vurdering,
+    VurderingMedGammelManglerData,
+} from './vilkårperiode';
 import { SelectOption } from '../../../../../komponenter/Skjema/SelectMedOptions';
 import { Stønadstype } from '../../../../../typer/behandling/behandlingTema';
 
@@ -124,7 +129,7 @@ export const MålgruppeTypeTilFaktiskMålgruppe: Record<MålgruppeType, FaktiskM
 export interface MålgruppeVurderinger {
     medlemskap: Vurdering | undefined;
     utgifterDekketAvAnnetRegelverk: Vurdering | undefined;
-    mottarSykepengerForFulltidsstilling: Vurdering | undefined;
+    mottarSykepengerForFulltidsstilling: VurderingMedGammelManglerData | undefined;
 }
 
 export interface SvarMålgruppe {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
@@ -86,12 +86,14 @@ export enum SvarJaNei {
     JA = 'JA',
     JA_IMPLISITT = 'JA_IMPLISITT',
     NEI = 'NEI',
+    NEI_IMPLISITT = 'NEI_IMPLISITT',
 }
 
 export const svarJaNeiMapping: Record<SvarJaNei, string> = {
     JA: 'Ja',
     JA_IMPLISITT: 'Ja',
     NEI: 'Nei',
+    NEI_IMPLISITT: 'Nei',
 };
 
 export interface Vurdering {

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
@@ -99,6 +99,11 @@ export interface Vurdering {
     resultat?: VilkårPeriodeResultat;
 }
 
+export interface VurderingMedGammelManglerData {
+    svar?: SvarJaNei | 'GAMMEL_MANGLER_DATA';
+    resultat?: VilkårPeriodeResultat;
+}
+
 export interface SlettVilkårperiode {
     behandlingId: string;
     kommentar: string;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/JaNeiVurdering.tsx
@@ -12,7 +12,7 @@ const LesMerTekst = styled(ReadMore)`
 
 export const JaNeiVurdering: React.FC<{
     label: string;
-    svar: SvarJaNei | undefined;
+    svar: SvarJaNei | undefined | 'GAMMEL_MANGLER_DATA';
     oppdaterSvar: (svar: SvarJaNei) => void;
     svarJa?: string;
     svarNei?: string;
@@ -29,6 +29,10 @@ export const JaNeiVurdering: React.FC<{
     hjelpetekstHeader,
     readOnly = false,
 }) => {
+    if (svar === 'GAMMEL_MANGLER_DATA' && readOnly) {
+        return null;
+    }
+
     return (
         <RadioGroup
             value={svar || ''}


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Man skal nå vurdere om bruker "mottar sykepenger for fulltidsstilling" på nedsatt arbeidsevne i stedet for å ha det som en egen målgruppe.

Om man redigerer en som GAMMEL_MANGLER_DATA må man fylle ut vilkåret for å få oppfylt videre:
<img width="1279" alt="image" src="https://github.com/user-attachments/assets/9a5d5f70-d86d-4a5e-a145-b64b60887e36" />

Vurdering av sykepenger eksisterer ikke fordi vilkåret er gjenbrukt. Får feilmelding om man prøver å forlenge fordi det revurderes midt i perioden:
<img width="1272" alt="image" src="https://github.com/user-attachments/assets/86dffa0c-ea89-435d-87d7-68b335af00cc" />

Oppsummering i venstrekolonne og på kort om at sykepenger er oppfylt eller ikke:
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/a43cdaf4-f432-446a-bad8-9294db6a83eb" />
<img width="1278" alt="image" src="https://github.com/user-attachments/assets/9ba71f68-5caf-4c78-bfc5-94b94f0265d6" />