### PR TITLE
♻️ Del EndreVilkår til flere mindre filer

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -56,7 +56,16 @@ type EndreVilkårProps = {
     kanVæreFremtidigUtgift: boolean;
 };
 
-export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
+export const EndreVilkår: FC<EndreVilkårProps> = ({
+    alleFelterKanRedigeres,
+    avsluttRedigering,
+    kanVæreFremtidigUtgift,
+    lagreVurdering,
+    redigerbareVilkårfelter,
+    regler,
+    slettVilkår,
+    vilkårtype,
+}) => {
     const { nullstillUlagretKomponent, settUlagretKomponent } = useApp();
     const { behandling } = useBehandling();
 
@@ -64,17 +73,17 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
     const [komponentId] = useId();
 
     const [delvilkårsett, settDelvilkårsett] = useState<Delvilkår[]>(
-        props.redigerbareVilkårfelter.delvilkårsett
+        redigerbareVilkårfelter.delvilkårsett
     );
 
     const [feilmeldinger, settFeilmeldinger] = useState<Feilmeldinger>(ingenFeil);
 
     const [endrePeriodeForVilkårForm, settEndrePeriodeForVilkårForm] =
         useState<EndrePeriodeForVilkårForm>({
-            fom: props.redigerbareVilkårfelter.fom,
-            tom: props.redigerbareVilkårfelter.tom,
-            utgift: props.redigerbareVilkårfelter.utgift,
-            erFremtidigUtgift: props.redigerbareVilkårfelter.erFremtidigUtgift,
+            fom: redigerbareVilkårfelter.fom,
+            tom: redigerbareVilkårfelter.tom,
+            utgift: redigerbareVilkårfelter.utgift,
+            erFremtidigUtgift: redigerbareVilkårfelter.erFremtidigUtgift,
         });
 
     const nullstillDelvilkårsett = () =>
@@ -119,8 +128,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
 
         const valideringsfeil = validerVilkårsvurderinger(
             delvilkårsett,
-            props.redigerbareVilkårfelter,
-            props.regler,
+            redigerbareVilkårfelter,
+            regler,
             fom,
             tom,
             behandling.revurderFra,
@@ -130,7 +139,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
         settFeilmeldinger(valideringsfeil);
 
         if (ingen(valideringsfeil)) {
-            const response = await props.lagreVurdering({
+            const response = await lagreVurdering({
                 delvilkårsett,
                 fom,
                 tom,
@@ -138,7 +147,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                 erFremtidigUtgift,
             });
             if (response.status === RessursStatus.SUKSESS) {
-                props.avsluttRedigering();
+                avsluttRedigering();
                 settFeilmeldingVedLagring(null);
             } else {
                 settFeilmeldingVedLagring(response.frontendFeilmelding);
@@ -146,16 +155,14 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
         }
     };
 
-    const slettVilkår = props.slettVilkår;
-
     return (
         <StyledForm onSubmit={validerOgLagreVilkårsvurderinger}>
             <FlexColumn $gap={1}>
                 <EndrePeriodeForVilkår
-                    alleFelterKanRedigeres={props.alleFelterKanRedigeres}
+                    alleFelterKanRedigeres={alleFelterKanRedigeres}
                     settDetFinnesUlagredeEndringer={settDetFinnesUlagredeEndringer}
-                    vilkårtype={props.vilkårtype}
-                    kanVæreFremtidigUtgift={props.kanVæreFremtidigUtgift}
+                    vilkårtype={vilkårtype}
+                    kanVæreFremtidigUtgift={kanVæreFremtidigUtgift}
                     endrePeriodeForVilkårFrom={endrePeriodeForVilkårForm}
                     oppdaterEndrePeriodeForVilkårForm={oppdaterendrePeriodeForVilkårForm}
                     feilmeldinger={feilmeldinger}
@@ -165,8 +172,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                 {!endrePeriodeForVilkårForm.erFremtidigUtgift && (
                     <EndreDelvilkår
                         delvilkårsett={delvilkårsett}
-                        regler={props.regler}
-                        alleFelterKanRedigeres={props.alleFelterKanRedigeres}
+                        regler={regler}
+                        alleFelterKanRedigeres={alleFelterKanRedigeres}
                         settDetFinnesUlagredeEndringer={settDetFinnesUlagredeEndringer}
                         feilmeldinger={feilmeldinger}
                         settFeilmeldinger={settFeilmeldinger}
@@ -176,7 +183,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = (props) => {
                 <VStack gap="4">
                     <Knapper>
                         <SmallButton>Lagre</SmallButton>
-                        <SmallButton variant="secondary" onClick={props.avsluttRedigering}>
+                        <SmallButton variant="secondary" onClick={avsluttRedigering}>
                             Avbryt
                         </SmallButton>
                         <div className={'right'}>

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår.tsx
@@ -25,6 +25,7 @@ import {
 } from '../vilkår';
 import EndrePeriodeForVilkår, {
     EndrePeriodeForVilkårForm,
+    TypePeriodeVelger,
 } from './EndreVilkår/EndrePeriodeForVilkår';
 
 const StyledForm = styled.form`
@@ -155,6 +156,13 @@ export const EndreVilkår: FC<EndreVilkårProps> = ({
         }
     };
 
+    const finnTypePeriodeVelger = () => {
+        if (vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING) {
+            return TypePeriodeVelger.DATO;
+        }
+        return TypePeriodeVelger.MANED_ÅR;
+    };
+
     return (
         <StyledForm onSubmit={validerOgLagreVilkårsvurderinger}>
             <FlexColumn $gap={1}>
@@ -167,6 +175,7 @@ export const EndreVilkår: FC<EndreVilkårProps> = ({
                     oppdaterEndrePeriodeForVilkårForm={oppdaterendrePeriodeForVilkårForm}
                     feilmeldinger={feilmeldinger}
                     settFeilmeldinger={settFeilmeldinger}
+                    typePeriodeVelger={finnTypePeriodeVelger()}
                 />
                 <Skillelinje />
                 {!endrePeriodeForVilkårForm.erFremtidigUtgift && (

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreDelvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreDelvilkår.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { ABorderAction } from '@navikt/ds-tokens/dist/tokens';
+
+import { Skillelinje } from '../../../../komponenter/Skillelinje';
+import { BegrunnelseRegel, Regler, Svaralternativ } from '../../../../typer/regel';
+import { Delvilkår, Vurdering } from '../../vilkår';
+import Begrunnelse from '../Begrunnelse';
+import DelvilkårRadioknapper from '../DelvilkårRadioknapper';
+import {
+    begrunnelseErPåkrevdOgUtfyllt,
+    hentSvaralternativ,
+    kanHaBegrunnelse,
+    kopierBegrunnelse,
+    leggTilNesteIdHvis,
+    oppdaterSvarIListe,
+} from '../utils';
+import { Feilmeldinger } from '../validering';
+
+const DelvilkårContainer = styled.div<{ $erUndervilkår: boolean }>`
+    border-left: ${({ $erUndervilkår }) =>
+        $erUndervilkår ? `5px solid ${ABorderAction}` : 'none'};
+    padding-left: ${({ $erUndervilkår }) => ($erUndervilkår ? '1rem' : '0')};
+    gap: ${({ $erUndervilkår }) => ($erUndervilkår ? `5rem` : `6rem`)};
+    display: flex;
+
+    @media (max-width: 900px) {
+        flex-direction: column;
+        gap: 1rem;
+    }
+`;
+
+const EndreDelvilkår: React.FC<{
+    delvilkårsett: Delvilkår[];
+    regler: Regler;
+    alleFelterKanRedigeres: boolean;
+    settDetFinnesUlagredeEndringer: (value: ((prevState: boolean) => boolean) | boolean) => void;
+    feilmeldinger: Feilmeldinger;
+    settFeilmeldinger: (
+        value: ((prevState: Feilmeldinger) => Feilmeldinger) | Feilmeldinger
+    ) => void;
+    settDelvilkårsett: (value: ((prevState: Delvilkår[]) => Delvilkår[]) | Delvilkår[]) => void;
+}> = ({
+    delvilkårsett,
+    regler,
+    alleFelterKanRedigeres,
+    settDetFinnesUlagredeEndringer,
+    feilmeldinger,
+    settFeilmeldinger,
+    settDelvilkårsett,
+}) => {
+    const oppdaterVilkårsvar = (index: number, nySvarArray: Vurdering[]) => {
+        settDelvilkårsett((prevSvar) => {
+            const prevDelvilkårsett = prevSvar[index];
+            return [
+                ...prevSvar.slice(0, index),
+                {
+                    ...prevDelvilkårsett,
+                    vurderinger: nySvarArray,
+                },
+                ...prevSvar.slice(index + 1),
+            ];
+        });
+    };
+
+    const oppdaterBegrunnelse = (
+        vurderinger: Vurdering[],
+        delvilkårIndex: number,
+        nyttSvar: Vurdering
+    ) => {
+        const { begrunnelse } = nyttSvar;
+        const svaralternativ: Svaralternativ | undefined = hentSvaralternativ(regler, nyttSvar);
+        if (!svaralternativ) {
+            return;
+        }
+
+        const oppdaterteSvar = oppdaterSvarIListe(nyttSvar, vurderinger, true);
+
+        const oppdaterteSvarMedNesteRegel = leggTilNesteIdHvis(
+            svaralternativ.regelId,
+            oppdaterteSvar,
+            () => begrunnelseErPåkrevdOgUtfyllt(svaralternativ, begrunnelse)
+        );
+        oppdaterVilkårsvar(delvilkårIndex, oppdaterteSvarMedNesteRegel);
+    };
+
+    const oppdaterSvar = (
+        vurderinger: Vurdering[],
+        delvilkårIndex: number,
+        nyttSvar: Vurdering
+    ) => {
+        const svaralternativer: Svaralternativ | undefined = hentSvaralternativ(regler, nyttSvar);
+
+        if (!svaralternativer) {
+            return;
+        }
+
+        const oppdaterteSvar = oppdaterSvarIListe(
+            nyttSvar,
+            vurderinger,
+            false,
+            kanHaBegrunnelse(svaralternativer)
+        );
+
+        const oppdaterteSvarMedNesteRegel = leggTilNesteIdHvis(
+            svaralternativer.regelId,
+            oppdaterteSvar,
+            () => svaralternativer.begrunnelseType !== BegrunnelseRegel.PÅKREVD
+        );
+
+        const oppdaterteSvarMedKopiertBegrunnelse = kopierBegrunnelse(
+            vurderinger,
+            oppdaterteSvarMedNesteRegel,
+            nyttSvar,
+            svaralternativer,
+            regler
+        );
+
+        oppdaterVilkårsvar(delvilkårIndex, oppdaterteSvarMedKopiertBegrunnelse);
+    };
+
+    const nullstillFeilmeldingForRegel = (regelId: string) => {
+        settFeilmeldinger({
+            ...feilmeldinger,
+            delvilkårsvurderinger: { ...feilmeldinger.delvilkårsvurderinger, [regelId]: undefined },
+        });
+    };
+
+    return delvilkårsett.map((delvikår, delvilkårIndex) => {
+        return delvikår.vurderinger.map((svar) => {
+            const gjeldendeRegel = regler[svar.regelId];
+            const erUndervilkår = !gjeldendeRegel.erHovedregel;
+            return (
+                <React.Fragment key={gjeldendeRegel.regelId}>
+                    {delvilkårIndex !== 0 && !erUndervilkår && <Skillelinje />}
+                    <DelvilkårContainer $erUndervilkår={erUndervilkår}>
+                        <DelvilkårRadioknapper
+                            vurdering={svar}
+                            regel={gjeldendeRegel}
+                            readOnly={!alleFelterKanRedigeres}
+                            settVurdering={(nyVurdering) => {
+                                settDetFinnesUlagredeEndringer(true);
+                                oppdaterSvar(delvikår.vurderinger, delvilkårIndex, nyVurdering);
+                            }}
+                            feilmelding={
+                                feilmeldinger.delvilkårsvurderinger[gjeldendeRegel.regelId]
+                            }
+                            nullstillFeilmelding={nullstillFeilmeldingForRegel}
+                        />
+                        <Begrunnelse
+                            oppdaterBegrunnelse={(begrunnelse) => {
+                                settDetFinnesUlagredeEndringer(true);
+                                oppdaterBegrunnelse(delvikår.vurderinger, delvilkårIndex, {
+                                    ...svar,
+                                    begrunnelse,
+                                });
+                            }}
+                            vurdering={svar}
+                            regel={gjeldendeRegel}
+                        />
+                    </DelvilkårContainer>
+                </React.Fragment>
+            );
+        });
+    });
+};
+
+export default EndreDelvilkår;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreDelvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreDelvilkår.tsx
@@ -32,7 +32,7 @@ const DelvilkårContainer = styled.div<{ $erUndervilkår: boolean }>`
     }
 `;
 
-const EndreDelvilkår: React.FC<{
+interface Props {
     delvilkårsett: Delvilkår[];
     regler: Regler;
     alleFelterKanRedigeres: boolean;
@@ -42,7 +42,9 @@ const EndreDelvilkår: React.FC<{
         value: ((prevState: Feilmeldinger) => Feilmeldinger) | Feilmeldinger
     ) => void;
     settDelvilkårsett: (value: ((prevState: Delvilkår[]) => Delvilkår[]) | Delvilkår[]) => void;
-}> = ({
+}
+
+const EndreDelvilkår: React.FC<Props> = ({
     delvilkårsett,
     regler,
     alleFelterKanRedigeres,

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreErFremtidigUtgift.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreErFremtidigUtgift.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+
+import { useFlag } from '@unleash/proxy-client-react';
+import styled from 'styled-components';
+
+import { Switch } from '@navikt/ds-react';
+
+import { Toggle } from '../../../../utils/toggles';
+import { StønadsvilkårType } from '../../vilkår';
+
+const StyledSwitch = styled(Switch)`
+    align-self: end;
+`;
+
+const EndreErFremtidigUtgift: React.FC<{
+    vilkårtype: StønadsvilkårType;
+    kanVæreFremtidigUtgift?: boolean;
+    erFremtidigUtgift?: boolean;
+    oppdaterErFremtidigUtgift: (verdi: boolean) => void;
+}> = ({ vilkårtype, kanVæreFremtidigUtgift, erFremtidigUtgift, oppdaterErFremtidigUtgift }) => {
+    const tillaterErFremtidigUtgift = useFlag(Toggle.TILLATER_NULLVEDAK);
+    if (!tillaterErFremtidigUtgift) return null;
+
+    return (
+        <>
+            {vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING && kanVæreFremtidigUtgift && (
+                <StyledSwitch
+                    size={'small'}
+                    checked={erFremtidigUtgift}
+                    onChange={(e) => oppdaterErFremtidigUtgift(e.target.checked)}
+                >
+                    Fremtidig utgift
+                </StyledSwitch>
+            )}
+        </>
+    );
+};
+
+export default EndreErFremtidigUtgift;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndrePeriodeForVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndrePeriodeForVilkår.tsx
@@ -22,6 +22,11 @@ const StyledSwitch = styled(Switch)`
     align-self: end;
 `;
 
+export enum TypePeriodeVelger {
+    DATO = 'DATO',
+    MANED_ÅR = 'MANED_ÅR',
+}
+
 export type EndrePeriodeForVilkårForm = {
     fom: string | undefined;
     tom: string | undefined;
@@ -42,6 +47,7 @@ const EndrePeriodeForVilkår: React.FC<{
         value: ((prevState: Feilmeldinger) => Feilmeldinger) | Feilmeldinger
     ) => void;
     feilmeldinger: Feilmeldinger;
+    typePeriodeVelger: TypePeriodeVelger;
     kanVæreFremtidigUtgift?: boolean;
 }> = ({
     endrePeriodeForVilkårFrom,
@@ -51,9 +57,9 @@ const EndrePeriodeForVilkår: React.FC<{
     vilkårtype,
     settFeilmeldinger,
     feilmeldinger,
+    typePeriodeVelger,
     kanVæreFremtidigUtgift,
 }) => {
-    const erUtgifterOvernatting = vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING;
     const skalBrukeMånedÅrVelger = useFlag(Toggle.SKAL_BRUKE_MANED_AR_VELGER);
     const tillaterErFremtidigUtgift = useFlag(Toggle.TILLATER_NULLVEDAK);
 
@@ -90,7 +96,7 @@ const EndrePeriodeForVilkår: React.FC<{
     return (
         <HStack gap="4" align="start">
             <FeilmeldingMaksBredde $maxWidth={152}>
-                {erUtgifterOvernatting ? (
+                {typePeriodeVelger == TypePeriodeVelger.DATO ? (
                     <DateInputMedLeservisning
                         label={'Fra'}
                         value={fom}
@@ -128,7 +134,7 @@ const EndrePeriodeForVilkår: React.FC<{
                 )}
             </FeilmeldingMaksBredde>
             <FeilmeldingMaksBredde $maxWidth={152}>
-                {erUtgifterOvernatting ? (
+                {typePeriodeVelger == TypePeriodeVelger.DATO ? (
                     <DateInputMedLeservisning
                         label={'Til'}
                         value={tom}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndrePeriodeForVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndrePeriodeForVilkår.tsx
@@ -1,0 +1,193 @@
+import React from 'react';
+
+import { useFlag } from '@unleash/proxy-client-react';
+import styled from 'styled-components';
+
+import { HStack, Switch } from '@navikt/ds-react';
+
+import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
+import MonthInput from '../../../../komponenter/Skjema/MonthInput';
+import { MånedÅrVelger } from '../../../../komponenter/Skjema/MånedÅrVelger/MånedÅrVelger';
+import TextField from '../../../../komponenter/Skjema/TextField';
+import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
+import { tilFørsteDagenIMåneden, tilSisteDagenIMåneden } from '../../../../utils/dato';
+import { harTallverdi, tilHeltall } from '../../../../utils/tall';
+import { Toggle } from '../../../../utils/toggles';
+import { fjernSpaces } from '../../../../utils/utils';
+import { StønadsvilkårType } from '../../vilkår';
+import { vilkårTypeTilUtgiftTekst } from '../tekster';
+import { Feilmeldinger } from '../validering';
+
+const StyledSwitch = styled(Switch)`
+    align-self: end;
+`;
+
+export type EndrePeriodeForVilkårForm = {
+    fom: string | undefined;
+    tom: string | undefined;
+    utgift: number | undefined;
+    erFremtidigUtgift: boolean | undefined;
+};
+
+const EndrePeriodeForVilkår: React.FC<{
+    endrePeriodeForVilkårFrom: EndrePeriodeForVilkårForm;
+    oppdaterEndrePeriodeForVilkårForm: (
+        key: keyof EndrePeriodeForVilkårForm,
+        nyVerdi: string | number | boolean | undefined
+    ) => void;
+    alleFelterKanRedigeres: boolean;
+    settDetFinnesUlagredeEndringer: (value: ((prevState: boolean) => boolean) | boolean) => void;
+    vilkårtype: StønadsvilkårType;
+    settFeilmeldinger: (
+        value: ((prevState: Feilmeldinger) => Feilmeldinger) | Feilmeldinger
+    ) => void;
+    feilmeldinger: Feilmeldinger;
+    kanVæreFremtidigUtgift?: boolean;
+}> = ({
+    endrePeriodeForVilkårFrom,
+    oppdaterEndrePeriodeForVilkårForm,
+    alleFelterKanRedigeres,
+    settDetFinnesUlagredeEndringer,
+    vilkårtype,
+    settFeilmeldinger,
+    feilmeldinger,
+    kanVæreFremtidigUtgift,
+}) => {
+    const erUtgifterOvernatting = vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING;
+    const skalBrukeMånedÅrVelger = useFlag(Toggle.SKAL_BRUKE_MANED_AR_VELGER);
+    const tillaterErFremtidigUtgift = useFlag(Toggle.TILLATER_NULLVEDAK);
+
+    const { fom, tom, utgift, erFremtidigUtgift } = endrePeriodeForVilkårFrom;
+
+    const oppdaterFom = (dato: string | undefined) => {
+        oppdaterEndrePeriodeForVilkårForm('fom', dato);
+        nullstillFeilmeldingerFor('fom');
+        settDetFinnesUlagredeEndringer(true);
+    };
+
+    const oppdaterTom = (dato: string | undefined) => {
+        oppdaterEndrePeriodeForVilkårForm('tom', dato);
+        nullstillFeilmeldingerFor('tom');
+        settDetFinnesUlagredeEndringer(true);
+    };
+
+    const oppdaterUtgift = (verdi: number | undefined) => {
+        oppdaterEndrePeriodeForVilkårForm('utgift', verdi);
+        nullstillFeilmeldingerFor('utgift');
+        settDetFinnesUlagredeEndringer(true);
+    };
+
+    const oppdaterErFremtidigUtgift = (verdi: boolean) => {
+        oppdaterEndrePeriodeForVilkårForm('erFremtidigUtgift', verdi);
+        nullstillFeilmeldingerFor('erFremtidigUtgift');
+        settDetFinnesUlagredeEndringer(true);
+    };
+
+    const nullstillFeilmeldingerFor = (felt: keyof EndrePeriodeForVilkårForm) => {
+        settFeilmeldinger((prevState) => ({ ...prevState, [felt]: undefined }));
+    };
+
+    return (
+        <HStack gap="4" align="start">
+            <FeilmeldingMaksBredde $maxWidth={152}>
+                {erUtgifterOvernatting ? (
+                    <DateInputMedLeservisning
+                        label={'Fra'}
+                        value={fom}
+                        onChange={(dato) => {
+                            oppdaterFom(dato);
+                        }}
+                        readOnly={!alleFelterKanRedigeres}
+                        size="small"
+                        feil={feilmeldinger.fom}
+                    />
+                ) : skalBrukeMånedÅrVelger ? (
+                    <MånedÅrVelger
+                        label="Fra"
+                        size="small"
+                        årMånedInitiell={fom}
+                        feilmelding={feilmeldinger.fom}
+                        lesevisning={!alleFelterKanRedigeres}
+                        onEndret={(dato) => {
+                            oppdaterFom(dato ? tilFørsteDagenIMåneden(dato) : undefined);
+                        }}
+                        antallÅrFrem={1}
+                        antallÅrTilbake={1}
+                    />
+                ) : (
+                    <MonthInput
+                        label="Fra"
+                        size="small"
+                        value={fom}
+                        feil={feilmeldinger.fom}
+                        readOnly={!alleFelterKanRedigeres}
+                        onChange={(dato) => {
+                            oppdaterFom(dato ? tilFørsteDagenIMåneden(dato) : undefined);
+                        }}
+                    />
+                )}
+            </FeilmeldingMaksBredde>
+            <FeilmeldingMaksBredde $maxWidth={152}>
+                {erUtgifterOvernatting ? (
+                    <DateInputMedLeservisning
+                        label={'Til'}
+                        value={tom}
+                        onChange={(dato) => {
+                            oppdaterTom(dato);
+                        }}
+                        size="small"
+                        feil={feilmeldinger.tom}
+                    />
+                ) : skalBrukeMånedÅrVelger ? (
+                    <MånedÅrVelger
+                        label="Til"
+                        size="small"
+                        årMånedInitiell={tom}
+                        feilmelding={feilmeldinger.tom}
+                        onEndret={(dato) => {
+                            oppdaterTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
+                        }}
+                        antallÅrFrem={2}
+                        antallÅrTilbake={1}
+                    />
+                ) : (
+                    <MonthInput
+                        label="Til"
+                        size="small"
+                        value={tom}
+                        feil={feilmeldinger.tom}
+                        onChange={(dato) => {
+                            oppdaterTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
+                        }}
+                    />
+                )}
+            </FeilmeldingMaksBredde>
+            <FeilmeldingMaksBredde $maxWidth={180}>
+                <TextField
+                    label={`${vilkårTypeTilUtgiftTekst[vilkårtype]}${erFremtidigUtgift ? ' (valgfri)' : ''}`}
+                    size="small"
+                    erLesevisning={false}
+                    value={harTallverdi(utgift) ? utgift : ''}
+                    readOnly={!alleFelterKanRedigeres}
+                    onChange={(e) => {
+                        oppdaterUtgift(tilHeltall(fjernSpaces(e.target.value)));
+                    }}
+                />
+            </FeilmeldingMaksBredde>
+            {/*VENTER PÅ AVKLARING PÅ HVORDAN OG OM VI SKAL STØTTE NULLVEDTAK*/}
+            {tillaterErFremtidigUtgift &&
+                vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING &&
+                kanVæreFremtidigUtgift && (
+                    <StyledSwitch
+                        size={'small'}
+                        checked={erFremtidigUtgift}
+                        onChange={(e) => oppdaterErFremtidigUtgift(e.target.checked)}
+                    >
+                        Fremtidig utgift
+                    </StyledSwitch>
+                )}
+        </HStack>
+    );
+};
+
+export default EndrePeriodeForVilkår;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndrePeriodeForVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndrePeriodeForVilkår.tsx
@@ -1,97 +1,42 @@
 import React from 'react';
 
 import { useFlag } from '@unleash/proxy-client-react';
-import styled from 'styled-components';
 
-import { HStack, Switch } from '@navikt/ds-react';
+import { HStack } from '@navikt/ds-react';
 
 import DateInputMedLeservisning from '../../../../komponenter/Skjema/DateInputMedLeservisning';
 import MonthInput from '../../../../komponenter/Skjema/MonthInput';
 import { MånedÅrVelger } from '../../../../komponenter/Skjema/MånedÅrVelger/MånedÅrVelger';
-import TextField from '../../../../komponenter/Skjema/TextField';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { tilFørsteDagenIMåneden, tilSisteDagenIMåneden } from '../../../../utils/dato';
-import { harTallverdi, tilHeltall } from '../../../../utils/tall';
 import { Toggle } from '../../../../utils/toggles';
-import { fjernSpaces } from '../../../../utils/utils';
-import { StønadsvilkårType } from '../../vilkår';
-import { vilkårTypeTilUtgiftTekst } from '../tekster';
 import { Feilmeldinger } from '../validering';
-
-const StyledSwitch = styled(Switch)`
-    align-self: end;
-`;
 
 export enum TypePeriodeVelger {
     DATO = 'DATO',
     MANED_ÅR = 'MANED_ÅR',
 }
 
-export type EndrePeriodeForVilkårForm = {
+export type PeriodeForVilkår = {
     fom: string | undefined;
     tom: string | undefined;
-    utgift: number | undefined;
-    erFremtidigUtgift: boolean | undefined;
 };
 
 const EndrePeriodeForVilkår: React.FC<{
-    endrePeriodeForVilkårFrom: EndrePeriodeForVilkårForm;
-    oppdaterEndrePeriodeForVilkårForm: (
-        key: keyof EndrePeriodeForVilkårForm,
-        nyVerdi: string | number | boolean | undefined
-    ) => void;
+    periodeForVilkår: PeriodeForVilkår;
+    oppdaterPeriodeForVilkår: (key: keyof PeriodeForVilkår, nyVerdi: string | undefined) => void;
     alleFelterKanRedigeres: boolean;
-    settDetFinnesUlagredeEndringer: (value: ((prevState: boolean) => boolean) | boolean) => void;
-    vilkårtype: StønadsvilkårType;
-    settFeilmeldinger: (
-        value: ((prevState: Feilmeldinger) => Feilmeldinger) | Feilmeldinger
-    ) => void;
     feilmeldinger: Feilmeldinger;
     typePeriodeVelger: TypePeriodeVelger;
-    kanVæreFremtidigUtgift?: boolean;
 }> = ({
-    endrePeriodeForVilkårFrom,
-    oppdaterEndrePeriodeForVilkårForm,
+    periodeForVilkår,
+    oppdaterPeriodeForVilkår,
     alleFelterKanRedigeres,
-    settDetFinnesUlagredeEndringer,
-    vilkårtype,
-    settFeilmeldinger,
     feilmeldinger,
     typePeriodeVelger,
-    kanVæreFremtidigUtgift,
 }) => {
     const skalBrukeMånedÅrVelger = useFlag(Toggle.SKAL_BRUKE_MANED_AR_VELGER);
-    const tillaterErFremtidigUtgift = useFlag(Toggle.TILLATER_NULLVEDAK);
-
-    const { fom, tom, utgift, erFremtidigUtgift } = endrePeriodeForVilkårFrom;
-
-    const oppdaterFom = (dato: string | undefined) => {
-        oppdaterEndrePeriodeForVilkårForm('fom', dato);
-        nullstillFeilmeldingerFor('fom');
-        settDetFinnesUlagredeEndringer(true);
-    };
-
-    const oppdaterTom = (dato: string | undefined) => {
-        oppdaterEndrePeriodeForVilkårForm('tom', dato);
-        nullstillFeilmeldingerFor('tom');
-        settDetFinnesUlagredeEndringer(true);
-    };
-
-    const oppdaterUtgift = (verdi: number | undefined) => {
-        oppdaterEndrePeriodeForVilkårForm('utgift', verdi);
-        nullstillFeilmeldingerFor('utgift');
-        settDetFinnesUlagredeEndringer(true);
-    };
-
-    const oppdaterErFremtidigUtgift = (verdi: boolean) => {
-        oppdaterEndrePeriodeForVilkårForm('erFremtidigUtgift', verdi);
-        nullstillFeilmeldingerFor('erFremtidigUtgift');
-        settDetFinnesUlagredeEndringer(true);
-    };
-
-    const nullstillFeilmeldingerFor = (felt: keyof EndrePeriodeForVilkårForm) => {
-        settFeilmeldinger((prevState) => ({ ...prevState, [felt]: undefined }));
-    };
+    const { fom, tom } = periodeForVilkår;
 
     return (
         <HStack gap="4" align="start">
@@ -101,7 +46,7 @@ const EndrePeriodeForVilkår: React.FC<{
                         label={'Fra'}
                         value={fom}
                         onChange={(dato) => {
-                            oppdaterFom(dato);
+                            oppdaterPeriodeForVilkår('fom', dato);
                         }}
                         readOnly={!alleFelterKanRedigeres}
                         size="small"
@@ -115,7 +60,10 @@ const EndrePeriodeForVilkår: React.FC<{
                         feilmelding={feilmeldinger.fom}
                         lesevisning={!alleFelterKanRedigeres}
                         onEndret={(dato) => {
-                            oppdaterFom(dato ? tilFørsteDagenIMåneden(dato) : undefined);
+                            oppdaterPeriodeForVilkår(
+                                'fom',
+                                dato ? tilFørsteDagenIMåneden(dato) : undefined
+                            );
                         }}
                         antallÅrFrem={1}
                         antallÅrTilbake={1}
@@ -128,7 +76,10 @@ const EndrePeriodeForVilkår: React.FC<{
                         feil={feilmeldinger.fom}
                         readOnly={!alleFelterKanRedigeres}
                         onChange={(dato) => {
-                            oppdaterFom(dato ? tilFørsteDagenIMåneden(dato) : undefined);
+                            oppdaterPeriodeForVilkår(
+                                'fom',
+                                dato ? tilFørsteDagenIMåneden(dato) : undefined
+                            );
                         }}
                     />
                 )}
@@ -139,7 +90,7 @@ const EndrePeriodeForVilkår: React.FC<{
                         label={'Til'}
                         value={tom}
                         onChange={(dato) => {
-                            oppdaterTom(dato);
+                            oppdaterPeriodeForVilkår('tom', dato);
                         }}
                         size="small"
                         feil={feilmeldinger.tom}
@@ -151,7 +102,10 @@ const EndrePeriodeForVilkår: React.FC<{
                         årMånedInitiell={tom}
                         feilmelding={feilmeldinger.tom}
                         onEndret={(dato) => {
-                            oppdaterTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
+                            oppdaterPeriodeForVilkår(
+                                'tom',
+                                dato ? tilSisteDagenIMåneden(dato) : undefined
+                            );
                         }}
                         antallÅrFrem={2}
                         antallÅrTilbake={1}
@@ -163,35 +117,14 @@ const EndrePeriodeForVilkår: React.FC<{
                         value={tom}
                         feil={feilmeldinger.tom}
                         onChange={(dato) => {
-                            oppdaterTom(dato ? tilSisteDagenIMåneden(dato) : undefined);
+                            oppdaterPeriodeForVilkår(
+                                'tom',
+                                dato ? tilSisteDagenIMåneden(dato) : undefined
+                            );
                         }}
                     />
                 )}
             </FeilmeldingMaksBredde>
-            <FeilmeldingMaksBredde $maxWidth={180}>
-                <TextField
-                    label={`${vilkårTypeTilUtgiftTekst[vilkårtype]}${erFremtidigUtgift ? ' (valgfri)' : ''}`}
-                    size="small"
-                    erLesevisning={false}
-                    value={harTallverdi(utgift) ? utgift : ''}
-                    readOnly={!alleFelterKanRedigeres}
-                    onChange={(e) => {
-                        oppdaterUtgift(tilHeltall(fjernSpaces(e.target.value)));
-                    }}
-                />
-            </FeilmeldingMaksBredde>
-            {/*VENTER PÅ AVKLARING PÅ HVORDAN OG OM VI SKAL STØTTE NULLVEDTAK*/}
-            {tillaterErFremtidigUtgift &&
-                vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING &&
-                kanVæreFremtidigUtgift && (
-                    <StyledSwitch
-                        size={'small'}
-                        checked={erFremtidigUtgift}
-                        onChange={(e) => oppdaterErFremtidigUtgift(e.target.checked)}
-                    >
-                        Fremtidig utgift
-                    </StyledSwitch>
-                )}
         </HStack>
     );
 };

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreUtgift.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreUtgift.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import TextField from '../../../../komponenter/Skjema/TextField';
+import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
+import { harTallverdi, tilHeltall } from '../../../../utils/tall';
+import { fjernSpaces } from '../../../../utils/utils';
+import { StønadsvilkårType } from '../../vilkår';
+import { vilkårTypeTilUtgiftTekst } from '../tekster';
+
+const EndreUtgift: React.FC<{
+    vilkårtype: StønadsvilkårType;
+    erFremtidigUtgift?: boolean;
+    utgift?: number;
+    alleFelterKanRedigeres: boolean;
+    oppdaterUtgift: (verdi: number | undefined) => void;
+}> = ({ vilkårtype, erFremtidigUtgift, utgift, alleFelterKanRedigeres, oppdaterUtgift }) => {
+    return (
+        <FeilmeldingMaksBredde $maxWidth={180}>
+            <TextField
+                label={`${vilkårTypeTilUtgiftTekst[vilkårtype]}${erFremtidigUtgift ? ' (valgfri)' : ''}`}
+                size="small"
+                erLesevisning={false}
+                value={harTallverdi(utgift) ? utgift : ''}
+                readOnly={!alleFelterKanRedigeres}
+                onChange={(e) => {
+                    oppdaterUtgift(tilHeltall(fjernSpaces(e.target.value)));
+                }}
+            />
+        </FeilmeldingMaksBredde>
+    );
+};
+
+export default EndreUtgift;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreVilkår.tsx
@@ -6,27 +6,27 @@ import { TrashIcon } from '@navikt/aksel-icons';
 import { ErrorMessage, VStack } from '@navikt/ds-react';
 import { AShadowXsmall } from '@navikt/ds-tokens/dist/tokens';
 
-import EndreDelvilkår from './EndreVilkår/EndreDelvilkår';
-import { Feilmeldinger, ingen, ingenFeil, validerVilkårsvurderinger } from './validering';
-import { useApp } from '../../../context/AppContext';
-import { useBehandling } from '../../../context/BehandlingContext';
-import SmallButton from '../../../komponenter/Knapper/SmallButton';
-import { Skillelinje } from '../../../komponenter/Skillelinje';
-import { SmallWarningTag } from '../../../komponenter/Tags';
-import { FlexColumn } from '../../../komponenter/Visningskomponenter/Flex';
-import { Regler } from '../../../typer/regel';
-import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../typer/ressurs';
+import EndreDelvilkår from './EndreDelvilkår';
+import EndrePeriodeForVilkår, {
+    EndrePeriodeForVilkårForm,
+    TypePeriodeVelger,
+} from './EndrePeriodeForVilkår';
+import { useApp } from '../../../../context/AppContext';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import SmallButton from '../../../../komponenter/Knapper/SmallButton';
+import { Skillelinje } from '../../../../komponenter/Skillelinje';
+import { SmallWarningTag } from '../../../../komponenter/Tags';
+import { FlexColumn } from '../../../../komponenter/Visningskomponenter/Flex';
+import { Regler } from '../../../../typer/regel';
+import { RessursFeilet, RessursStatus, RessursSuksess } from '../../../../typer/ressurs';
 import {
     Delvilkår,
     RedigerbareVilkårfelter,
     StønadsvilkårType,
     Vilkår,
     Vilkårsresultat,
-} from '../vilkår';
-import EndrePeriodeForVilkår, {
-    EndrePeriodeForVilkårForm,
-    TypePeriodeVelger,
-} from './EndreVilkår/EndrePeriodeForVilkår';
+} from '../../vilkår';
+import { Feilmeldinger, ingen, ingenFeil, validerVilkårsvurderinger } from '../validering';
 
 const StyledForm = styled.form`
     background: white;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/NyttVilkår.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { PlusCircleIcon } from '@navikt/aksel-icons';
 
-import { EndreVilkår } from './EndreVilkår';
+import { EndreVilkår } from './EndreVilkår/EndreVilkår';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { useSteg } from '../../../context/StegContext';
 import { useVilkår } from '../../../context/VilkårContext';

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/VisEllerEndreVilkår.tsx
@@ -1,6 +1,6 @@
 import React, { FC, useState } from 'react';
 
-import { EndreVilkår } from './EndreVilkår';
+import { EndreVilkår } from './EndreVilkår/EndreVilkår';
 import LesevisningVilkår from './LesevisningVilkår';
 import { useSteg } from '../../../context/StegContext';
 import { useVilkår } from '../../../context/VilkårContext';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Deler opp `EndreVilkår` til:
- `EndrePeriodeForVilkår`
- `EndreErFremtidigUtgift`
- `EndreUtgift`
- `EndreDelvilkår`

Målet et at filene skal bli mindre så det er lettere å sette seg inn i og gjøre endringer. 

⚠️ Dette er kun refaktorering. Det skal ikke være noen funksjonelle endringer her
ℹ️ Samme endring som i https://github.com/navikt/tilleggsstonader-sak-frontend/pull/750, men siden den ble henge så langt bak klarte jeg ikke å merge inn main på noen fornuftig måte
