### PR TITLE
Hjelpetekster boutgifter

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/DelvilkårRadioknapper.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/DelvilkårRadioknapper.tsx
@@ -64,13 +64,16 @@ const DelvilkårRadioknapper: FC<Props> = ({
 };
 
 const Spørsmålsbeskrivelse = (regelId: string): React.ReactNode => {
-    if (regelId === 'UTGIFTER_DOKUMENTERT' || regelId === 'NØDVENDIGE_MERUTGIFTER') {
-        return <SlikGjørDuVurderingen regelId={regelId} />;
+    switch (regelId) {
+        case 'UTGIFTER_DOKUMENTERT':
+        case 'NØDVENDIGE_MERUTGIFTER':
+        case 'NØDVENDIG_Å_BO_NÆRMERE_AKTIVITET':
+            return <SlikGjørDuVurderingen regelId={regelId} />;
+        case 'HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER':
+            return <Detail>Skal søker få dekket faktiske utgifter?</Detail>;
+        default:
+            return null;
     }
-    if (regelId === 'HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER') {
-        return <Detail>Skal søker få dekket faktiske utgifter?</Detail>;
-    }
-    return null;
 };
 
 export default DelvilkårRadioknapper;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/DelvilkårRadioknapper.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/DelvilkårRadioknapper.tsx
@@ -64,14 +64,13 @@ const DelvilkårRadioknapper: FC<Props> = ({
 };
 
 const Spørsmålsbeskrivelse = (regelId: string): React.ReactNode => {
-    switch (regelId) {
-        case 'UTGIFTER_DOKUMENTERT':
-            return <SlikGjørDuVurderingen regelId={regelId} />;
-        case 'HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER':
-            return <Detail>Skal søker få dekket faktiske utgifter?</Detail>;
-        default:
-            return null;
+    if (regelId === 'UTGIFTER_DOKUMENTERT' || regelId === 'NØDVENDIGE_MERUTGIFTER') {
+        return <SlikGjørDuVurderingen regelId={regelId} />;
     }
+    if (regelId === 'HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER') {
+        return <Detail>Skal søker få dekket faktiske utgifter?</Detail>;
+    }
+    return null;
 };
 
 export default DelvilkårRadioknapper;

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreErFremtidigUtgift.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreErFremtidigUtgift.tsx
@@ -26,7 +26,7 @@ const EndreErFremtidigUtgift: React.FC<{
             {vilkårtype === StønadsvilkårType.UTGIFTER_OVERNATTING && kanVæreFremtidigUtgift && (
                 <StyledSwitch
                     size={'small'}
-                    checked={erFremtidigUtgift}
+                    checked={erFremtidigUtgift ?? false}
                     onChange={(e) => oppdaterErFremtidigUtgift(e.target.checked)}
                 >
                     Fremtidig utgift

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreUtgift.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreUtgift.tsx
@@ -1,11 +1,13 @@
 import React from 'react';
 
+import { HelpText, HStack } from '@navikt/ds-react';
+
 import TextField from '../../../../komponenter/Skjema/TextField';
 import { FeilmeldingMaksBredde } from '../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { harTallverdi, tilHeltall } from '../../../../utils/tall';
 import { fjernSpaces } from '../../../../utils/utils';
 import { StønadsvilkårType } from '../../vilkår';
-import { vilkårTypeTilUtgiftTekst } from '../tekster';
+import { vilkårTypeTilUtgiftHjelpeTekst, vilkårTypeTilUtgiftTekst } from '../tekster';
 
 const EndreUtgift: React.FC<{
     vilkårtype: StønadsvilkårType;
@@ -14,10 +16,17 @@ const EndreUtgift: React.FC<{
     alleFelterKanRedigeres: boolean;
     oppdaterUtgift: (verdi: number | undefined) => void;
 }> = ({ vilkårtype, erFremtidigUtgift, utgift, alleFelterKanRedigeres, oppdaterUtgift }) => {
+    const hjelpetekst = vilkårTypeTilUtgiftHjelpeTekst[vilkårtype];
     return (
         <FeilmeldingMaksBredde $maxWidth={180}>
             <TextField
-                label={`${vilkårTypeTilUtgiftTekst[vilkårtype]}${erFremtidigUtgift ? ' (valgfri)' : ''}`}
+                label={
+                    <HStack gap="2" align="center">
+                        {vilkårTypeTilUtgiftTekst[vilkårtype]}
+                        {erFremtidigUtgift ? ' (valgfri)' : ''}
+                        {hjelpetekst && <HelpText>{hjelpetekst}</HelpText>}
+                    </HStack>
+                }
                 size="small"
                 erLesevisning={false}
                 value={harTallverdi(utgift) ? utgift : ''}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreUtgift.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreUtgift.tsx
@@ -22,8 +22,10 @@ const EndreUtgift: React.FC<{
             <TextField
                 label={
                     <HStack gap="2" align="center">
-                        {vilkårTypeTilUtgiftTekst[vilkårtype]}
-                        {erFremtidigUtgift ? ' (valgfri)' : ''}
+                        <span>
+                            {vilkårTypeTilUtgiftTekst[vilkårtype]}
+                            {erFremtidigUtgift ? ' (valgfri)' : ''}
+                        </span>
                         {hjelpetekst && <HelpText>{hjelpetekst}</HelpText>}
                     </HStack>
                 }

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -65,6 +65,9 @@ export const hjelpetekster: Record<RegelId, string[]> = {
     NØDVENDIGE_MERUTGIFTER: [
         'Det må vurderes om aktivitetsstedet er i naturlig pendleravstand fra bostedet. Ved vurdering av naturlig pendleravstand skal det blant annet legges vekt på avstanden mellom hjem og arbeidssted, tilgjengelig transportmidler, reisetid, kostnader og ev. andre forhold knyttet til søker.',
     ],
+    NØDVENDIG_Å_BO_NÆRMERE_AKTIVITET: [
+        'Det må vurderes om aktivitetsstedet er i naturlig pendleravstand fra bostedet. Ved vurdering av naturlig pendleravstand skal det blant annet legges vekt på avstanden mellom hjem og arbeidssted, tilgjengelig transportmidler, reisetid, kostnader og ev. andre forhold knyttet til søker.',
+    ],
 };
 
 export const vilkårTypeTilUtgiftTekst: Record<StønadsvilkårType, string> = {

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -29,7 +29,7 @@ export const regelIdTilSpørsmål: Record<RegelId, string> = {
     HAR_FULLFØRT_FJERDEKLASSE: 'Er barnet ferdig med 4. skoleår?',
     UNNTAK_ALDER:
         'Har barnet behov for pass utover 4. skoleår, og er behovet tilfredsstillende dokumentert?',
-    NØDVENDIGE_MERUTGIFTER: 'Har søker nødvendige merutgifter til bolig eller overnatting?',
+    NØDVENDIGE_MERUTGIFTER: 'Har søker nødvendige merutgifter til overnatting?',
     HØYERE_BOUTGIFTER_SAMMENLIGNET_MED_TIDLIGERE:
         'Har søker dokumentert høyere boutgifter på aktivitetssted sammenlignet med tidligere bolig?',
     NØDVENDIG_Å_BO_NÆRMERE_AKTIVITET: 'Er det nødvendig for søker å bo nærmere aktivitetsstedet?',

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -74,6 +74,15 @@ export const vilkårTypeTilUtgiftTekst: Record<StønadsvilkårType, string> = {
     LØPENDE_UTGIFTER_TO_BOLIGER: 'Merutgifter per måned',
 };
 
+export const vilkårTypeTilUtgiftHjelpeTekst: Record<StønadsvilkårType, string | undefined> = {
+    PASS_BARN: undefined,
+    UTGIFTER_OVERNATTING: undefined,
+    LØPENDE_UTGIFTER_EN_BOLIG:
+        'Merutgift utgjør differansen mellom boutgift på aktivitetsstedet og boutgift på tidligere hjemsted. Eventuelle inntekter for utleie av bolig skal ikke være med i beregningen.',
+    LØPENDE_UTGIFTER_TO_BOLIGER:
+        'Merutgiften tilsvarer utgiften til boligen på aktivitetsstedet, som kommer i tillegg til utgifter til bolig på hjemstedet. Eventuelle inntekter for utleie av bolig skal ikke være med i beregningen.',
+};
+
 export const vilkårTypeTilTekst: Record<StønadsvilkårType, string> = {
     PASS_BARN: 'Pass av barn',
     UTGIFTER_OVERNATTING: 'Utgifter til overnatting',

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -62,6 +62,9 @@ export const hjelpetekster: Record<RegelId, string[]> = {
         'Faktura fra barnehage må i tillegg inneholde eventuelle kostnader til bleier, så det er mulig å trekke dette fra.',
         'Ved privat pass så skal det vurderes om det er sannsynlig at søker har hatt utgifter til barnepass i perioden det søkes for. Avtale mellom barnepasser og søker eller A-melding kan være eksempler på dokumentasjon som godtas. Skjermbilde av betalinger via vipps eller bankutskrift godkjennes ikke. ',
     ],
+    NØDVENDIGE_MERUTGIFTER: [
+        'Det må vurderes om aktivitetsstedet er i naturlig pendleravstand fra bostedet. Ved vurdering av naturlig pendleravstand skal det blant annet legges vekt på avstanden mellom hjem og arbeidssted, tilgjengelig transportmidler, reisetid, kostnader og ev. andre forhold knyttet til søker.',
+    ],
 };
 
 export const vilkårTypeTilUtgiftTekst: Record<StønadsvilkårType, string> = {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker at det skal bli lettere for saksbehandler å gjøre vurderingen.

- lagt til "Slik gjør du vurderingen" 
- lagt til hjelpetekst på merugfiter
- oppdatert spørsmålstekst på overnatting

"Slik gjør du vurderingen" eksempel: 
<img width="1034" alt="image" src="https://github.com/user-attachments/assets/18c11a77-f3e9-4b34-96aa-b22ca632737f" />

Hjelpetekst merutgift eksempel:
<img width="1054" alt="image" src="https://github.com/user-attachments/assets/c84ff4a8-8dbe-4060-8de6-61f0f811658e" />
