### PR TITLE
Viser mnd og år for simulering

### DIFF
--- a/src/frontend/Sider/Behandling/Simulering/SimuleringResultatWrapper.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/SimuleringResultatWrapper.tsx
@@ -10,7 +10,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import DataViewer from '../../../komponenter/DataViewer';
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
 import { VedtakResponse } from '../../../typer/vedtak/vedtak';
-import { formaterDato } from '../../../utils/dato';
+import { formaterÅrFullMåned } from '../../../utils/dato';
 
 const SimuleringResultatWrapper: React.FC<{ vedtak: VedtakResponse }> = ({ vedtak }) => {
     const { behandling, hentBehandling } = useBehandling();
@@ -46,7 +46,7 @@ const SimuleringResultatWrapper: React.FC<{ vedtak: VedtakResponse }> = ({ vedta
                 return perioder && oppsummering ? (
                     <>
                         <Heading size={'medium'}>
-                            {`Simulering for perioden ${formaterDato(oppsummering.fom)} - ${formaterDato(oppsummering.tom)}`}
+                            {`Simulering for perioden ${formaterÅrFullMåned(oppsummering.fom)} - ${formaterÅrFullMåned(oppsummering.tom)}`}
                         </Heading>
                         <Oppsumering oppsummering={oppsummering} />
                         <SimuleringTabell perioder={perioder} />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Endrer titelen til å vise måned og år for å tydeliggjøre at:
 - Simuleringen kan gå over flere år
 - Hindre forvirring dersom man simulerer fra en dato som er midt i en måned.
 
 **Ny titel**
![Screenshot 2025-05-22 at 12 07 24](https://github.com/user-attachments/assets/582a3828-6e8e-48e0-a75e-9a68956b45ab)

[Oppgave i favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-25226)
