### PR TITLE
Overskrift på vedtaksperioder

### DIFF
--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { VStack } from '@navikt/ds-react';
+import { Heading, VStack } from '@navikt/ds-react';
 
 import { VedtaksperioderOversiktBoutgifter } from './Boutgifter/VedtaksperioderOversiktBoutgifter';
 import { OversiktKort } from './OversiktKort';
@@ -25,35 +25,40 @@ export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
     }
 
     return (
-        <DataViewer response={{ vedtaksperioderOversikt, arenaSakOgVedtak }}>
-            {({ vedtaksperioderOversikt, arenaSakOgVedtak }) => (
-                <VStack gap={'8'}>
-                    {vedtaksperioderOversikt.tilsynBarn.length > 0 && (
-                        <OversiktKort tittel={'Tilsyn Barn'}>
-                            <VedtaksperioderOversiktTilsynBarn
-                                vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
-                            />
-                        </OversiktKort>
-                    )}
-                    {vedtaksperioderOversikt.læremidler.length > 0 && (
-                        <OversiktKort tittel={'Læremidler'}>
-                            <VedtaksperioderOversiktLæremidler
-                                vedtaksperioder={vedtaksperioderOversikt.læremidler}
-                            />
-                        </OversiktKort>
-                    )}
-                    {vedtaksperioderOversikt.boutgifter.length > 0 && (
-                        <OversiktKort tittel={'Boutgifter'}>
-                            <VedtaksperioderOversiktBoutgifter
-                                vedtaksperioder={vedtaksperioderOversikt.boutgifter}
-                            />
-                        </OversiktKort>
-                    )}
-                    {arenaSakOgVedtak.vedtak.length > 0 && (
-                        <VedtaksperioderOversiktArena arenaSakOgVedtak={arenaSakOgVedtak} />
-                    )}
-                </VStack>
-            )}
-        </DataViewer>
+        <>
+            <Heading size="small" spacing>
+                Vedtaksperioder i TS-sak
+            </Heading>
+            <DataViewer response={{ vedtaksperioderOversikt, arenaSakOgVedtak }}>
+                {({ vedtaksperioderOversikt, arenaSakOgVedtak }) => (
+                    <VStack gap={'8'}>
+                        {vedtaksperioderOversikt.tilsynBarn.length > 0 && (
+                            <OversiktKort tittel={'Tilsyn Barn'}>
+                                <VedtaksperioderOversiktTilsynBarn
+                                    vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
+                                />
+                            </OversiktKort>
+                        )}
+                        {vedtaksperioderOversikt.læremidler.length > 0 && (
+                            <OversiktKort tittel={'Læremidler'}>
+                                <VedtaksperioderOversiktLæremidler
+                                    vedtaksperioder={vedtaksperioderOversikt.læremidler}
+                                />
+                            </OversiktKort>
+                        )}
+                        {vedtaksperioderOversikt.boutgifter.length > 0 && (
+                            <OversiktKort tittel={'Boutgifter'}>
+                                <VedtaksperioderOversiktBoutgifter
+                                    vedtaksperioder={vedtaksperioderOversikt.boutgifter}
+                                />
+                            </OversiktKort>
+                        )}
+                        {arenaSakOgVedtak.vedtak.length > 0 && (
+                            <VedtaksperioderOversiktArena arenaSakOgVedtak={arenaSakOgVedtak} />
+                        )}
+                    </VStack>
+                )}
+            </DataViewer>
+        </>
     );
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å tydligere indikere at siden ikke har innhold. 
Tidligere viste bare en tom side dersom det ikke var data. Nå vil det alltid være en overskrift.

**Tom side**
<img width="1071" alt="Screenshot 2025-06-06 at 14 39 48" src="https://github.com/user-attachments/assets/be4f48a5-9043-44cf-9033-af73d98278ae" />

**Side med innhold**
<img width="1728" alt="Screenshot 2025-06-06 at 14 36 20" src="https://github.com/user-attachments/assets/ea3845c4-cda4-4c88-a6ca-4d87c0aada8b" />
