### PR TITLE
✨Vedtaksperioder paa personoversikt

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
@@ -1,6 +1,5 @@
 import React, { useEffect, useState } from 'react';
 
-import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { Heading, Table } from '@navikt/ds-react';
@@ -11,7 +10,6 @@ import { useApp } from '../../../../context/AppContext';
 import DataViewer from '../../../../komponenter/DataViewer';
 import { byggTomRessurs, Ressurs } from '../../../../typer/ressurs';
 import { formaterNullableIsoDato, formaterNullablePeriode } from '../../../../utils/dato';
-import { Toggle } from '../../../../utils/toggles';
 
 const Vedtakstabell = styled(Table)`
     max-width: 1200px;
@@ -28,10 +26,9 @@ export const VedtaksoversiktArena: React.FC<{ fagsakPersonId: string }> = ({ fag
         );
     }, [request, fagsakPersonId]);
 
-    const visVedtaksperiodeOversikt = useFlag(Toggle.SKAL_VISE_VEDTAKSPERIODER_TAB);
     return (
         <>
-            {!visVedtaksperiodeOversikt && <Heading size="small">Vedtak i Arena</Heading>}
+            <Heading size="small">Vedtak i Arena</Heading>
             <DataViewer response={{ vedtakArena }}>
                 {({ vedtakArena }) => (
                     <Vedtakstabell size={'small'}>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { Heading, Table } from '@navikt/ds-react';
@@ -10,6 +11,7 @@ import { useApp } from '../../../../context/AppContext';
 import DataViewer from '../../../../komponenter/DataViewer';
 import { byggTomRessurs, Ressurs } from '../../../../typer/ressurs';
 import { formaterNullableIsoDato, formaterNullablePeriode } from '../../../../utils/dato';
+import { Toggle } from '../../../../utils/toggles';
 
 const Vedtakstabell = styled(Table)`
     max-width: 1200px;
@@ -26,9 +28,10 @@ export const VedtaksoversiktArena: React.FC<{ fagsakPersonId: string }> = ({ fag
         );
     }, [request, fagsakPersonId]);
 
