### PR TITLE
💄 Wrap feilmelding-tekster når bruker `\n` for ny linje

### DIFF
--- a/src/frontend/komponenter/Feil/Feilmelding.tsx
+++ b/src/frontend/komponenter/Feil/Feilmelding.tsx
@@ -26,7 +26,9 @@ export const Feilmelding = React.forwardRef<HTMLDivElement | HTMLParagraphElemen
             <Alert variant={finnFeilmeldingVariant(feil.status)} size="small" ref={ref} fullWidth>
                 {feil.tittel && <Label size="small">{feil.tittel}</Label>}
 
-                <BodyShort size="small">{feil.feilmelding}</BodyShort>
+                <BodyShort style={{ whiteSpace: 'pre-wrap' }} size="small">
+                    {feil.feilmelding}
+                </BodyShort>
                 <HStack align="center" wrap={false}>
                     {feil.feilkode && <Detail>Feilkode: {feil.feilkode}</Detail>}
                     {feil.feilmeldingMedFeilkode && (


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Skal formatere feilmelding fra backend på en hyggeligere måte. 

Før:
<img width="1032" alt="image" src="https://github.com/user-attachments/assets/105f48b6-729c-466b-9c5f-6a67943f00de" /> 

Nå:
![image](https://github.com/user-attachments/assets/b623ee67-79bf-43ff-9905-8d742afccc9c)
