### PR TITLE
 ✨ Puktliste for innvilget periode i brev

### DIFF
--- a/src/frontend/komponenter/Brev/Brevmeny.tsx
+++ b/src/frontend/komponenter/Brev/Brevmeny.tsx
@@ -11,7 +11,10 @@ import { MellomlagretBrevDto, parseMellomlagretBrev } from './mellomlagring';
 import { lagInnvilgetPerioderPunktliste } from './punktliste/lagInnvilgetPerioderPunktliste';
 import { lagVerdier } from './stønadsverdier/lagVerdier';
 import { Fritekst, FritekstAvsnitt, MalStruktur, Tekst, Valg, Valgfelt } from './typer';
-import { variabelInnvilgetPerioderPunktlisteId } from './variablerUtils';
+import {
+    variabelBeregningstabellId,
+    variabelInnvilgetPerioderPunktlisteId,
+} from './variablerUtils';
 import { lagVedtakstabell } from './vedtakstabell/lagVedtakstabell';
 import { useApp } from '../../context/AppContext';
 import { usePersonopplysninger } from '../../context/PersonopplysningerContext';
@@ -147,7 +150,11 @@ const Brevmeny: React.FC<Props> = ({
                 behandling,
                 vedtak
             ),
-            ...lagVedtakstabell(behandling, vedtak, skalViseDetaljertBeregningsresultatFlag),
+            [variabelBeregningstabellId]: lagVedtakstabell(
+                behandling,
+                vedtak,
+                skalViseDetaljertBeregningsresultatFlag
+            ),
         };
         return htmlVariabler;
     };

--- a/src/frontend/komponenter/Brev/Brevmeny.tsx
+++ b/src/frontend/komponenter/Brev/Brevmeny.tsx
@@ -8,8 +8,10 @@ import { Brevknapp } from './Brevknapp';
 import Delmal from './Delmal';
 import { lagHtmlStringAvBrev } from './Html';
 import { MellomlagretBrevDto, parseMellomlagretBrev } from './mellomlagring';
+import { lagInnvilgetPerioderPunktliste } from './punktliste/lagInnvilgetPerioderPunktliste';
 import { lagVerdier } from './stønadsverdier/lagVerdier';
 import { Fritekst, FritekstAvsnitt, MalStruktur, Tekst, Valg, Valgfelt } from './typer';
+import { variabelInnvilgetPerioderPunktlisteId } from './variablerUtils';
 import { lagVedtakstabell } from './vedtakstabell/lagVedtakstabell';
 import { useApp } from '../../context/AppContext';
 import { usePersonopplysninger } from '../../context/PersonopplysningerContext';
@@ -139,6 +141,17 @@ const Brevmeny: React.FC<Props> = ({
         request<null, MellomlagretBrevDto>(mellomlagerUrl, 'POST', data);
     };
 
+    const genererHtmlVariabler = () => {
+        const htmlVariabler: Record<string, string> = {
+            [variabelInnvilgetPerioderPunktlisteId]: lagInnvilgetPerioderPunktliste(
+                behandling,
+                vedtak
+            ),
+            ...lagVedtakstabell(behandling, vedtak, skalViseDetaljertBeregningsresultatFlag),
+        };
+        return htmlVariabler;
+    };
+
     const genererPdf = () => {
         const url = behandlingId ? `/api/sak/brev/${behandlingId}` : `/api/sak/frittstaende-brev`;
 
@@ -153,11 +166,7 @@ const Brevmeny: React.FC<Props> = ({
                 mal: mal,
                 valgfelt: valgfelt,
                 variabler: variabler,
-                htmlVariabler: lagVedtakstabell(
-                    behandling,
-                    vedtak,
-                    skalViseDetaljertBeregningsresultatFlag
-                ),
+                htmlVariabler: genererHtmlVariabler(),
                 inkluderBeslutterSignaturPlaceholder: !!behandlingId,
             }),
         }).then(settFil);

--- a/src/frontend/komponenter/Brev/Brevmeny.tsx
+++ b/src/frontend/komponenter/Brev/Brevmeny.tsx
@@ -13,7 +13,7 @@ import { lagVerdier } from './stønadsverdier/lagVerdier';
 import { Fritekst, FritekstAvsnitt, MalStruktur, Tekst, Valg, Valgfelt } from './typer';
 import {
     variabelBeregningstabellId,
-    variabelInnvilgetPerioderPunktlisteId,
+    variabelInnvilgedePerioderPunktlisteId,
 } from './variablerUtils';
 import { lagVedtakstabell } from './vedtakstabell/lagVedtakstabell';
 import { useApp } from '../../context/AppContext';