+    const visVedtaksperiodeOversikt = useFlag(Toggle.SKAL_VISE_VEDTAKSPERIODER_TAB);
     return (
         <>
-            <Heading size="small">Vedtak i Arena</Heading>
+            {!visVedtaksperiodeOversikt && <Heading size="small">Vedtak i Arena</Heading>}
             <DataViewer response={{ vedtakArena }}>
                 {({ vedtakArena }) => (
                     <Vedtakstabell>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
@@ -34,7 +34,7 @@ export const VedtaksoversiktArena: React.FC<{ fagsakPersonId: string }> = ({ fag
             {!visVedtaksperiodeOversikt && <Heading size="small">Vedtak i Arena</Heading>}
             <DataViewer response={{ vedtakArena }}>
                 {({ vedtakArena }) => (
-                    <Vedtakstabell>
+                    <Vedtakstabell size={'small'}>
                         <Table.Header>
                             <Table.Row>
                                 <Table.HeaderCell scope="col">Rettighetstype</Table.HeaderCell>

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import { Navigate, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -11,7 +12,9 @@ import Behandlingsoversikt from './Behandlingsoversikt/BehandlingOversikt';
 import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import FrittståendeBrevFane from './FrittståendeBrev/FrittståendeBrevFane';
 import Oppgaveoversikt from './Oppgaveoversikt/Oppgaveoversikt';
+import { VedtaksperioderOversikt } from './Vedtaksperioderoversikt/VedtaksperioderOversikt';
 import Ytelseoversikt from './Ytelseoversikt/Ytelseoversikt';
+import { Toggle } from '../../utils/toggles';
 
 type TabWithRouter = {
     label: string;
@@ -39,6 +42,11 @@ const tabs: TabWithRouter[] = [
         label: 'TS-Arena',
         path: 'arena',
         komponent: (fagsakPersonId) => <VedtaksoversiktArena fagsakPersonId={fagsakPersonId} />,
+    },
+    {
+        label: 'Vedtaksperiode',
+        path: 'vedtaksperiode',
+        komponent: (fagsakPersonId) => <VedtaksperioderOversikt fagsakPersonId={fagsakPersonId} />,
     },
     {
         label: 'Ytelser',
@@ -70,7 +78,10 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
     const paths = useLocation().pathname.split('/').slice(-1);
     const path = paths.length ? paths[paths.length - 1] : '';
 
-    const tabsSomSkalVises = tabs;
+    const visVedtaksperiodeOversikt = useFlag(Toggle.SKAL_VISE_VEDTAKSPERIODER_TAB);
+    const tabsSomSkalVises = tabs.filter(
+        (tab) => tab.path !== 'vedtaksperiode' || visVedtaksperiodeOversikt
+    );
 
     return (
         <>

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -44,8 +44,8 @@ const tabs: TabWithRouter[] = [
         komponent: (fagsakPersonId) => <VedtaksoversiktArena fagsakPersonId={fagsakPersonId} />,
     },
     {
-        label: 'Vedtaksperiode',
-        path: 'vedtaksperiode',
+        label: 'Vedtaksperioder',
+        path: 'vedtaksperioder',
         komponent: (fagsakPersonId) => <VedtaksperioderOversikt fagsakPersonId={fagsakPersonId} />,
     },
     {
@@ -80,7 +80,7 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
 
     const visVedtaksperiodeOversikt = useFlag(Toggle.SKAL_VISE_VEDTAKSPERIODER_TAB);
     const tabsSomSkalVises = tabs.filter(
-        (tab) => tab.path !== 'vedtaksperiode' || visVedtaksperiodeOversikt
+        (tab) => tab.path !== 'vedtaksperioder' || visVedtaksperiodeOversikt
     );
 
     return (

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -49,7 +49,7 @@ const tabs: TabWithRouter[] = [
         komponent: (fagsakPersonId) => <VedtaksperioderOversikt fagsakPersonId={fagsakPersonId} />,
     },
     {
-        label: 'Ytelser',
+        label: 'Andre ytelser',
         path: 'ytelser',
         komponent: (fagsakPersonId) => <Ytelseoversikt fagsakPersonId={fagsakPersonId} />,
     },
@@ -79,9 +79,15 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
     const path = paths.length ? paths[paths.length - 1] : '';
 
     const visVedtaksperiodeOversikt = useFlag(Toggle.SKAL_VISE_VEDTAKSPERIODER_TAB);
-    const tabsSomSkalVises = tabs.filter(
-        (tab) => tab.path !== 'vedtaksperioder' || visVedtaksperiodeOversikt
-    );
+    const tabsSomSkalVises = tabs.filter((tab) => {
+        if (tab.path === 'vedtaksperioder' && !visVedtaksperiodeOversikt) {
+            return false;
+        }
+        if (tab.path === 'arena' && visVedtaksperiodeOversikt) {
+            return false;
+        }
+        return true;
+    });
 
     return (
         <>

--- a/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
+++ b/src/frontend/Sider/Personoversikt/PersonoversiktInnhold.tsx
@@ -83,10 +83,7 @@ const PersonoversiktInnhold: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
         if (tab.path === 'vedtaksperioder' && !visVedtaksperiodeOversikt) {
             return false;
         }
-        if (tab.path === 'arena' && visVedtaksperiodeOversikt) {
-            return false;
-        }
-        return true;
+        return !(tab.path === 'arena' && visVedtaksperiodeOversikt);
     });
 
     return (

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DetaljertVedtaksperiodeRadBoutgifter.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DetaljertVedtaksperiodeRadBoutgifter.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Table } from '@navikt/ds-react';
+import { ASurfaceSubtle, ABorderDefault, AGray300 } from '@navikt/ds-tokens/dist/tokens';
+
+import { formaterNullableIsoDato } from '../../../utils/dato';
+import {
+    FaktiskMålgruppe,
+    faktiskMålgruppeTilTekst,
+} from '../../Behandling/Felles/faktiskMålgruppe';
+import { aktivitetTypeTilTekst } from '../../Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet';
+import { AktivitetType } from '../../Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet';
+
+const TabellRad = styled(Table.Row)<{ skalHaLinjeUnder: boolean; fargetBakrunn: boolean }>`
+    background-color: ${({ fargetBakrunn }) => (fargetBakrunn ? 'white' : ASurfaceSubtle)};
+    
+    .navds-table__data-cell {
+        border-bottom: ${({ skalHaLinjeUnder }) =>
+            `1px solid ${skalHaLinjeUnder ? ABorderDefault : AGray300}`};
+    
+`;
+
+export const DetaljertVedtaksperiodeRadBoutgifter: React.FC<{
+    fom: string;
+    tom: string;
+    skalViseAntallMånederKolonne?: boolean;
+    antallMåneder?: number;
+    aktivitet: AktivitetType;
+    målgruppe: FaktiskMålgruppe;
+    type: string;
+    totalUtgiftMåned: number;
+    stønadsbeløpMnd: number;
+    fargetBakgrunn: boolean;
+    skalHaLinjeUnder?: boolean;
+}> = ({
+    fom,
+    tom,
+    skalViseAntallMånederKolonne = true,
+    antallMåneder,
+    aktivitet,
+    målgruppe,
+    type,
+    totalUtgiftMåned,
+    stønadsbeløpMnd,
+    fargetBakgrunn: fargetBagrunn,
+    skalHaLinjeUnder = true,
+}) => {
+    return (
+        <TabellRad skalHaLinjeUnder={skalHaLinjeUnder} fargetBakrunn={fargetBagrunn}>
+            <Table.DataCell>{formaterNullableIsoDato(fom)}</Table.DataCell>
+            <Table.DataCell>{formaterNullableIsoDato(tom)}</Table.DataCell>
+            {skalViseAntallMånederKolonne && (
+                <Table.DataCell align={'center'}>{antallMåneder}</Table.DataCell>
+            )}
+            <Table.DataCell>{aktivitetTypeTilTekst(aktivitet)}</Table.DataCell>
+            <Table.DataCell>{faktiskMålgruppeTilTekst(målgruppe)}</Table.DataCell>
+            <Table.DataCell>{type}</Table.DataCell>
+            <Table.DataCell align={'right'}>{totalUtgiftMåned} kr</Table.DataCell>
+            <Table.DataCell align={'right'}>{stønadsbeløpMnd} kr</Table.DataCell>
+        </TabellRad>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/OversiktKort.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/OversiktKort.tsx
@@ -10,21 +10,23 @@ const Container = styled(VStack)`
     border-radius: 4px;
     padding: 1rem;
     background-color: ${ABgDefault};
-    width: 1020px;
+    width: 1200px;
 `;
 
 interface Props {
     tittel: string;
+    tagTittel?: string;
+    tagVariant?: 'info' | 'alt2';
     children: React.ReactNode;
 }
 
-export const OversiktKort: React.FC<Props> = ({ tittel, children }) => {
+export const OversiktKort: React.FC<Props> = ({ tittel, tagTittel, tagVariant, children }) => {
     return (
         <Container gap={'6'}>
             <HStack justify={'space-between'}>
                 <Heading size={'small'}>{tittel}</Heading>
-                <Tag size={'small'} variant="alt2">
-                    TS-Sak
+                <Tag size={'small'} variant={tagVariant ? tagVariant : 'alt2'}>
+                    {tagTittel ? tagTittel : 'TS - Sak'}
                 </Tag>
             </HStack>
             {children}

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/OversiktKort.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/OversiktKort.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Heading, HStack, Tag, VStack } from '@navikt/ds-react';
+import { ABgDefault, ABorderDefault } from '@navikt/ds-tokens/dist/tokens';
+
+const Container = styled(VStack)`
+    border: 1px solid ${ABorderDefault};
+    border-radius: 4px;
+    padding: 1rem;
+    background-color: ${ABgDefault};
+    width: 956px;
+`;
+
+interface Props {
+    tittel: string;
+    children: React.ReactNode;
+}
+
+export const OversiktKort: React.FC<Props> = ({ tittel, children }) => {
+    return (
+        <Container gap={'6'}>
+            <HStack justify={'space-between'}>
+                <Heading size={'small'}>{tittel}</Heading>
+                <Tag size={'small'} variant="alt2">
+                    TS-Sak
+                </Tag>
+            </HStack>
+            {children}
+        </Container>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/OversiktKort.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/OversiktKort.tsx
@@ -10,7 +10,7 @@ const Container = styled(VStack)`
     border-radius: 4px;
     padding: 1rem;
     background-color: ${ABgDefault};
-    width: 956px;
+    width: 1020px;
 `;
 
 interface Props {

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { VStack } from '@navikt/ds-react';
 
+import { VedtaksperioderOversiktBoutgifter } from './VedtaksperioderOversiktBoutgifter';
 import { VedtaksperioderOversiktLæremidler } from './VedtaksperioderOversiktLæremidler';
 import { VedtaksperioderOversiktTilsynBarn } from './VedtaksperioderOversiktTilsynBarn';
 import { useHentFullstendigVedtaksOversikt } from '../../../hooks/useHentFullstendigVedtaksOversikt';
@@ -26,6 +27,9 @@ export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
                     />
                     <VedtaksperioderOversiktLæremidler
                         vedtaksperioder={vedtaksperioderOversikt.læremidler}
+                    />
+                    <VedtaksperioderOversiktBoutgifter
+                        vedtaksperioder={vedtaksperioderOversikt.boutgifter}
                     />
                 </VStack>
             )}

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -2,13 +2,15 @@ import React from 'react';
 
 import { VStack } from '@navikt/ds-react';
 
-import { OversiktKort } from './OversiktKort';
+import { VedtaksperioderOversiktArena } from './VedtaksperioderOversiktArena';
 import { VedtaksperioderOversiktBoutgifter } from './VedtaksperioderOversiktBoutgifter';
 import { VedtaksperioderOversiktLæremidler } from './VedtaksperioderOversiktLæremidler';
 import { VedtaksperioderOversiktTilsynBarn } from './VedtaksperioderOversiktTilsynBarn';
-import { useHentFullstendigVedtaksOversikt } from '../../../hooks/useHentFullstendigVedtaksOversikt';
+import {
+    useHentFullstendigVedtaksOversikt,
+    useVedtaksperioderOversiktArena,
+} from '../../../hooks/useHentFullstendigVedtaksOversikt';
 import DataViewer from '../../../komponenter/DataViewer';
-import { VedtaksoversiktArena } from '../Behandlingsoversikt/Arena/VedtaksoversiktArena';
 
 interface Props {
     fagsakPersonId: string;
@@ -16,30 +18,33 @@ interface Props {
 
 export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
     const { vedtaksperioderOversikt } = useHentFullstendigVedtaksOversikt(fagsakPersonId);
+    const { arenaSakOgVedtak } = useVedtaksperioderOversiktArena(fagsakPersonId);
     if (vedtaksperioderOversikt.status !== 'SUKSESS') {
         return;
     }
 
     return (
-        <DataViewer response={{ vedtaksperioderOversikt }}>
-            {({ vedtaksperioderOversikt }) => (
+        <DataViewer response={{ vedtaksperioderOversikt, arenaSakOgVedtak }}>
+            {({ vedtaksperioderOversikt, arenaSakOgVedtak }) => (
                 <VStack gap={'8'}>
-                    <VedtaksperioderOversiktTilsynBarn
-                        vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
-                    />
-                    <VedtaksperioderOversiktLæremidler
-                        vedtaksperioder={vedtaksperioderOversikt.læremidler}
-                    />
-                    <VedtaksperioderOversiktBoutgifter
-                        vedtaksperioder={vedtaksperioderOversikt.boutgifter}
-                    />
-                    <OversiktKort
-                        tittel={'TS vedtak i Arena'}
-                        tagTittel={'Arena'}
-                        tagVariant={'info'}
-                    >
-                        <VedtaksoversiktArena fagsakPersonId={fagsakPersonId} />
-                    </OversiktKort>
+                    {vedtaksperioderOversikt.tilsynBarn.length > 0 && (
+                        <VedtaksperioderOversiktTilsynBarn
+                            vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
+                        />
+                    )}
+                    {vedtaksperioderOversikt.læremidler.length > 0 && (
+                        <VedtaksperioderOversiktLæremidler
+                            vedtaksperioder={vedtaksperioderOversikt.læremidler}
+                        />
+                    )}
+                    {vedtaksperioderOversikt.boutgifter.length > 0 && (
+                        <VedtaksperioderOversiktBoutgifter
+                            vedtaksperioder={vedtaksperioderOversikt.boutgifter}
+                        />
+                    )}
+                    {arenaSakOgVedtak.vedtak.length > 0 && (
+                        <VedtaksperioderOversiktArena arenaSakOgVedtak={arenaSakOgVedtak} />
+                    )}
                 </VStack>
             )}
         </DataViewer>

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { VStack } from '@navikt/ds-react';
 
+import { VedtaksperioderOversiktLæremidler } from './VedtaksperioderOversiktLæremidler';
 import { VedtaksperioderOversiktTilsynBarn } from './VedtaksperioderOversiktTilsynBarn';
 import { useHentFullstendigVedtaksOversikt } from '../../../hooks/useHentFullstendigVedtaksOversikt';
 import DataViewer from '../../../komponenter/DataViewer';
@@ -22,6 +23,9 @@ export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
                 <VStack gap={'8'}>
                     <VedtaksperioderOversiktTilsynBarn
                         vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
+                    />
+                    <VedtaksperioderOversiktLæremidler
+                        vedtaksperioder={vedtaksperioderOversikt.læremidler}
                     />
                 </VStack>
             )}

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -2,11 +2,13 @@ import React from 'react';
 
 import { VStack } from '@navikt/ds-react';
 
+import { OversiktKort } from './OversiktKort';
 import { VedtaksperioderOversiktBoutgifter } from './VedtaksperioderOversiktBoutgifter';
 import { VedtaksperioderOversiktLæremidler } from './VedtaksperioderOversiktLæremidler';
 import { VedtaksperioderOversiktTilsynBarn } from './VedtaksperioderOversiktTilsynBarn';
 import { useHentFullstendigVedtaksOversikt } from '../../../hooks/useHentFullstendigVedtaksOversikt';
 import DataViewer from '../../../komponenter/DataViewer';
+import { VedtaksoversiktArena } from '../Behandlingsoversikt/Arena/VedtaksoversiktArena';
 
 interface Props {
     fagsakPersonId: string;
@@ -31,6 +33,13 @@ export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
                     <VedtaksperioderOversiktBoutgifter
                         vedtaksperioder={vedtaksperioderOversikt.boutgifter}
                     />
+                    <OversiktKort
+                        tittel={'TS vedtak i Arena'}
+                        tagTittel={'Arena'}
+                        tagVariant={'info'}
+                    >
+                        <VedtaksoversiktArena fagsakPersonId={fagsakPersonId} />
+                    </OversiktKort>
                 </VStack>
             )}
         </DataViewer>

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -1,0 +1,30 @@
+import React from 'react';
+
+import { VStack } from '@navikt/ds-react';
+
+import { VedtaksperioderOversiktTilsynBarn } from './VedtaksperioderOversiktTilsynBarn';
+import { useHentFullstendigVedtaksOversikt } from '../../../hooks/useHentFullstendigVedtaksOversikt';
+import DataViewer from '../../../komponenter/DataViewer';
+
+interface Props {
+    fagsakPersonId: string;
+}
+
+export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
+    const { vedtaksperioderOversikt } = useHentFullstendigVedtaksOversikt(fagsakPersonId);
+    if (vedtaksperioderOversikt.status !== 'SUKSESS') {
+        return;
+    }
+
+    return (
+        <DataViewer response={{ vedtaksperioderOversikt }}>
+            {({ vedtaksperioderOversikt }) => (
+                <VStack gap={'8'}>
+                    <VedtaksperioderOversiktTilsynBarn
+                        vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
+                    />
+                </VStack>
+            )}
+        </DataViewer>
+    );
+}

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktArena.tsx
@@ -1,0 +1,51 @@
+import React from 'react';
+
+import { Table } from '@navikt/ds-react';
+
+import { OversiktKort } from './OversiktKort';
+import { formaterNullableIsoDato, formaterNullablePeriode } from '../../../utils/dato';
+import { ArenaSakOgVedtak } from '../Behandlingsoversikt/Arena/vedtakArena';
+import { Vedtaksdetaljer } from '../Behandlingsoversikt/Arena/Vedtaksdetaljer';
+
+export const VedtaksperioderOversiktArena: React.FC<{ arenaSakOgVedtak: ArenaSakOgVedtak }> = ({
+    arenaSakOgVedtak,
+}) => {
+    return (
+        <OversiktKort tittel={'TS vedtak i Arena'} tagTittel={'Arena'} tagVariant={'info'}>
+            <Table size={'small'}>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell scope="col">Rettighetstype</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Utfall</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Periode</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Dato innstillt</Table.HeaderCell>
+                        <Table.HeaderCell scope="col"></Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {arenaSakOgVedtak.vedtak.map((vedtak, index) => {
+                        const sak = arenaSakOgVedtak.saker[vedtak.sakId];
+                        return (
+                            <Table.ExpandableRow
+                                key={index}
+                                content={<Vedtaksdetaljer vedtak={vedtak} sak={sak} />}
+                                togglePlacement={'right'}
+                            >
+                                <Table.DataCell>{vedtak.rettighet}</Table.DataCell>
+                                <Table.DataCell>{vedtak.type}</Table.DataCell>
+                                <Table.DataCell>{vedtak.utfall}</Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterNullablePeriode(vedtak.fom, vedtak.tom)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterNullableIsoDato(vedtak.datoInnstillt)}
+                                </Table.DataCell>
+                            </Table.ExpandableRow>
+                        );
+                    })}
+                </Table.Body>
+            </Table>
+        </OversiktKort>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
@@ -2,18 +2,17 @@ import React from 'react';
 
 import { Table } from '@navikt/ds-react';
 
+import { DetaljertVedtaksperiodeRadBoutgifter } from './DetaljertVedtaksperiodeRadBoutgifter';
 import { OversiktKort } from './OversiktKort';
-import { TypeBoutgift, typeBoutgiftTilTekst } from '../../../typer/vedtak/vedtakBoutgifter';
 import { DetaljertVedtaksperiodeBoutgifter } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
-import { formaterNullableIsoDato } from '../../../utils/dato';
-import { faktiskMålgruppeTilTekst } from '../../Behandling/Felles/faktiskMålgruppe';
-import { aktivitetTypeTilTekst } from '../../Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet';
 
 interface Props {
     vedtaksperioder: DetaljertVedtaksperiodeBoutgifter[];
 }
 
 export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperioder }) => {
+    const inneholderLøpendeUtgifter = vedtaksperioder.some((periode) => periode.erLøpendeUtgift);
+
     return (
         <OversiktKort tittel={'Boutgifter'}>
             <Table size={'small'}>
@@ -21,9 +20,7 @@ export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperi
                     <Table.Row>
                         <Table.HeaderCell scope="col">Fra</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Til</Table.HeaderCell>
-                        {!vedtaksperioder.some(
-                            (periode) => periode.type === TypeBoutgift.UTGIFTER_OVERNATTING
-                        ) && (
+                        {inneholderLøpendeUtgifter && (
                             <Table.HeaderCell scope="col" align="center">
                                 Ant.mnd
                             </Table.HeaderCell>
@@ -40,33 +37,41 @@ export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperi
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
-                    {vedtaksperioder.map((periode) => {
-                        return (
-                            <Table.Row key={periode.fom}>
-                                <Table.DataCell>
-                                    {formaterNullableIsoDato(periode.fom)}
-                                </Table.DataCell>
-                                <Table.DataCell>
-                                    {formaterNullableIsoDato(periode.tom)}
-                                </Table.DataCell>
-                                {periode.type !== TypeBoutgift.UTGIFTER_OVERNATTING && (
-                                    <Table.DataCell align={'center'}>
-                                        {periode.antallMåneder}
-                                    </Table.DataCell>
-                                )}
-                                <Table.DataCell>
-                                    {aktivitetTypeTilTekst(periode.aktivitet)}
-                                </Table.DataCell>
-                                <Table.DataCell>
-                                    {faktiskMålgruppeTilTekst(periode.målgruppe)}
-                                </Table.DataCell>
-                                <Table.DataCell>
-                                    {typeBoutgiftTilTekst(periode.type)}
-                                </Table.DataCell>
-                                <Table.DataCell align={'right'}>{periode.utgift} kr</Table.DataCell>
-                                <Table.DataCell align={'right'}>{periode.stønad} kr</Table.DataCell>
-                            </Table.Row>
-                        );
+                    {vedtaksperioder.map((periode, tabellIndeks) => {
+                        if (periode.utgifterTilOvernatting) {
+                            return periode.utgifterTilOvernatting.map((utgift, utgiftIndeks) => (
+                                <DetaljertVedtaksperiodeRadBoutgifter
+                                    key={utgift.fom}
+                                    fom={utgift.fom}
+                                    tom={utgift.tom}
+                                    skalViseAntallMånederKolonne={false}
+                                    aktivitet={periode.aktivitet}
+                                    målgruppe={periode.målgruppe}
+                                    type="Overnatting"
+                                    totalUtgiftMåned={utgift.utgift}
+                                    stønadsbeløpMnd={utgift.beløpSomDekkes}
+                                    skalHaLinjeUnder={
+                                        utgiftIndeks === periode.utgifterTilOvernatting!.length - 1
+                                    }
+                                    fargetBakgrunn={tabellIndeks % 2 === 0}
+                                />
+                            ));
+                        } else {
+                            return (
+                                <DetaljertVedtaksperiodeRadBoutgifter
+                                    key={periode.fom}
+                                    fom={periode.fom}
+                                    tom={periode.tom}
+                                    antallMåneder={periode.antallMåneder}
+                                    aktivitet={periode.aktivitet}
+                                    målgruppe={periode.målgruppe}
+                                    type="Løpende"
+                                    totalUtgiftMåned={periode.totalUtgiftMåned}
+                                    stønadsbeløpMnd={periode.stønadsbeløpMnd}
+                                    fargetBakgrunn={tabellIndeks % 2 === 0}
+                                />
+                            );
+                        }
                     })}
                 </Table.Body>
             </Table>

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { Table } from '@navikt/ds-react';
+
+import { OversiktKort } from './OversiktKort';
+import { typeBoutgiftTilTekst } from '../../../typer/vedtak/vedtakBoutgifter';
+import { DetaljertVedtaksperiodeBoutgifter } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
+import { formaterNullableIsoDato } from '../../../utils/dato';
+import { faktiskMålgruppeTilTekst } from '../../Behandling/Felles/faktiskMålgruppe';
+import { aktivitetTypeTilTekst } from '../../Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet';
+
+interface Props {
+    vedtaksperioder: DetaljertVedtaksperiodeBoutgifter[];
+}
+
+export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperioder }) => {
+    return (
+        <OversiktKort tittel={'Boutgifter'}>
+            <Table size={'small'}>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell scope="col">Fra</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Til</Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'center'}>
+                            Ant.mnd
+                        </Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Målgruppe</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'center'}>
+                            Utgift
+                        </Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'right'}>
+                            Stønad
+                        </Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {vedtaksperioder.map((periode) => {
+                        return (
+                            <Table.Row key={periode.fom}>
+                                <Table.DataCell>
+                                    {formaterNullableIsoDato(periode.fom)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterNullableIsoDato(periode.tom)}
+                                </Table.DataCell>
+                                <Table.DataCell align={'center'}>
+                                    {periode.antallMåneder}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {aktivitetTypeTilTekst(periode.aktivitet)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {faktiskMålgruppeTilTekst(periode.målgruppe)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {typeBoutgiftTilTekst(periode.type)}
+                                </Table.DataCell>
+                                <Table.DataCell align={'right'}>{periode.utgift} kr</Table.DataCell>
+                                <Table.DataCell align={'right'}>{periode.stønad} kr</Table.DataCell>
+                            </Table.Row>
+                        );
+                    })}
+                </Table.Body>
+            </Table>
+        </OversiktKort>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { Table } from '@navikt/ds-react';
 
 import { OversiktKort } from './OversiktKort';
-import { typeBoutgiftTilTekst } from '../../../typer/vedtak/vedtakBoutgifter';
+import { TypeBoutgift, typeBoutgiftTilTekst } from '../../../typer/vedtak/vedtakBoutgifter';
 import { DetaljertVedtaksperiodeBoutgifter } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
 import { formaterNullableIsoDato } from '../../../utils/dato';
 import { faktiskMålgruppeTilTekst } from '../../Behandling/Felles/faktiskMålgruppe';
@@ -21,9 +21,13 @@ export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperi
                     <Table.Row>
                         <Table.HeaderCell scope="col">Fra</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Til</Table.HeaderCell>
-                        <Table.HeaderCell scope="col" align={'center'}>
-                            Ant.mnd
-                        </Table.HeaderCell>
+                        {!vedtaksperioder.some(
+                            (periode) => periode.type === TypeBoutgift.UTGIFTER_OVERNATTING
+                        ) && (
+                            <Table.HeaderCell scope="col" align="center">
+                                Ant.mnd
+                            </Table.HeaderCell>
+                        )}
                         <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Målgruppe</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Type</Table.HeaderCell>
@@ -45,9 +49,11 @@ export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperi
                                 <Table.DataCell>
                                     {formaterNullableIsoDato(periode.tom)}
                                 </Table.DataCell>
-                                <Table.DataCell align={'center'}>
-                                    {periode.antallMåneder}
-                                </Table.DataCell>
+                                {periode.type !== TypeBoutgift.UTGIFTER_OVERNATTING && (
+                                    <Table.DataCell align={'center'}>
+                                        {periode.antallMåneder}
+                                    </Table.DataCell>
+                                )}
                                 <Table.DataCell>
                                     {aktivitetTypeTilTekst(periode.aktivitet)}
                                 </Table.DataCell>

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktBoutgifter.tsx
@@ -27,7 +27,7 @@ export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperi
                         <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Målgruppe</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Type</Table.HeaderCell>
-                        <Table.HeaderCell scope="col" align={'center'}>
+                        <Table.HeaderCell scope="col" align={'right'}>
                             Utgift
                         </Table.HeaderCell>
                         <Table.HeaderCell scope="col" align={'right'}>

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktLæremidler.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktLæremidler.tsx
@@ -27,7 +27,9 @@ export const VedtaksperioderOversiktLæremidler: React.FC<Props> = ({ vedtaksper
                         <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Målgruppe</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Nivå</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Prosent</Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'right'}>
+                            Prosent
+                        </Table.HeaderCell>
                         <Table.HeaderCell scope="col" align={'right'}>
                             Månedsbeløp
                         </Table.HeaderCell>

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktLæremidler.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktLæremidler.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { Table } from '@navikt/ds-react';
+
+import { OversiktKort } from './OversiktKort';
+import { DetaljertVedtaksperiodeLæremidler } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
+import { formaterNullableIsoDato } from '../../../utils/dato';
+import { faktiskMålgruppeTilTekst } from '../../Behandling/Felles/faktiskMålgruppe';
+import { aktivitetTypeTilTekst } from '../../Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet';
+import { studienivåTilTekst } from '../../Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
+
+interface Props {
+    vedtaksperioder: DetaljertVedtaksperiodeLæremidler[];
+}
+
+export const VedtaksperioderOversiktLæremidler: React.FC<Props> = ({ vedtaksperioder }) => {
+    return (
+        <OversiktKort tittel={'Læremidler'}>
+            <Table size={'small'}>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell scope="col">Fra</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Til</Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'center'}>
+                            Ant.mnd
+                        </Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Målgruppe</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Nivå</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Prosent</Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'right'}>
+                            Månedsbeløp
+                        </Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {vedtaksperioder.map((periode) => {
+                        return (
+                            <Table.Row key={periode.fom}>
+                                <Table.DataCell>
+                                    {formaterNullableIsoDato(periode.fom)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterNullableIsoDato(periode.tom)}
+                                </Table.DataCell>
+                                <Table.DataCell align={'center'}>
+                                    {periode.antallMåneder}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {aktivitetTypeTilTekst(periode.aktivitet)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {faktiskMålgruppeTilTekst(periode.målgruppe)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {studienivåTilTekst[periode.studienivå]}
+                                </Table.DataCell>
+                                <Table.DataCell align={'right'}>
+                                    {periode.studieprosent}%
+                                </Table.DataCell>
+                                <Table.DataCell align={'right'}>
+                                    {periode.månedsbeløp} kr
+                                </Table.DataCell>
+                            </Table.Row>
+                        );
+                    })}
+                </Table.Body>
+            </Table>
+        </OversiktKort>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktTilsynBarn.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktTilsynBarn.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+
+import { Table } from '@navikt/ds-react';
+
+import { OversiktKort } from './OversiktKort';
+import { DetaljertVedtaksperiodeTilsynBarn } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
+import { formaterNullableIsoDato } from '../../../utils/dato';
+import { formaterTallMedTusenSkille } from '../../../utils/fomatering';
+import { faktiskMålgruppeTilTekst } from '../../Behandling/Felles/faktiskMålgruppe';
+import { aktivitetTypeTilTekst } from '../../Behandling/Inngangsvilkår/Aktivitet/utilsAktivitet';
+
+interface Props {
+    vedtaksperioder: DetaljertVedtaksperiodeTilsynBarn[];
+}
+
+export const VedtaksperioderOversiktTilsynBarn: React.FC<Props> = ({ vedtaksperioder }) => {
+    return (
+        <OversiktKort tittel={'Tilsyn Barn'}>
+            <Table size={'small'}>
+                <Table.Header>
+                    <Table.Row>
+                        <Table.HeaderCell scope="col">Fra</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Til</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Målgruppe</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Ant. barn</Table.HeaderCell>
+                        <Table.HeaderCell scope="col">Utgifter</Table.HeaderCell>
+                    </Table.Row>
+                </Table.Header>
+                <Table.Body>
+                    {vedtaksperioder.map((periode) => {
+                        return (
+                            <Table.Row key={periode.fom}>
+                                <Table.DataCell>
+                                    {formaterNullableIsoDato(periode.fom)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterNullableIsoDato(periode.tom)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {aktivitetTypeTilTekst(periode.aktivitet)}
+                                </Table.DataCell>
+                                <Table.DataCell>
+                                    {faktiskMålgruppeTilTekst(periode.målgruppe)}
+                                </Table.DataCell>
+                                <Table.DataCell>{periode.antallBarn}</Table.DataCell>
+                                <Table.DataCell>
+                                    {formaterTallMedTusenSkille(periode.totalMånedsUtgift)}
+                                </Table.DataCell>
+                            </Table.Row>
+                        );
+                    })}
+                </Table.Body>
+            </Table>
+        </OversiktKort>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktTilsynBarn.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktTilsynBarn.tsx
@@ -24,7 +24,9 @@ export const VedtaksperioderOversiktTilsynBarn: React.FC<Props> = ({ vedtaksperi
                         <Table.HeaderCell scope="col">Aktivitet</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Målgruppe</Table.HeaderCell>
                         <Table.HeaderCell scope="col">Ant. barn</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Utgifter</Table.HeaderCell>
+                        <Table.HeaderCell scope="col" align={'right'}>
+                            Utgifter
+                        </Table.HeaderCell>
                     </Table.Row>
                 </Table.Header>
                 <Table.Body>
@@ -44,8 +46,8 @@ export const VedtaksperioderOversiktTilsynBarn: React.FC<Props> = ({ vedtaksperi
                                     {faktiskMålgruppeTilTekst(periode.målgruppe)}
                                 </Table.DataCell>
                                 <Table.DataCell>{periode.antallBarn}</Table.DataCell>
-                                <Table.DataCell>
-                                    {formaterTallMedTusenSkille(periode.totalMånedsUtgift)}
+                                <Table.DataCell align={'right'}>
+                                    {formaterTallMedTusenSkille(periode.totalMånedsUtgift)} kr
                                 </Table.DataCell>
                             </Table.Row>
                         );

--- a/src/frontend/hooks/useHentFullstendigVedtaksOversikt.tsx
+++ b/src/frontend/hooks/useHentFullstendigVedtaksOversikt.tsx
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react';
+
+import { useApp } from '../context/AppContext';
+import { byggTomRessurs, Ressurs } from '../typer/ressurs';
+import { VedtakperioderOversiktResponse } from '../typer/vedtak/vedtaksperiodeOppsummering';
+
+export const useHentFullstendigVedtaksOversikt = (
+    fagsakPersonId: string
+): { vedtaksperioderOversikt: Ressurs<VedtakperioderOversiktResponse> } => {
+    const { request } = useApp();
+
+    const [vedtakOversiktResponse, setVedtakOversiktResponse] =
+        useState<Ressurs<VedtakperioderOversiktResponse>>(byggTomRessurs());
+
+    useEffect(() => {
+        request<VedtakperioderOversiktResponse, null>(
+            `/api/sak/vedtak/fullstendig-oversikt/${fagsakPersonId}`
+        ).then(setVedtakOversiktResponse);
+    }, [request, fagsakPersonId]);
+
+    return { vedtaksperioderOversikt: vedtakOversiktResponse };
+};

--- a/src/frontend/hooks/useHentFullstendigVedtaksOversikt.tsx
+++ b/src/frontend/hooks/useHentFullstendigVedtaksOversikt.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
 
 import { useApp } from '../context/AppContext';
+import { ArenaSakOgVedtak } from '../Sider/Personoversikt/Behandlingsoversikt/Arena/vedtakArena';
 import { byggTomRessurs, Ressurs } from '../typer/ressurs';
 import { VedtakperioderOversiktResponse } from '../typer/vedtak/vedtaksperiodeOppsummering';
 
@@ -19,4 +20,20 @@ export const useHentFullstendigVedtaksOversikt = (
     }, [request, fagsakPersonId]);
 
     return { vedtaksperioderOversikt: vedtakOversiktResponse };
+};
+
+export const useVedtaksperioderOversiktArena = (
+    fagsakPersonId: string
+): { arenaSakOgVedtak: Ressurs<ArenaSakOgVedtak> } => {
+    const { request } = useApp();
+
+    const [vedtakArena, settVedtakArena] = useState<Ressurs<ArenaSakOgVedtak>>(byggTomRessurs());
+
+    useEffect(() => {
+        request<ArenaSakOgVedtak, null>(`/api/sak/arena/vedtak/${fagsakPersonId}`).then(
+            settVedtakArena
+        );
+    }, [request, fagsakPersonId]);
+
+    return { arenaSakOgVedtak: vedtakArena };
 };

--- a/src/frontend/typer/vedtak/vedtakBoutgifter.ts
+++ b/src/frontend/typer/vedtak/vedtakBoutgifter.ts
@@ -6,6 +6,22 @@ import { AktivitetType } from '../../Sider/Behandling/Inngangsvilkår/typer/vilk
 
 export type VedtakBoutgifter = InnvilgelseBoutgifter | AvslagBoutgifter | OpphørBoutgifter;
 
+export enum TypeBoutgift {
+    UTGIFTER_OVERNATTING = 'UTGIFTER_OVERNATTING',
+    LØPENDE_UTGIFTER_EN_BOLIG = 'LØPENDE_UTGIFTER_EN_BOLIG',
+    LØPENDE_UTGIFTER_TO_BOLIGER = 'LØPENDE_UTGIFTER_TO_BOLIGER',
+}
+
+export const TypeboutgiftTilTekst: Record<TypeBoutgift, string> = {
+    UTGIFTER_OVERNATTING: 'Overnatting',
+    LØPENDE_UTGIFTER_EN_BOLIG: 'Løpende',
+    LØPENDE_UTGIFTER_TO_BOLIGER: 'Løpende',
+};
+
+export const typeBoutgiftTilTekst = (type: TypeBoutgift) => {
+    return TypeboutgiftTilTekst[type];
+};
+
 export const vedtakErInnvilgelse = (vedtak: VedtakBoutgifter): vedtak is InnvilgelseBoutgifter =>
     vedtak.type === TypeVedtak.INNVILGELSE;
 

--- a/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
+++ b/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
@@ -1,4 +1,3 @@
-import { TypeBoutgift } from './vedtakBoutgifter';
 import { FaktiskMålgruppe } from '../../Sider/Behandling/Felles/faktiskMålgruppe';
 import { AktivitetType } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet';
 import { Studienivå } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
@@ -33,9 +32,17 @@ export type DetaljertVedtaksperiodeBoutgifter = {
     fom: string;
     tom: string;
     antallMåneder: number;
-    type: TypeBoutgift;
+    erLøpendeUtgift: boolean;
     aktivitet: AktivitetType;
     målgruppe: FaktiskMålgruppe;
-    utgift: number;
-    stønad: number;
+    totalUtgiftMåned: number;
+    stønadsbeløpMnd: number;
+    utgifterTilOvernatting?: UtgiftBoutgift[];
 };
+
+export interface UtgiftBoutgift {
+    fom: string;
+    tom: string;
+    utgift: number;
+    beløpSomDekkes: number;
+}

--- a/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
+++ b/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
@@ -1,3 +1,4 @@
+import { TypeBoutgift } from './vedtakBoutgifter';
 import { FaktiskMålgruppe } from '../../Sider/Behandling/Felles/faktiskMålgruppe';
 import { AktivitetType } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet';
 import { Studienivå } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
@@ -5,6 +6,7 @@ import { Studienivå } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkå
 export interface VedtakperioderOversiktResponse {
     tilsynBarn: DetaljertVedtaksperiodeTilsynBarn[];
     læremidler: DetaljertVedtaksperiodeLæremidler[];
+    boutgifter: DetaljertVedtaksperiodeBoutgifter[];
 }
 
 export type DetaljertVedtaksperiodeTilsynBarn = {
@@ -25,4 +27,15 @@ export type DetaljertVedtaksperiodeLæremidler = {
     studienivå: Studienivå;
     studieprosent: number;
     månedsbeløp: number;
+};
+
+export type DetaljertVedtaksperiodeBoutgifter = {
+    fom: string;
+    tom: string;
+    antallMåneder: number;
+    type: TypeBoutgift;
+    aktivitet: AktivitetType;
+    målgruppe: FaktiskMålgruppe;
+    utgift: number;
+    stønad: number;
 };

--- a/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
+++ b/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
@@ -1,8 +1,10 @@
 import { FaktiskMålgruppe } from '../../Sider/Behandling/Felles/faktiskMålgruppe';
 import { AktivitetType } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet';
+import { Studienivå } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
 
 export interface VedtakperioderOversiktResponse {
     tilsynBarn: DetaljertVedtaksperiodeTilsynBarn[];
+    læremidler: DetaljertVedtaksperiodeLæremidler[];
 }
 
 export type DetaljertVedtaksperiodeTilsynBarn = {
@@ -12,4 +14,15 @@ export type DetaljertVedtaksperiodeTilsynBarn = {
     målgruppe: FaktiskMålgruppe;
     antallBarn: number;
     totalMånedsUtgift: number;
+};
+
+export type DetaljertVedtaksperiodeLæremidler = {
+    fom: string;
+    tom: string;
+    antallMåneder: number;
+    aktivitet: AktivitetType;
+    målgruppe: FaktiskMålgruppe;
+    studienivå: Studienivå;
+    studieprosent: number;
+    månedsbeløp: number;
 };

--- a/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
+++ b/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
@@ -1,0 +1,15 @@
+import { FaktiskMålgruppe } from '../../Sider/Behandling/Felles/faktiskMålgruppe';
+import { AktivitetType } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet';
+
+export interface VedtakperioderOversiktResponse {
+    tilsynBarn: DetaljertVedtaksperiodeTilsynBarn[];
+}
+
+export type DetaljertVedtaksperiodeTilsynBarn = {
+    fom: string;
+    tom: string;
+    aktivitet: AktivitetType;
+    målgruppe: FaktiskMålgruppe;
+    antallBarn: number;
+    totalMånedsUtgift: number;
+};

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -22,4 +22,5 @@ export enum Toggle {
      */
     TILLATER_NULLVEDAK = `sak.tillater_nullvedtak`,
     SKAL_VISE_DETALJERT_BEREGNINGSRESULTAT = `sak.detaljert_beregningsresultat`,
+    SKAL_VISE_VEDTAKSPERIODER_TAB = `sak.frontend.skal-vise-vedtaksperiode-tab`,
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

- Legger til tab for vedtaksperioder. 
- Fjerner TS-Arena tab
- Re-namer Ytelser -> Andre ytelser

**Alt ligger bak bryter.**

_Note:
Dersom det er overnatting vil fom og tom være perioden for utgiften._

**Vedtaksperioder alle stønader:**
![Screenshot 2025-05-13 at 12 18 22](https://github.com/user-attachments/assets/bf8ee10b-3af1-4f3b-8521-285a7cbc579e)

**Oversikt over boutgifter overnatting:**
![Screenshot 2025-05-13 at 13 10 59](https://github.com/user-attachments/assets/5b54a586-4a75-4397-be73-4211bbb0e03a)

Dersom bryteren er av ser det slik ut: 
![Screenshot 2025-05-13 at 13 18 35](https://github.com/user-attachments/assets/075a5392-2797-40f1-8397-fe7cec2d699e)

