### PR TITLE
Viser alltid knappen for fullfør på underkjennelse, med feltvalidering

### DIFF
--- a/src/frontend/komponenter/Feil/Feilmelding.tsx
+++ b/src/frontend/komponenter/Feil/Feilmelding.tsx
@@ -27,7 +27,7 @@ export const Feilmelding = React.forwardRef<HTMLDivElement | HTMLParagraphElemen
                 {feil.tittel && <Label size="small">{feil.tittel}</Label>}
 
                 <BodyShort size="small">{feil.feilmelding}</BodyShort>
-                <HStack align="center">
+                <HStack align="center" wrap={false}>
                     {feil.feilkode && <Detail>Feilkode: {feil.feilkode}</Detail>}
                     {feil.feilmeldingMedFeilkode && (
                         <CopyButton copyText={feil.feilmeldingMedFeilkode} size="small" />


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Liten fiks på at man alltid viser knappen for fullfør på totrinnskontroll når man underkjenner. 
Skjemaet har også fått feltvalidering for å hindre at man sender inn tom årsak og begrunnelse. 

[Oppgave i Favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-25116)

**Før:**
<img width="312" alt="image (3)" src="https://github.com/user-attachments/assets/d4998905-430b-479b-acea-0f4df966bb0c" />

**Etter:**
![Screenshot 2025-05-22 at 14 49 43](https://github.com/user-attachments/assets/a9230f6d-83b6-4912-839f-fd9c213f0d12)

**Feltvalidering**
![Screenshot 2025-05-22 at 14 49 48](https://github.com/user-attachments/assets/06bdc097-fea3-49b3-9a83-6a201c11e376)
![Screenshot 2025-05-22 at 14 49 54](https://github.com/user-attachments/assets/290674af-eb46-4800-941d-06b356f2fb4d)

**Feilmelding fra back-end**
![Screenshot 2025-05-22 at 14 50 58](https://github.com/user-attachments/assets/37031f43-1935-4700-9c02-f055b48428d6)