@@ -146,7 +146,7 @@ const Brevmeny: React.FC<Props> = ({
 
     const genererHtmlVariabler = () => {
         const htmlVariabler: Record<string, string> = {
-            [variabelInnvilgetPerioderPunktlisteId]: lagInnvilgetPerioderPunktliste(
+            [variabelInnvilgedePerioderPunktlisteId]: lagInnvilgetPerioderPunktliste(
                 behandling,
                 vedtak
             ),

--- a/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
+++ b/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
@@ -37,6 +37,7 @@ const lagPunktlisteInnvilgedePerioderForBoutgifter = (
                     (utgift) =>
                         `<li style="margin: 0;">fra og med ${formaterTilTekstligDato(utgift.fom)} til og med ${formaterTilTekstligDato(utgift.tom)}</li>`
                 )
+                .join('')
         )
         .join('')}
     </ul>`;

--- a/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
+++ b/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
@@ -17,7 +17,7 @@ export const lagInnvilgetPerioderPunktliste = (
 
     switch (behandling?.stønadstype) {
         case Stønadstype.BOUTGIFTER:
-            return lagPunktlisteInnvilgetPerioderForBoutgifter(
+            return lagPunktlisteInnvilgedePerioderForBoutgifter(
                 vedtak.beregningsresultat as BeregningsresultatBoutgifter
             );
         default:
@@ -25,7 +25,7 @@ export const lagInnvilgetPerioderPunktliste = (
     }
 };
 
-const lagPunktlisteInnvilgetPerioderForBoutgifter = (
+const lagPunktlisteInnvilgedePerioderForBoutgifter = (
     beregningsresultat: BeregningsresultatBoutgifter
 ): string => {
     return `<ul style="margin: 0; padding-top: 0">

--- a/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
+++ b/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
@@ -1,0 +1,43 @@
+import { Behandling } from '../../../typer/behandling/behandling';
+import { Stønadstype } from '../../../typer/behandling/behandlingTema';
+import { VedtakResponse } from '../../../typer/vedtak/vedtak';
+import { BeregningsresultatBoutgifter } from '../../../typer/vedtak/vedtakBoutgifter';
+import { formaterTilTekstligDato } from '../../../utils/dato';
+
+export const lagInnvilgetPerioderPunktliste = (
+    behandling: Behandling | undefined,
+    vedtak: VedtakResponse | undefined
+): string => {
+    if (!vedtak) {
+        return '';
+    }
+    if (vedtak.type !== 'INNVILGELSE') {
+        return '';
+    }
+
+    switch (behandling?.stønadstype) {
+        case Stønadstype.BOUTGIFTER:
+            return lagPunktlisteInnvilgetPerioderForBoutgifter(
+                vedtak.beregningsresultat as BeregningsresultatBoutgifter
+            );
+        default:
+            return '';
+    }
+};
+
+const lagPunktlisteInnvilgetPerioderForBoutgifter = (
+    beregningsresultat: BeregningsresultatBoutgifter
+): string => {
+    return `<ul style="margin: 0; padding-top: 0">
+    ${beregningsresultat.perioder
+        .map((periode) =>
+            periode.utgifterTilUtbetaling
+                .filter((utgift) => !utgift.erFørRevurderFra)
+                .map(
+                    (utgift) =>
+                        `<li style="margin: 0;">fra og med ${formaterTilTekstligDato(utgift.fom)} til og med ${formaterTilTekstligDato(utgift.tom)}</li>`
+                )
+        )
+        .join('')}
+    </ul>`;
+};

--- a/src/frontend/komponenter/Brev/variablerUtils.ts
+++ b/src/frontend/komponenter/Brev/variablerUtils.ts
@@ -1,1 +1,2 @@
 export const variabelBeregningstabellId = '02408de1-5ad8-44e9-a004-51f677d6ebab';
+export const variabelInnvilgetPerioderPunktlisteId = '0a8db7bd-dab7-4292-a1c5-fe347b6a45b3';

--- a/src/frontend/komponenter/Brev/variablerUtils.ts
+++ b/src/frontend/komponenter/Brev/variablerUtils.ts
@@ -1,2 +1,2 @@
 export const variabelBeregningstabellId = '02408de1-5ad8-44e9-a004-51f677d6ebab';
-export const variabelInnvilgetPerioderPunktlisteId = '0a8db7bd-dab7-4292-a1c5-fe347b6a45b3';
+export const variabelInnvilgedePerioderPunktlisteId = '0a8db7bd-dab7-4292-a1c5-fe347b6a45b3';

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabell.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabell.ts
@@ -10,8 +10,6 @@ import { BeregningsresultatTilsynBarn } from '../../../typer/vedtak/vedtakTilsyn
 
 export type LagVedtakstabell = Record<string, string>;
 
-const TOM_VEDTAKSTABELL = {};
-
 /**
  * Lager en vedtakstabell i html som vises i innvilgelsebrevet
  * @param behandling trengs for å vite hvilken stønadstype det er for å kunne typecaste
@@ -20,12 +18,12 @@ export const lagVedtakstabell = (
     behandling: Behandling | undefined,
     vedtak: VedtakResponse | undefined,
     skalViseDetaljertBeregningsresultatFlag: boolean
-): LagVedtakstabell => {
+): string => {
     if (!behandling || !vedtak) {
-        return TOM_VEDTAKSTABELL;
+        return '';
     }
     if (vedtak.type !== 'INNVILGELSE') {
-        return TOM_VEDTAKSTABELL;
+        return '';
     }
 
     switch (behandling.stønadstype) {
@@ -43,6 +41,6 @@ export const lagVedtakstabell = (
                 skalViseDetaljertBeregningsresultatFlag
             );
         default:
-            return TOM_VEDTAKSTABELL;
+            return '';
     }
 };

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -2,24 +2,11 @@ import { BeregningsresultatBoutgifter } from '../../../typer/vedtak/vedtakBoutgi
 import { formaterIsoPeriodeMedTankestrek } from '../../../utils/dato';
 import { formaterTallMedTusenSkille } from '../../../utils/fomatering';
 import { Periode } from '../../../utils/periode';
-import { variabelBeregningstabellId } from '../variablerUtils';
 
 const borderStylingCompact = 'border: 1px solid black; padding: 3px 2px 3px 5px;';
 const borderStyling = 'border: 1px solid black; padding: 3px 10px 3px 5px;';
 
 export const lagVedtakstabellBoutgifter = (
-    beregningsresultat: BeregningsresultatBoutgifter | undefined,
-    skalViseDetaljertBeregningsresultatFlag: boolean
-) => {
-    return {
-        [variabelBeregningstabellId]: lagBeregningstabell(
-            beregningsresultat,
-            skalViseDetaljertBeregningsresultatFlag
-        ),
-    };
-};
-
-const lagBeregningstabell = (
     beregningsresultat: BeregningsresultatBoutgifter | undefined,
     skalViseDetaljertBeregningsresultatFlag: boolean
 ): string => {

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellLæremidler.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellLæremidler.ts
@@ -1,21 +1,13 @@
-import { LagVedtakstabell } from './lagVedtakstabell';
 import { BeregningsresultatLæremidler } from '../../../typer/vedtak/vedtakLæremidler';
 import { formaterIsoPeriodeMedTankestrek } from '../../../utils/dato';
 import { formaterTallMedTusenSkille } from '../../../utils/fomatering';
-import { variabelBeregningstabellId } from '../variablerUtils';
 
 const borderStylingCompact = 'border: 1px solid black; padding: 3px 2px 3px 5px;';
 const borderStyling = 'border: 1px solid black; padding: 3px 10px 3px 5px;';
 
 export const lagVedtakstabellLæremidler = (
-    beregningsresultat: BeregningsresultatLæremidler | undefined
-): LagVedtakstabell => {
-    return {
-        [variabelBeregningstabellId]: lagBeregningstabell(beregningsresultat),
-    };
-};
-
-const lagBeregningstabell = (beregningsresultat?: BeregningsresultatLæremidler): string => {
+    beregningsresultat?: BeregningsresultatLæremidler
+): string => {
     return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
                     <tr>

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellTilsynBarn.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellTilsynBarn.ts
@@ -1,22 +1,14 @@
-import { LagVedtakstabell } from './lagVedtakstabell';
 import { BeregningsresultatTilsynBarn } from '../../../typer/vedtak/vedtakTilsynBarn';
 import { formaterÅrFullMåned } from '../../../utils/dato';
 import { formaterTallMedTusenSkille } from '../../../utils/fomatering';
 import { toTitleCase } from '../../../utils/tekstformatering';
-import { variabelBeregningstabellId } from '../variablerUtils';
 
 const borderStylingCompact = 'border: 1px solid black; padding: 3px 2px 3px 5px;';
 const borderStyling = 'border: 1px solid black; padding: 3px 10px 3px 5px;';
 
 export const lagVedtakstabellTilsynBarn = (
-    beregningsresultat: BeregningsresultatTilsynBarn | undefined
-): LagVedtakstabell => {
-    return {
-        [variabelBeregningstabellId]: lagBeregningstabell(beregningsresultat),
-    };
-};
-
-const lagBeregningstabell = (beregningsresultat?: BeregningsresultatTilsynBarn): string => {
+    beregningsresultat?: BeregningsresultatTilsynBarn
+): string => {
     return `<table style="margin-left: 2px; margin-right: 2px; border-collapse: collapse; ${borderStylingCompact}">
                 <thead>
                     <tr>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger til muligheten til å legge inn en punktliste med datoer vedtaket innvilges for. Dette er for å tydeliggjøre eventuelle "hull" mellom første dato i første periode og siste dato i siste periode. 

Utkast fra eksempelbrev:
![image](https://github.com/user-attachments/assets/a687cd15-a276-4cc6-a3fe-dc1bf35feafa)

Det gjenstår å ta dette i bruk i eksisterende brev. Nå brukes den kun i et eksempelbrev
