### PR TITLE
👔 Alltid vis slett-vilkår knappen hvis vilkår er fremtidig utgift

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
@@ -52,7 +52,7 @@ export const VisEllerEndreVilkår: FC<LesEllerEndreDelvilkårProps> = ({ regler,
             avsluttRedigering={() => settRedigerer(false)}
             alleFelterKanRedigeres={alleFelterKanEndres}
             slettVilkår={
-                vilkår.status === PeriodeStatus.NY
+                vilkår.status === PeriodeStatus.NY || vilkår.erFremtidigUtgift
                     ? () => {
                           slettVilkår(vilkår);
                       }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal alltid kunne slette vilkår som er fremtidig utgift. Dette trengs hvis en fremtidig utgift ikke taes i bruk.

⚠️ Lager PR mest for å vente på denne https://github.com/navikt/tilleggsstonader-sak/pull/698