### PR TITLE
Utbetaling tabell i brev

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatContainer.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatContainer.tsx
@@ -15,7 +15,7 @@ const BeregningsresultatContainer: React.FC<{
     );
 
     const skalBrukeDetaljertVisning = () =>
-        skalViseDetaljertBeregningsresultat && beregningsresultat.skalBrukeDetaljertVisning;
+        skalViseDetaljertBeregningsresultat && beregningsresultat.inneholderUtgifterOvernatting;
 
     return skalBrukeDetaljertVisning() ? (
         <BeregningsresultatMedUtgift beregningsresultat={beregningsresultat} />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatContainer.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatContainer.tsx
@@ -4,10 +4,7 @@ import { useFlag } from '@unleash/proxy-client-react';
 
 import Beregningsresultat from './Beregningsresultat';
 import BeregningsresultatMedUtgift from './BeregningsresultatMedUtgift';
-import {
-    BeregningsresultatBoutgifter,
-    BeregningsresultatUtgifterKeys,
-} from '../../../../../typer/vedtak/vedtakBoutgifter';
+import { BeregningsresultatBoutgifter } from '../../../../../typer/vedtak/vedtakBoutgifter';
 import { Toggle } from '../../../../../utils/toggles';
 
 const BeregningsresultatContainer: React.FC<{
@@ -18,10 +15,7 @@ const BeregningsresultatContainer: React.FC<{
     );
 
     const skalBrukeDetaljertVisning = () =>
-        skalViseDetaljertBeregningsresultat &&
-        beregningsresultat.perioder.some(
-            (periode) => periode.utgifter[BeregningsresultatUtgifterKeys.UTGIFTER_OVERNATTING]
-        );
+        skalViseDetaljertBeregningsresultat && beregningsresultat.skalBrukeDetaljertVisning;
 
     return skalBrukeDetaljertVisning() ? (
         <BeregningsresultatMedUtgift beregningsresultat={beregningsresultat} />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatMedUtgift.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatMedUtgift.tsx
@@ -47,19 +47,17 @@ const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => (
                             <Table.DataCell>{periode.sumUtgifter}</Table.DataCell>
                             <Table.DataCell>{periode.stønadsbeløp}</Table.DataCell>
                         </TableRow>
-                        {Object.values(periode.utgifter)
-                            .flat()
-                            .map((utgift, index, utgifter) => (
-                                <TableRowGray
-                                    key={utgift.fom + utgift.tom}
-                                    borderbottom={index === utgifter.length - 1}
-                                >
-                                    <Table.DataCell />
-                                    <Table.DataCell>{`${formaterIsoDato(utgift.fom)} - ${formaterIsoDato(utgift.tom)}`}</Table.DataCell>
-                                    <Table.DataCell>{utgift.utgift}</Table.DataCell>
-                                    <Table.DataCell />
-                                </TableRowGray>
-                            ))}
+                        {periode.utgifter.map((utgift, index, utgifter) => (
+                            <TableRowGray
+                                key={utgift.fom + utgift.tom}
+                                borderbottom={index === utgifter.length - 1}
+                            >
+                                <Table.DataCell />
+                                <Table.DataCell>{`${formaterIsoDato(utgift.fom)} - ${formaterIsoDato(utgift.tom)}`}</Table.DataCell>
+                                <Table.DataCell>{utgift.utgift}</Table.DataCell>
+                                <Table.DataCell>{utgift.tilUtbetaling}</Table.DataCell>
+                            </TableRowGray>
+                        ))}
                     </React.Fragment>
                 ))}
             </Table.Header>

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatMedUtgift.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatMedUtgift.tsx
@@ -47,7 +47,7 @@ const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => (
                             <Table.DataCell>{periode.sumUtgifter}</Table.DataCell>
                             <Table.DataCell>{periode.stønadsbeløp}</Table.DataCell>
                         </TableRow>
-                        {periode.utgifter.map((utgift, index, utgifter) => (
+                        {periode.utgifterTilUtbetaling.map((utgift, index, utgifter) => (
                             <TableRowGray
                                 key={utgift.fom + utgift.tom}
                                 borderbottom={index === utgifter.length - 1}

--- a/src/frontend/komponenter/Brev/Brevmeny.tsx
+++ b/src/frontend/komponenter/Brev/Brevmeny.tsx
@@ -1,5 +1,6 @@
 import React, { SetStateAction, useEffect, useMemo, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 import { useDebouncedCallback } from 'use-debounce';
 
@@ -15,6 +16,7 @@ import { usePersonopplysninger } from '../../context/PersonopplysningerContext';
 import { Behandling } from '../../typer/behandling/behandling';
 import { Ressurs } from '../../typer/ressurs';
 import { VedtakResponse } from '../../typer/vedtak/vedtak';
+import { Toggle } from '../../utils/toggles';
 
 type Props = {
     mal: MalStruktur;
@@ -86,6 +88,10 @@ const Brevmeny: React.FC<Props> = ({
         mellomlagredeVariabler,
     } = useMemo(() => parseMellomlagretBrev(mellomlagretBrev), [mellomlagretBrev]);
 
+    const skalViseDetaljertBeregningsresultatFlag = useFlag(
+        Toggle.SKAL_VISE_DETALJERT_BEREGNINGSRESULTAT
+    );
+
     const [valgfelt, settValgfelt] = useState<
         Partial<Record<string, Record<Valgfelt['_id'], Valg>>>
     >(mellomlagredeValgfelt || {});
@@ -147,7 +153,11 @@ const Brevmeny: React.FC<Props> = ({
                 mal: mal,
                 valgfelt: valgfelt,
                 variabler: variabler,
-                htmlVariabler: lagVedtakstabell(behandling, vedtak),
+                htmlVariabler: lagVedtakstabell(
+                    behandling,
+                    vedtak,
+                    skalViseDetaljertBeregningsresultatFlag
+                ),
                 inkluderBeslutterSignaturPlaceholder: !!behandlingId,
             }),
         }).then(settFil);

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabell.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabell.ts
@@ -18,7 +18,8 @@ const TOM_VEDTAKSTABELL = {};
  */
 export const lagVedtakstabell = (
     behandling: Behandling | undefined,
-    vedtak: VedtakResponse | undefined
+    vedtak: VedtakResponse | undefined,
+    skalViseDetaljertBeregningsresultatFlag: boolean
 ): LagVedtakstabell => {
     if (!behandling || !vedtak) {
         return TOM_VEDTAKSTABELL;
@@ -38,7 +39,8 @@ export const lagVedtakstabell = (
             );
         case Stønadstype.BOUTGIFTER:
             return lagVedtakstabellBoutgifter(
-                vedtak.beregningsresultat as BeregningsresultatBoutgifter
+                vedtak.beregningsresultat as BeregningsresultatBoutgifter,
+                skalViseDetaljertBeregningsresultatFlag
             );
         default:
             return TOM_VEDTAKSTABELL;

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -50,7 +50,8 @@ const lagRaderForVedtakMidlertidigOvernatting = (
                     lagRadForVedtak(
                         { fom: utgift.fom, tom: utgift.tom },
                         utgift.utgift,
-                        utgift.tilUtbetaling
+                        utgift.tilUtbetaling,
+                        periode.makssatsBekreftet
                     )
                 )
                 .join('')
@@ -65,20 +66,32 @@ const lagRaderForVedtakLøpendeUtgifter = (
         return '';
     }
     return beregningsresultat.perioder
-        .map((periode) => lagRadForVedtak(periode, periode.sumUtgifter, periode.stønadsbeløp))
+        .map((periode) =>
+            lagRadForVedtak(
+                periode,
+                periode.sumUtgifter,
+                periode.stønadsbeløp,
+                periode.makssatsBekreftet
+            )
+        )
         .join('');
 };
 
-const lagRadForVedtak = (datoperiode: Periode, merutgift: number, stønadsbeløp: number) => {
+const lagRadForVedtak = (
+    datoperiode: Periode,
+    merutgift: number,
+    stønadsbeløp: number,
+    makssatsBekreftet: boolean
+) => {
     const datoperiodeString = formaterIsoPeriodeMedTankestrek(datoperiode);
     const merutgiftString = formaterTallMedTusenSkille(merutgift);
     const stønadsbeløpString = formaterTallMedTusenSkille(stønadsbeløp);
     // const stjernemerktRad = periode.delAvTidligereUtbetaling ? '*' : '';
-    // const asteriksForSatsendring = periode.makssatsBekreftet ? '' : '*';
+    const asteriksForSatsendring = makssatsBekreftet ? '' : '*';
 
     return `<tr style="text-align: right;">
                         <td style="text-align: left; ${borderStylingCompact}">${datoperiodeString}</td>
                         <td style="${borderStyling}">${merutgiftString} kr</td>
-                        <td style="${borderStyling}">${stønadsbeløpString} kr</td>
+                        <td style="${borderStyling}">${stønadsbeløpString} kr${asteriksForSatsendring}</td>
                     </tr>`;
 };

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -22,7 +22,7 @@ const lagBeregningstabell = (
                     <tr>
                         <th style="width: 270px; word-wrap: break-word; ${borderStylingCompact}">Periode</th>
                         <th style="width: 120px; word-wrap: break-word; ${borderStylingCompact}">Merutgift</th>
-                        <th style="width: 120px; word-wrap: break-word; ${borderStylingCompact}">Beløpet du får</th>
+                        <th style="width: 120px; word-wrap: break-word; ${borderStylingCompact}">Stønadsbeløp</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -36,18 +36,26 @@ const lagRaderForVedtak = (beregningsresultat?: BeregningsresultatBoutgifter): s
         return '';
     }
     return beregningsresultat.perioder
-        .map((periode) => {
-            const datoperiode = formaterIsoPeriodeMedTankestrek(periode);
-            const merutgift = formaterTallMedTusenSkille(periode.sumUtgifter);
-            const stønadsbeløp = formaterTallMedTusenSkille(periode.stønadsbeløp);
-            // const stjernemerktRad = periode.delAvTidligereUtbetaling ? '*' : '';
-            const asteriksForSatsendring = periode.makssatsBekreftet ? '' : '*';
+        .map((periode) =>
+            periode.utgifter
+                .filter((utgift) => !utgift.erFørRevurderFra)
+                .map((utgift) => {
+                    const datoperiode = formaterIsoPeriodeMedTankestrek({
+                        fom: utgift.fom,
+                        tom: utgift.tom,
+                    });
+                    const merutgift = formaterTallMedTusenSkille(utgift.utgift);
+                    const stønadsbeløp = formaterTallMedTusenSkille(utgift.tilUtbetaling);
+                    // const stjernemerktRad = periode.delAvTidligereUtbetaling ? '*' : '';
+                    // const asteriksForSatsendring = periode.makssatsBekreftet ? '' : '*';
 
-            return `<tr style="text-align: right;">
+                    return `<tr style="text-align: right;">
                         <td style="text-align: left; ${borderStylingCompact}">${datoperiode}</td>
                         <td style="${borderStyling}">${merutgift} kr</td>
-                        <td style="${borderStyling}">${stønadsbeløp} kr${asteriksForSatsendring}</td>
+                        <td style="${borderStyling}">${stønadsbeløp} kr</td>
                     </tr>`;
-        })
-        .join('');
+                })
+        )
+        .join('')
+        .replaceAll(',', '');
 };

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -8,15 +8,20 @@ const borderStylingCompact = 'border: 1px solid black; padding: 3px 2px 3px 5px;
 const borderStyling = 'border: 1px solid black; padding: 3px 10px 3px 5px;';
 
 export const lagVedtakstabellBoutgifter = (
-    beregningsresultat: BeregningsresultatBoutgifter | undefined
+    beregningsresultat: BeregningsresultatBoutgifter | undefined,
+    skalViseDetaljertBeregningsresultatFlag: boolean
 ) => {
     return {
-        [variabelBeregningstabellId]: lagBeregningstabell(beregningsresultat),
+        [variabelBeregningstabellId]: lagBeregningstabell(
+            beregningsresultat,
+            skalViseDetaljertBeregningsresultatFlag
+        ),
     };
 };
 
 const lagBeregningstabell = (
-    beregningsresultat: BeregningsresultatBoutgifter | undefined
+    beregningsresultat: BeregningsresultatBoutgifter | undefined,
+    skalViseDetaljertBeregningsresultatFlag: boolean
 ): string => {
     return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
@@ -28,18 +33,14 @@ const lagBeregningstabell = (
                 </thead>
                 <tbody>
                ${
+                   skalViseDetaljertBeregningsresultatFlag &&
                    beregningsresultat?.inneholderUtgifterOvernatting
                        ? lagRaderForVedtakMidlertidigOvernatting(beregningsresultat)
                        : lagRaderForVedtakLøpendeUtgifter(beregningsresultat)
                }
                 </tbody>
             </table>
-            ${
-                skalHaTekstForBegrensetAvMakssats(beregningsresultat) &&
-                `<p style="margin-left: 2px; margin-right: 2px; margin-top: 1px; padding: 0;">
-                    * beløpet er begrenset av makssats
-                </p>`
-            }
+            ${lagTekstForBegrensetAvMakssats(skalViseDetaljertBeregningsresultatFlag, beregningsresultat)}
             `;
 };
 
@@ -107,7 +108,21 @@ const lagRadForVedtak = (
                     </tr>`;
 };
 
-const skalHaTekstForBegrensetAvMakssats = (beregningsresultat?: BeregningsresultatBoutgifter) =>
+const lagTekstForBegrensetAvMakssats = (
+    skalViseDetaljertBeregningsresultatFlag: boolean,
+    beregningsresultat?: BeregningsresultatBoutgifter
+) =>
+    skalHaTekstForBegrensetAvMakssats(skalViseDetaljertBeregningsresultatFlag, beregningsresultat)
+        ? `<p style="margin-left: 2px; margin-right: 2px; margin-top: 1px; padding: 0;">
+                    * beløpet er begrenset av makssats
+                </p>`
+        : '';
+
+const skalHaTekstForBegrensetAvMakssats = (
+    skalViseDetaljertBeregningsresultatFlag: boolean,
+    beregningsresultat?: BeregningsresultatBoutgifter
+) =>
+    skalViseDetaljertBeregningsresultatFlag &&
     beregningsresultat?.inneholderUtgifterOvernatting &&
     beregningsresultat.perioder.some((periode) =>
         periode.utgifterTilUtbetaling.some((utgift) => utgift.tilUtbetaling < utgift.utgift)

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -37,7 +37,7 @@ const lagRaderForVedtak = (beregningsresultat?: BeregningsresultatBoutgifter): s
     }
     return beregningsresultat.perioder
         .map((periode) =>
-            periode.utgifter
+            periode.utgifterTilUtbetaling
                 .filter((utgift) => !utgift.erFørRevurderFra)
                 .map((utgift) => {
                     const datoperiode = formaterIsoPeriodeMedTankestrek({

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -53,9 +53,9 @@ const lagRaderForVedtakMidlertidigOvernatting = (
                         utgift.tilUtbetaling
                     )
                 )
+                .join('')
         )
-        .join('')
-        .replaceAll(',', '');
+        .join('');
 };
 
 const lagRaderForVedtakLøpendeUtgifter = (

--- a/src/frontend/typer/vedtak/vedtakBoutgifter.ts
+++ b/src/frontend/typer/vedtak/vedtakBoutgifter.ts
@@ -1,8 +1,6 @@
 import { TypeVedtak, ÅrsakAvslag } from './vedtak';
 import { Vedtaksperiode } from './vedtakperiode';
 import { OpphørRequest } from '../../hooks/useLagreOpphør';
-import { FaktiskMålgruppe } from '../../Sider/Behandling/Felles/faktiskMålgruppe';
-import { AktivitetType } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet';
 
 export type VedtakBoutgifter = InnvilgelseBoutgifter | AvslagBoutgifter | OpphørBoutgifter;
 
@@ -48,6 +46,7 @@ export type BeregnBoutgifterRequest = {
 
 export type BeregningsresultatBoutgifter = {
     perioder: Beregningsresultat[];
+    skalBrukeDetaljertVisning: boolean;
 };
 
 export enum BeregningsresultatUtgifterKeys {
@@ -56,25 +55,20 @@ export enum BeregningsresultatUtgifterKeys {
     LØPENDE_UTGIFTER_TO_BOLIGER = 'LØPENDE_UTGIFTER_TO_BOLIGER',
 }
 
-export type BeregningsresultatUtgifterMap = {
-    [key in BeregningsresultatUtgifterKeys]: BeregningsresultatUtgifter[];
-};
-
 export type BeregningsresultatUtgifter = {
     fom: string;
     tom: string;
     utgift: number;
+    tilUtbetaling: number;
+    erFørRevurderFra: boolean;
 };
 
 type Beregningsresultat = {
-    stønadsbeløp: number;
     fom: string;
     tom: string;
-    utbetalingsdato: string;
+    stønadsbeløp: number;
     sumUtgifter: number;
-    utgifter: BeregningsresultatUtgifterMap;
-    målgruppe: FaktiskMålgruppe;
-    aktivitet: AktivitetType;
+    utgifter: BeregningsresultatUtgifter[];
     makssatsBekreftet: boolean;
     delAvTidligereUtbetaling: boolean;
 };

--- a/src/frontend/typer/vedtak/vedtakBoutgifter.ts
+++ b/src/frontend/typer/vedtak/vedtakBoutgifter.ts
@@ -46,7 +46,7 @@ export type BeregnBoutgifterRequest = {
 
 export type BeregningsresultatBoutgifter = {
     perioder: Beregningsresultat[];
-    skalBrukeDetaljertVisning: boolean;
+    inneholderUtgifterOvernatting: boolean;
 };
 
 export enum BeregningsresultatUtgifterKeys {
@@ -68,7 +68,7 @@ type Beregningsresultat = {
     tom: string;
     stønadsbeløp: number;
     sumUtgifter: number;
-    utgifter: BeregningsresultatUtgifter[];
+    utgifterTilUtbetaling: BeregningsresultatUtgifter[];
     makssatsBekreftet: boolean;
     delAvTidligereUtbetaling: boolean;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker at det skal være tydlig for brukeren hvor mye hen får utbetalt per samling.

Har oppdatert utbetalingstabellen i brevet slik at den viser alle utgifter og hvor stor andel av utgiften som blir utbetalt. 

<img width="548" alt="image" src="https://github.com/user-attachments/assets/a736a717-dede-473f-83a5-424bc396157b" />
