### PR TITLE
Skal laste inn oppsummeringen ved fanebytte

### DIFF
--- a/src/frontend/hooks/useBehandlingOppsummering.ts
+++ b/src/frontend/hooks/useBehandlingOppsummering.ts
@@ -1,5 +1,7 @@
 import { useEffect, useState } from 'react';
 
+import { useLocation } from 'react-router-dom';
+
 import { useApp } from '../context/AppContext';
 import { useBehandling } from '../context/BehandlingContext';
 import { BehandlingOppsummering } from '../typer/behandling/behandlingOppsummering';
@@ -12,6 +14,7 @@ interface Response {
 export const useBehandlingOppsummering = (): Response => {
     const { request } = useApp();
     const { behandling } = useBehandling();
+    const location = useLocation();
 
     const [behandlingOppsummering, settBehandlingOppsummering] =
         useState<Ressurs<BehandlingOppsummering>>(byggTomRessurs());
@@ -22,7 +25,7 @@ export const useBehandlingOppsummering = (): Response => {
         request<BehandlingOppsummering, null>(
             `/api/sak/behandlingsoppsummering/${behandling.id}`
         ).then(settBehandlingOppsummering);
-    }, [request, behandling.id, behandling.steg]);
+    }, [request, behandling.id, behandling.steg, location.pathname]);
 
     return {
         behandlingOppsummering,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tidligere ble oppsummeringen kun lastet inn ved steg-bytte, men det gjorde at den feks ikke ble lastet inn på nytt ved endring av revurderFra-dato