### PR TITLE
Varsel vedtaksperiode før arena vedtak

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -12,8 +12,6 @@ import DataViewer from '../../../../../komponenter/DataViewer';
 import { Feil } from '../../../../../komponenter/Feil/feilmeldingUtils';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
-import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
-import { Steg } from '../../../../../typer/behandling/steg';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '../../../../../typer/ressurs';
 import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakperiode';
 import {
@@ -22,9 +20,9 @@ import {
     InnvilgeBarnetilsynRequest,
     InnvilgelseBarnetilsyn,
 } from '../../../../../typer/vedtak/vedtakTilsynBarn';
-import { FanePath } from '../../../faner';
 import { lenkerBeregningTilsynBarn } from '../../../lenker';
 import { Begrunnelsesfelt } from '../../Felles/Begrunnelsesfelt';
+import { StegKnappInnvilgelseMedVarselOmVedtakIArena } from '../../Felles/StegKnappInnvilgelseMedVarselOmVedtakIArena';
 import { validerVedtaksperioder } from '../../Felles/vedtaksperioder/valideringVedtaksperioder';
 import { Vedtaksperioder } from '../../Felles/vedtaksperioder/Vedtaksperioder';
 import { initialiserVedtaksperioder } from '../../Felles/vedtaksperioder/vedtaksperiodeUtils';
@@ -163,14 +161,10 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({
             {visHarIkkeBeregnetFeilmelding && !erVedtaksperioderBeregnet && (
                 <ErrorMessage>{'Du må beregne før du kan gå videre'}</ErrorMessage>
             )}
-            <StegKnapp
-                steg={Steg.BEREGNE_YTELSE}
-                nesteFane={FanePath.SIMULERING}
-                onNesteSteg={lagreVedtak}
-                validerUlagedeKomponenter={false}
-            >
-                Lagre vedtak og gå videre
-            </StegKnapp>
+            <StegKnappInnvilgelseMedVarselOmVedtakIArena
+                lagreVedtak={lagreVedtak}
+                vedtaksperioder={vedtaksperioder}
+            />
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/InnvilgeBoutgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/InnvilgeBoutgifter.tsx
@@ -12,8 +12,6 @@ import DataViewer from '../../../../../komponenter/DataViewer';
 import { Feil } from '../../../../../komponenter/Feil/feilmeldingUtils';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
-import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
-import { Steg } from '../../../../../typer/behandling/steg';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '../../../../../typer/ressurs';
 import {
     BeregnBoutgifterRequest,
@@ -22,8 +20,8 @@ import {
     InnvilgelseBoutgifter,
 } from '../../../../../typer/vedtak/vedtakBoutgifter';
 import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakperiode';
-import { FanePath } from '../../../faner';
 import { Begrunnelsesfelt } from '../../Felles/Begrunnelsesfelt';
+import { StegKnappInnvilgelseMedVarselOmVedtakIArena } from '../../Felles/StegKnappInnvilgelseMedVarselOmVedtakIArena';
 import { validerVedtaksperioder } from '../../Felles/vedtaksperioder/valideringVedtaksperioder';
 import { Vedtaksperioder } from '../../Felles/vedtaksperioder/Vedtaksperioder';
 import { initialiserVedtaksperioder } from '../../Felles/vedtaksperioder/vedtaksperiodeUtils';
@@ -152,14 +150,10 @@ export const InnvilgeBoutgifter: React.FC<Props> = ({
             {visHarIkkeBeregnetFeilmelding && !erVedtaksperioderBeregnet && (
                 <ErrorMessage>{'Du må beregne før du kan gå videre'}</ErrorMessage>
             )}
-            <StegKnapp
-                steg={Steg.BEREGNE_YTELSE}
-                nesteFane={FanePath.SIMULERING}
-                onNesteSteg={lagreVedtak}
-                validerUlagedeKomponenter={false}
-            >
-                Lagre vedtak og gå videre
-            </StegKnapp>
+            <StegKnappInnvilgelseMedVarselOmVedtakIArena
+                lagreVedtak={lagreVedtak}
+                vedtaksperioder={vedtaksperioder}
+            />
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/StegKnappInnvilgelseMedVarselOmVedtakIArena.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/StegKnappInnvilgelseMedVarselOmVedtakIArena.tsx
@@ -1,0 +1,115 @@
+import React from 'react';
+
+import { useBehandling } from '../../../../context/BehandlingContext';
+import { StegKnapp } from '../../../../komponenter/Stegflyt/StegKnapp';
+import { Behandling } from '../../../../typer/behandling/behandling';
+import { BehandlingFakta } from '../../../../typer/behandling/behandlingFakta/behandlingFakta';
+import { Steg } from '../../../../typer/behandling/steg';
+import { RessursFeilet, RessursSuksess } from '../../../../typer/ressurs';
+import { nullableTilDato, tilDato } from '../../../../utils/dato';
+import { Periode } from '../../../../utils/periode';
+import { FanePath } from '../../faner';
+
+export const StegKnappInnvilgelseMedVarselOmVedtakIArena = ({
+    lagreVedtak,
+    vedtaksperioder,
+}: {
+    vedtaksperioder: Periode[];
+    lagreVedtak: () => Promise<RessursSuksess<unknown> | RessursFeilet>;
+}) => {
+    const { behandling, behandlingFakta } = useBehandling();
+
+    const harVedtaksperioderFørVedtakIArena = finnHarVedtaksperioderFørVedtakIArena(
+        behandling,
+        behandlingFakta,
+        vedtaksperioder
+    );
+
+    const bekreftelseModal = harVedtaksperioderFørVedtakIArena
+        ? {
+              tittel: 'Vedtak i Arena i samme periode',
+              tekst: 'Er du sikker på at det er riktig at det skal være innvilgelse for samme periode som det er innvilget i Arena?',
+              hovedKnapp: {
+                  tekst: 'Angre og endre vedtaksperiode',
+                  skalTriggeGåTilNesteSteg: false,
+              },
+              sekundærKnapp: {
+                  tekst: 'Lagre og gå videre',
+                  skalTriggeGåTilNesteSteg: true,
+              },
+              lukkKnapp: {
+                  tekst: 'Avbryt',
+              },
+          }
+        : undefined;
+    return (
+        <StegKnapp
+            steg={Steg.BEREGNE_YTELSE}
+            nesteFane={FanePath.SIMULERING}
+            onNesteSteg={lagreVedtak}
+            validerUlagedeKomponenter={false}
+            bekreftelseModal={bekreftelseModal}
+        >
+            Lagre vedtak og gå videre
+        </StegKnapp>
+    );
+};
+
+/**
+ * Finnes ut om man har vedtaksperiode før vedtak i Arena.
+ * Dersom det er en revurdering så må man avkorte vedtaksperiodene fra og med revurder fra.
+ */
+const finnHarVedtaksperioderFørVedtakIArena = (
+    behandling: Behandling,
+    behandlingFakta: BehandlingFakta,
+    vedtaksperioder: Periode[]
+): boolean => {
+    const arenaVedtakTom = nullableTilDato(behandlingFakta.arena?.vedtakTom);
+    if (!arenaVedtakTom) {
+        return false;
+    }
+    const førsteDatoEtterRevurderFra = finnFørsteDatoEtterRevurderFra(
+        behandling.revurderFra,
+        vedtaksperioder
+    );
+    return !!førsteDatoEtterRevurderFra && førsteDatoEtterRevurderFra <= arenaVedtakTom;
+};
+
+const finnFørsteDatoEtterRevurderFra = (
+    revurderFra: string | undefined,
+    vedtaksperioder: Periode[]
+): Date | undefined => {
+    const revurderFraDate = nullableTilDato(revurderFra);
+
+    const fraOgMedDatoer = vedtaksperioder
+        .map((periode) => førsteGyldigeDatoForPeriode(periode, revurderFraDate))
+        .filter((d): d is Date => !!d);
+
+    return fraOgMedDatoer.length > 0
+        ? fraOgMedDatoer.reduce((tidligst, dato) => (dato < tidligst ? dato : tidligst))
+        : undefined;
+};
+
+/**
+ * Finner første gyldige dato for periode.
+ * Hvis man ikke har revurderFraDate, returneres fom.
+ * Hvis revurderFraDate er etter tom, returneres undefined fordi vedtaksperioden ikke er aktuell i denne behandlingen
+ * Hvis ikke så avkortes perioden til revurderFraDate.
+ */
+const førsteGyldigeDatoForPeriode = (
+    periode: Periode,
+    revurderFraDate: Date | undefined
+): Date | undefined => {
+    const fom = tilDato(periode.fom);
+    const tom = tilDato(periode.tom);
+
+    if (!revurderFraDate) {
+        return fom;
+    }
+
+    if (tom < revurderFraDate) {
+        return undefined;
+    }
+
+    return fom < revurderFraDate ? revurderFraDate : fom;
+};

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/StegKnappInnvilgelseMedVarselOmVedtakIArena.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/StegKnappInnvilgelseMedVarselOmVedtakIArena.tsx
@@ -10,6 +10,22 @@ import { nullableTilDato, tilDato } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
 import { FanePath } from '../../faner';
 
+const bekreftelseModalProps = {
+    tittel: 'Vedtak i Arena i samme periode',
+    tekst: 'Er du sikker på at det er riktig at det skal være innvilgelse for samme periode som det er innvilget i Arena?',
+    hovedKnapp: {
+        tekst: 'Angre og endre vedtaksperiode',
+        skalTriggeGåTilNesteSteg: false,
+    },
+    sekundærKnapp: {
+        tekst: 'Lagre og gå videre',
+        skalTriggeGåTilNesteSteg: true,
+    },
+    lukkKnapp: {
+        tekst: 'Avbryt',
+    },
+};
+
 export const StegKnappInnvilgelseMedVarselOmVedtakIArena = ({
     lagreVedtak,
     vedtaksperioder,
@@ -25,30 +41,15 @@ export const StegKnappInnvilgelseMedVarselOmVedtakIArena = ({
         vedtaksperioder
     );
 
-    const bekreftelseModal = harVedtaksperioderFørVedtakIArena
-        ? {
-              tittel: 'Vedtak i Arena i samme periode',
-              tekst: 'Er du sikker på at det er riktig at det skal være innvilgelse for samme periode som det er innvilget i Arena?',
-              hovedKnapp: {
-                  tekst: 'Angre og endre vedtaksperiode',
-                  skalTriggeGåTilNesteSteg: false,
-              },
-              sekundærKnapp: {
-                  tekst: 'Lagre og gå videre',
-                  skalTriggeGåTilNesteSteg: true,
-              },
-              lukkKnapp: {
-                  tekst: 'Avbryt',
-              },
-          }
-        : undefined;
     return (
         <StegKnapp
             steg={Steg.BEREGNE_YTELSE}
             nesteFane={FanePath.SIMULERING}
             onNesteSteg={lagreVedtak}
             validerUlagedeKomponenter={false}
-            bekreftelseModal={bekreftelseModal}
+            bekreftelseModalProps={
+                harVedtaksperioderFørVedtakIArena ? bekreftelseModalProps : undefined
+            }
         >
             Lagre vedtak og gå videre
         </StegKnapp>
@@ -68,14 +69,14 @@ const finnHarVedtaksperioderFørVedtakIArena = (
     if (!arenaVedtakTom) {
         return false;
     }
-    const førsteDatoEtterRevurderFra = finnFørsteDatoEtterRevurderFra(
+    const førsteDagIVedtaksperiode = finnFørsteDagIVedtaksperiodeEtterRevurderFra(
         behandling.revurderFra,
         vedtaksperioder
     );
-    return !!førsteDatoEtterRevurderFra && førsteDatoEtterRevurderFra <= arenaVedtakTom;
+    return !!førsteDagIVedtaksperiode && førsteDagIVedtaksperiode <= arenaVedtakTom;
 };
 
-const finnFørsteDatoEtterRevurderFra = (
+const finnFørsteDagIVedtaksperiodeEtterRevurderFra = (
     revurderFra: string | undefined,
     vedtaksperioder: Periode[]
 ): Date | undefined => {

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -12,8 +12,6 @@ import DataViewer from '../../../../../komponenter/DataViewer';
 import { Feil } from '../../../../../komponenter/Feil/feilmeldingUtils';
 import SmallButton from '../../../../../komponenter/Knapper/SmallButton';
 import Panel from '../../../../../komponenter/Panel/Panel';
-import { StegKnapp } from '../../../../../komponenter/Stegflyt/StegKnapp';
-import { Steg } from '../../../../../typer/behandling/steg';
 import { byggHenterRessurs, byggTomRessurs, RessursStatus } from '../../../../../typer/ressurs';
 import { TypeVedtak } from '../../../../../typer/vedtak/vedtak';
 import {
@@ -23,8 +21,8 @@ import {
 } from '../../../../../typer/vedtak/vedtakLæremidler';
 import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakperiode';
 import { Periode } from '../../../../../utils/periode';
-import { FanePath } from '../../../faner';
 import { Begrunnelsesfelt } from '../../Felles/Begrunnelsesfelt';
+import { StegKnappInnvilgelseMedVarselOmVedtakIArena } from '../../Felles/StegKnappInnvilgelseMedVarselOmVedtakIArena';
 import { validerVedtaksperioder } from '../../Felles/vedtaksperioder/valideringVedtaksperioder';
 import { Vedtaksperioder } from '../../Felles/vedtaksperioder/Vedtaksperioder';
 import { initialiserVedtaksperioder } from '../../Felles/vedtaksperioder/vedtaksperiodeUtils';
@@ -140,14 +138,10 @@ export const InnvilgeLæremidler: React.FC<{
             {visHarIkkeBeregnetFeilmelding && !erVedtaksperioderBeregnet && (
                 <ErrorMessage>{'Du må beregne før du kan gå videre'}</ErrorMessage>
             )}
-            <StegKnapp
-                steg={Steg.BEREGNE_YTELSE}
-                nesteFane={FanePath.SIMULERING}
-                onNesteSteg={lagreVedtak}
-                validerUlagedeKomponenter={false}
-            >
-                Lagre vedtak og gå videre
-            </StegKnapp>
+            <StegKnappInnvilgelseMedVarselOmVedtakIArena
+                lagreVedtak={lagreVedtak}
+                vedtaksperioder={vedtaksperioder}
+            />
         </>
     );
 };

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -24,14 +24,14 @@ export const StegKnapp: FC<{
     steg: Steg;
     onNesteSteg?: () => Promise<RessursSuksess<unknown> | RessursFeilet>;
     validerUlagedeKomponenter?: boolean;
-    bekreftelseModal?: StegBekreftelseModal;
+    bekreftelseModalProps?: StegBekreftelseModal;
     children: React.ReactNode;
 }> = ({
     nesteFane,
     steg,
     onNesteSteg,
     validerUlagedeKomponenter = true,
-    bekreftelseModal,
+    bekreftelseModalProps,
     children,
 }) => {
     const navigate = useNavigateUtenSjekkForUlagredeKomponenter();
@@ -112,7 +112,7 @@ export const StegKnapp: FC<{
             {behandling.steg === steg && erStegRedigerbart && (
                 <>
                     <StegKnappBekreftelsesModal
-                        modalProps={bekreftelseModal}
+                        modalProps={bekreftelseModalProps}
                         gåTilNesteSteg={gåTilNesteSteg}
                         visModal={visModal}
                         settVisModal={settVisModal}
@@ -121,7 +121,7 @@ export const StegKnapp: FC<{
                         variant="primary"
                         size="small"
                         onClick={() => {
-                            if (bekreftelseModal) {
+                            if (bekreftelseModalProps) {
                                 settVisModal(true);
                             } else {
                                 gåTilNesteSteg();

--- a/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnapp.tsx
@@ -2,6 +2,7 @@ import React, { FC, useEffect, useState } from 'react';
 
 import { Button, VStack } from '@navikt/ds-react';
 
+import { StegBekreftelseModal, StegKnappBekreftelsesModal } from './StegKnappBekreftelsesModal';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
 import { useSteg } from '../../context/StegContext';
@@ -23,8 +24,16 @@ export const StegKnapp: FC<{
     steg: Steg;
     onNesteSteg?: () => Promise<RessursSuksess<unknown> | RessursFeilet>;
     validerUlagedeKomponenter?: boolean;
+    bekreftelseModal?: StegBekreftelseModal;
     children: React.ReactNode;
-}> = ({ nesteFane, steg, onNesteSteg, validerUlagedeKomponenter = true, children }) => {
+}> = ({
+    nesteFane,
+    steg,
+    onNesteSteg,
+    validerUlagedeKomponenter = true,
+    bekreftelseModal,
+    children,
+}) => {
     const navigate = useNavigateUtenSjekkForUlagredeKomponenter();
     const { request, harUlagradeKomponenter } = useApp();
 
@@ -32,6 +41,7 @@ export const StegKnapp: FC<{
     const { erStegRedigerbart } = useSteg();
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<Feil | undefined>();
+    const [visModal, settVisModal] = useState<boolean>(false);
 
     useEffect(() => {
         if (!harUlagradeKomponenter && feilmelding?.feilmelding === feilmeldingUlagretData) {
@@ -100,9 +110,28 @@ export const StegKnapp: FC<{
         <VStack align="start" gap="4">
             <Feilmelding feil={feilmelding} />
             {behandling.steg === steg && erStegRedigerbart && (
-                <Button variant="primary" size="small" onClick={gåTilNesteSteg} disabled={laster}>
-                    {children}
-                </Button>
+                <>
+                    <StegKnappBekreftelsesModal
+                        modalProps={bekreftelseModal}
+                        gåTilNesteSteg={gåTilNesteSteg}
+                        visModal={visModal}
+                        settVisModal={settVisModal}
+                    />
+                    <Button
+                        variant="primary"
+                        size="small"
+                        onClick={() => {
+                            if (bekreftelseModal) {
+                                settVisModal(true);
+                            } else {
+                                gåTilNesteSteg();
+                            }
+                        }}
+                        disabled={laster}
+                    >
+                        {children}
+                    </Button>
+                </>
             )}
             {stegErEtterAnnetSteg(behandling.steg, steg) && (
                 <Button variant="secondary" size="small" onClick={redigerSteg} disabled={laster}>

--- a/src/frontend/komponenter/Stegflyt/StegKnappBekreftelsesModal.tsx
+++ b/src/frontend/komponenter/Stegflyt/StegKnappBekreftelsesModal.tsx
@@ -1,0 +1,71 @@
+import React from 'react';
+
+import { ModalWrapper } from '../Modal/ModalWrapper';
+
+export interface StegBekreftelseModal {
+    tittel: string;
+    tekst: string;
+    hovedKnapp: {
+        skalTriggeGåTilNesteSteg: boolean;
+        tekst: string;
+    };
+    sekundærKnapp?: {
+        skalTriggeGåTilNesteSteg: boolean;
+        tekst: string;
+    };
+    lukkKnapp: {
+        tekst: string;
+    };
+}
+
+export const StegKnappBekreftelsesModal = ({
+    modalProps,
+    gåTilNesteSteg,
+    visModal,
+    settVisModal,
+}: {
+    modalProps: StegBekreftelseModal | undefined;
+    gåTilNesteSteg: () => void;
+    visModal: boolean;
+    settVisModal: (visModal: boolean) => void;
+}) => {
+    if (!modalProps) {
+        return null;
+    }
+    const { tittel, tekst, hovedKnapp, sekundærKnapp, lukkKnapp } = modalProps;
+    return (
+        <ModalWrapper
+            visModal={visModal}
+            tittel={tittel}
+            onClose={() => settVisModal(false)}
+            aksjonsknapper={{
+                hovedKnapp: {
+                    tekst: hovedKnapp.tekst,
+                    onClick: () => {
+                        if (hovedKnapp.skalTriggeGåTilNesteSteg) {
+                            gåTilNesteSteg();
+                        }
+                        settVisModal(false);
+                    },
+                },
+                sekundærKnapp: sekundærKnapp
+                    ? {
+                          tekst: sekundærKnapp.tekst,
+                          onClick: () => {
+                              if (sekundærKnapp.skalTriggeGåTilNesteSteg) {
+                                  gåTilNesteSteg();
+                              }
+                              settVisModal(false);
+                          },
+                      }
+                    : undefined,
+                lukkKnapp: {
+                    tekst: lukkKnapp.tekst,
+                    onClick: () => settVisModal(false),
+                },
+            }}
+        >
+            {tekst}
+        </ModalWrapper>
+    );
+};


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Hvis man har et vedtaksperioder som begynner før vedtak i Arena slutter så er det ønskelig med en bekreftelsesmodal for saksbehandler.
Modalen er lagt til i `StegKnapp` for å kunne håndtere `gåTilNesteSteg` i `StegKnapp` som gjør diverse saker. 

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24238

<img width="698" alt="image" src="https://github.com/user-attachments/assets/80c7c0a3-3ada-4deb-94ab-e5db20098003" />


