### PR TITLE
Endrer på luft og størrelse på knapper

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingTabell.tsx
@@ -26,6 +26,7 @@ import { formaterEnumVerdi } from '../../../utils/tekstformatering';
 const Tabell = styled(Table)`
     max-width: fit-content;
     border: 1px solid ${ABorderDefault};
+    margin-left: 10px;
 `;
 
 const AdvarselIkon = styled(ExclamationmarkTriangleIcon)`

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
@@ -18,7 +18,7 @@ import {
 const Container = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 0.625rem;
 `;
 
 const TittelLinje = styled.div`

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useState } from 'react';
 
+import styled from 'styled-components';
+
 import { Button, Select, VStack } from '@navikt/ds-react';
 
 import OpprettKlageBehandling from './OpprettKlageBehandling';
@@ -18,6 +20,11 @@ interface Props {
     hentKlagebehandlinger: () => void;
     hentBehandlinger: () => void;
 }
+
+const StyledContainer = styled.div`
+    margin-left: 10px;
+    margin-bottom: 14px;
+`;
 
 const OpprettNyBehandlingModal: FC<Props> = ({
     fagsakId,
@@ -40,8 +47,8 @@ const OpprettNyBehandlingModal: FC<Props> = ({
     }
 
     return (
-        <div className="py-16">
-            <Button variant={'secondary'} onClick={() => settVisModal(true)}>
+        <StyledContainer className="py-16">
+            <Button size={'small'} variant={'secondary'} onClick={() => settVisModal(true)}>
                 Opprett ny behandling
             </Button>
             <ModalWrapper visModal={visModal} onClose={lukkModal} tittel={'Opprett ny behandling'}>
@@ -82,7 +89,7 @@ const OpprettNyBehandlingModal: FC<Props> = ({
                     )}
                 </VStack>
             </ModalWrapper>
-        </div>
+        </StyledContainer>
     );
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Småfiks på luft mellom tabeller og størrelse på knapper i sak fanen på personoversikten.

[Oppgave i Favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-25291)
[Skisser i figma](https://www.figma.com/design/7eVA9o9YdfQi7MRuzx9wWu/TS-sak--Personoversikt?node-id=115-1469&m=dev)

**Etter:**
![Screenshot 2025-06-02 at 11 24 34](https://github.com/user-attachments/assets/d9fc9cb7-56a1-48ce-b996-543b8dc588ec)
