### PR TITLE
Skal ikke kunne gjore et vilkårsvurdert vilkår til fremtidig utgift

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -87,6 +87,7 @@ type EndreVilkårProps = {
     slettVilkår: undefined | (() => void);
     alleFelterKanRedigeres: boolean;
     vilkårtype: StønadsvilkårType;
+    kanVæreFremtidigUtgift: boolean;
 };
 
 export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
@@ -340,7 +341,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
             </FeilmeldingMaksBredde>
             {/*VENTER PÅ AVKLARING PÅ HVORDAN OG OM VI SKAL STØTTE NULLVEDTAK*/}
             {tillaterErFremtidigUtgift &&
-                props.vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING && (
+                props.vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING &&
+                props.kanVæreFremtidigUtgift && (
                     <StyledSwitch
                         size={'small'}
                         checked={erFremtidigUtgift}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
@@ -55,6 +55,7 @@ export const NyttVilkår: React.FC<{
             alleFelterKanRedigeres={true}
             slettVilkår={undefined}
             vilkårtype={vilkårtype}
+            kanVæreFremtidigUtgift={true}
         />
     );
 };

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
@@ -6,6 +6,7 @@ import { useSteg } from '../../../context/StegContext';
 import { useVilkår } from '../../../context/VilkårContext';
 import { useRevurderingAvPerioder } from '../../../hooks/useRevurderingAvPerioder';
 import { Regler } from '../../../typer/regel';
+import { PeriodeStatus } from '../Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
 import { Vilkår, Vilkårsresultat } from '../vilkår';
 
 type LesEllerEndreDelvilkårProps = {
@@ -27,6 +28,10 @@ export const VisEllerEndreVilkår: FC<LesEllerEndreDelvilkårProps> = ({ regler,
         nyRadLeggesTil: false,
     });
 
+    const kanVæreFremtidigUtgift =
+        vilkår.status === PeriodeStatus.NY ||
+        vilkår.resultat === Vilkårsresultat.IKKE_TATT_STILLING_TIL;
+
     return erStegRedigerbart && !helePeriodenErLåstForEndring && redigerer ? (
         <EndreVilkår
             regler={regler}
@@ -47,13 +52,14 @@ export const VisEllerEndreVilkår: FC<LesEllerEndreDelvilkårProps> = ({ regler,
             avsluttRedigering={() => settRedigerer(false)}
             alleFelterKanRedigeres={alleFelterKanEndres}
             slettVilkår={
-                vilkår.opphavsvilkår
-                    ? undefined
-                    : () => {
+                vilkår.status === PeriodeStatus.NY
+                    ? () => {
                           slettVilkår(vilkår);
                       }
+                    : undefined
             }
             vilkårtype={vilkår.vilkårType}
+            kanVæreFremtidigUtgift={kanVæreFremtidigUtgift}
         />
     ) : (
         <LesevisningVilkår


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal ikke kunne gjøre et vilkårsvurdert vilkår til fremtidig utgift i en revurdering. Dette ville vært en rar endring. 

Bildet viser fremtidig utgift som kan bli til vanlig vilkår
<img width="1115" alt="image" src="https://github.com/user-attachments/assets/8cb9903b-36d9-44ad-8c6a-ec9e14ef767d" />

Bildet viser vilkårsvurdert vilkår der switch for å gjøre vilkåret om til fremtidig utgift er fjernet
<img width="1138" alt="image" src="https://github.com/user-attachments/assets/4ad03e0e-d0b5-435b-839a-aa56810e197c" />

