### PR TITLE
Dataviewer med type/tittel

### DIFF
--- a/src/frontend/Sider/Admin/Oppfølging/OppfølgingAdmin.tsx
+++ b/src/frontend/Sider/Admin/Oppfølging/OppfølgingAdmin.tsx
@@ -46,7 +46,7 @@ export const OppølgingAdmin = () => {
     }, [request]);
 
     return (
-        <DataViewer response={{ oppfølginger }}>
+        <DataViewer type={'oppfølginger'} response={{ oppfølginger }}>
             {({ oppfølginger }) => <OppfølgingTabell oppfølgingerInit={oppfølginger} />}
         </DataViewer>
     );

--- a/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
+++ b/src/frontend/Sider/Admin/OpprettFørstegangsbehandlingAdmin.tsx
@@ -185,7 +185,7 @@ function OpprettFørstegangsbehandling({ stønadstype }: { stønadstype: Stønad
                 </Button>
             </VStack>
 
-            <DataViewer response={{ personinfo }}>
+            <DataViewer type={'personinformasjon'} response={{ personinfo }}>
                 {({ personinfo }) => (
                     <>
                         <Heading size={'small'}>Informasjon om søker</Heading>
@@ -245,7 +245,9 @@ function OpprettFørstegangsbehandling({ stønadstype }: { stønadstype: Stønad
                     </>
                 )}
             </DataViewer>
-            <DataViewer response={{ opprettBehandlingResponse }}>{() => <>Ok</>}</DataViewer>
+            <DataViewer type={'opprett behandling'} response={{ opprettBehandlingResponse }}>
+                {() => <>Ok</>}
+            </DataViewer>
         </>
     );
 }

--- a/src/frontend/Sider/Behandling/BehandlingContainer.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingContainer.tsx
@@ -53,7 +53,10 @@ const BehandlingContainer = () => {
     }, []);
 
     return (
-        <DataViewer response={{ behandling, personopplysninger, behandlingFakta }}>
+        <DataViewer
+            type={'behandlingsinformasjon'}
+            response={{ behandling, personopplysninger, behandlingFakta }}
+        >
             {({ behandling, personopplysninger, behandlingFakta }) => (
                 <BehandlingInnhold
                     behandling={behandling}

--- a/src/frontend/Sider/Behandling/Brev/Brev.tsx
+++ b/src/frontend/Sider/Behandling/Brev/Brev.tsx
@@ -93,7 +93,7 @@ const Brev: React.FC = () => {
     return (
         <Container>
             {behandlingErRedigerbar ? (
-                <DataViewer response={{ brevmaler, mellomlagretBrev }}>
+                <DataViewer type={'brevmaler'} response={{ brevmaler, mellomlagretBrev }}>
                     {({ brevmaler, mellomlagretBrev }) => (
                         <ToKolonner>
                             <VStack gap="8" align="start">
@@ -110,7 +110,10 @@ const Brev: React.FC = () => {
                                         brevmal={brevmal}
                                         settBrevmal={settBrevmal}
                                     />
-                                    <DataViewer response={{ malStruktur, vedtak }}>
+                                    <DataViewer
+                                        type={'delmaler'}
+                                        response={{ malStruktur, vedtak }}
+                                    >
                                         {({ malStruktur, vedtak }) => (
                                             <Brevmeny
                                                 mal={malStruktur}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -46,6 +46,7 @@ const Inngangsvilkår = () => {
             <VarselRevurderFraDatoMangler />
 
             <DataViewer
+                type={'inngangsvilkår'}
                 response={{
                     vilkårperioderResponse,
                 }}

--- a/src/frontend/Sider/Behandling/RevurderFra/Boutgifter/VedtakshistorikkBoutgifter.tsx
+++ b/src/frontend/Sider/Behandling/RevurderFra/Boutgifter/VedtakshistorikkBoutgifter.tsx
@@ -23,6 +23,7 @@ export const VedtakshistorikkBoutgifter: FC<Props> = ({ forrigeIverksatteBehandl
         <StyledVStack gap="4">
             <Heading size="xsmall">Vedtakshistorikk boutgifter TS-Sak </Heading>
             <DataViewer
+                type={'vedtaksperioder'}
                 response={{
                     detaljerteVedtaksperioderBoutgifter: detaljerteVedtaksperioderBoutgifter,
                 }}

--- a/src/frontend/Sider/Behandling/RevurderFra/Læremidler/VedtakshistorikkLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/RevurderFra/Læremidler/VedtakshistorikkLæremidler.tsx
@@ -19,7 +19,7 @@ export const VedtakshistorikkLæremidler: FC<Props> = ({ forrigeIverksatteBehand
     return (
         <StyledVStack gap="4">
             <Heading size="xsmall">Vedtakshistorikk læremidler TS-Sak </Heading>
-            <DataViewer response={{ vedtakLæremidler }}>
+            <DataViewer type={'vedtaksperioder'} response={{ vedtakLæremidler }}>
                 {({ vedtakLæremidler }) => (
                     <VedtakshistorikkLæremidlerTabellVisning vedtakLæremidler={vedtakLæremidler} />
                 )}

--- a/src/frontend/Sider/Behandling/RevurderFra/TilsynBarn/VedtakshistorikkTilsynBarn.tsx
+++ b/src/frontend/Sider/Behandling/RevurderFra/TilsynBarn/VedtakshistorikkTilsynBarn.tsx
@@ -22,7 +22,7 @@ export const VedtakshistorikkTilsynBarn: FC<Props> = ({ forrigeIverksatteBehandl
     return (
         <StyledVStack gap="4">
             <Heading size="xsmall">Vedtakshistorikk tilsyn barn TS-Sak </Heading>
-            <DataViewer response={{ vedtakBarnetilsyn }}>
+            <DataViewer type={'vedtaksperioder'} response={{ vedtakBarnetilsyn }}>
                 {({ vedtakBarnetilsyn }) => (
                     <VedtakshistorikkTilsynBarnTabellVisning
                         vedtakBarnetilsyn={vedtakBarnetilsyn}

--- a/src/frontend/Sider/Behandling/Simulering/Simulering.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/Simulering.tsx
@@ -22,7 +22,7 @@ const Simulering: React.FC = () => {
     return (
         <Container>
             <VarselVedtakIArena />
-            <DataViewer response={{ vedtak }}>
+            <DataViewer type={'vedtak'} response={{ vedtak }}>
                 {({ vedtak }) => <SimuleringResultatWrapper vedtak={vedtak} />}
             </DataViewer>
         </Container>

--- a/src/frontend/Sider/Behandling/Simulering/SimuleringResultatWrapper.tsx
+++ b/src/frontend/Sider/Behandling/Simulering/SimuleringResultatWrapper.tsx
@@ -39,7 +39,7 @@ const SimuleringResultatWrapper: React.FC<{ vedtak: VedtakResponse }> = ({ vedta
     };
 
     return (
-        <DataViewer response={{ simuleringsresultat }}>
+        <DataViewer type={'simuleringsresultat'} response={{ simuleringsresultat }}>
             {({ simuleringsresultat }) => {
                 const { perioder, oppsummering } = simuleringsresultat || {};
 

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -44,6 +44,7 @@ const Stønadsvilkår: React.FC<{
             <VarselVedtakIArena />
             <VarselRevurderFraDatoMangler />
             <DataViewer
+                type={'stønadsvilkår'}
                 response={{
                     regler,
                     vilkårsvurdering,

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/Totrinnskontroll.tsx
@@ -17,7 +17,7 @@ const Totrinnskontroll: FC = () => {
 
     return (
         <>
-            <DataViewer response={{ totrinnskontroll }}>
+            <DataViewer type={'totrinnskontroll'} response={{ totrinnskontroll }}>
                 {({ totrinnskontroll }) => (
                     <TotrinnskontrollSwitch
                         totrinnskontroll={totrinnskontroll}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgeBarnetilsyn.tsx
@@ -147,7 +147,7 @@ export const InnvilgeBarnetilsyn: React.FC<Props> = ({
                         <SmallButton onClick={beregnBarnetilsyn}>Beregn</SmallButton>
                     )}
                     {erStegRedigerbart && (
-                        <DataViewer response={{ beregningsresultat }}>
+                        <DataViewer type={'beregningsresultat'} response={{ beregningsresultat }}>
                             {({ beregningsresultat }) => (
                                 <Beregningsresultat beregningsresultat={beregningsresultat} />
                             )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgelseTilsynBarnEllerVedtaksperioderFraForrigeBehandling.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/InnvilgelseTilsynBarnEllerVedtaksperioderFraForrigeBehandling.tsx
@@ -50,7 +50,7 @@ const InnvilgeTilsynBarnMedPerioderFraForrigeBehandling = ({
     }, [hentForrigeVedtak, forrigeIverksatteBehandlingId, stønadstype]);
 
     return (
-        <DataViewer response={{ forrigeVedtak }}>
+        <DataViewer type={'forrige vedtak'} response={{ forrigeVedtak }}>
             {({ forrigeVedtak }) => {
                 return (
                     <InnvilgeBarnetilsyn

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/VedtakOgBeregningBarnetilsyn.tsx
@@ -40,7 +40,7 @@ const VedtakOgBeregningBarnetilsyn: FC = () => {
 
     return (
         <>
-            <DataViewer response={{ vedtak }}>
+            <DataViewer type={'vedtak'} response={{ vedtak }}>
                 {({ vedtak }) => (
                     <Container>
                         <VarselVedtakIArena />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/VedtakOgBeregningBoutgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/VedtakOgBeregningBoutgifter.tsx
@@ -41,7 +41,7 @@ export const VedtakOgBeregningBoutgifter: FC = () => {
 
     return (
         <>
-            <DataViewer response={{ vedtak }}>
+            <DataViewer type={'vedtak'} response={{ vedtak }}>
                 {({ vedtak }) => (
                     <Container>
                         <VarselVedtakIArena />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/InnvilgeBoutgifter.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/InnvilgeBoutgifter.tsx
@@ -132,7 +132,7 @@ export const InnvilgeBoutgifter: React.FC<Props> = ({
                         <SmallButton onClick={beregnBoutgifter}>Beregn</SmallButton>
                     )}
                     {erStegRedigerbart && (
-                        <DataViewer response={{ beregningsresultat }}>
+                        <DataViewer type={'beregningsresultat'} response={{ beregningsresultat }}>
                             {({ beregningsresultat }) => (
                                 <BeregningsresultatContainer
                                     beregningsresultat={beregningsresultat}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/InnvilgelseBoutgifterEllerVedtaksperioderFraForrigeBehandling.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/InnvilgelseBoutgifterEllerVedtaksperioderFraForrigeBehandling.tsx
@@ -50,7 +50,7 @@ const InnvilgeBoutgifterMedPerioderFraForrigeBehandling = ({
     }, [hentForrigeVedtak, forrigeIverksatteBehandlingId, stønadstype]);
 
     return (
-        <DataViewer response={{ forrigeVedtak }}>
+        <DataViewer type={'forrige vedtak'} response={{ forrigeVedtak }}>
             {({ forrigeVedtak }) => {
                 return (
                     <InnvilgeBoutgifter

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgeLæremidler.tsx
@@ -124,7 +124,7 @@ export const InnvilgeLæremidler: React.FC<{
                 {erStegRedigerbart && <SmallButton onClick={beregnLæremidler}>Beregn</SmallButton>}
                 <VStack gap="8">
                     {erStegRedigerbart && (
-                        <DataViewer response={{ beregningsresultat }}>
+                        <DataViewer type={'beregningsresultat'} response={{ beregningsresultat }}>
                             {({ beregningsresultat }) => (
                                 <Beregningsresultat beregningsresultat={beregningsresultat} />
                             )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/InnvilgelseLæremidlerEllerVedtaksperioderFraForrigeBehandling.tsx
@@ -50,7 +50,7 @@ const InnvilgeLæremidlerMedPerioderFraForrigeBehandling = ({
     }, [hentForrigeVedtak, forrigeIverksatteBehandlingId, stønadstype]);
 
     return (
-        <DataViewer response={{ forrigeVedtak }}>
+        <DataViewer type={'forrige vedtak'} response={{ forrigeVedtak }}>
             {({ forrigeVedtak }) => {
                 return (
                     <InnvilgeLæremidler

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/VedtakOgBeregningLæremidler.tsx
@@ -40,7 +40,7 @@ const VedtakOgBeregningLæremidler: FC = () => {
     }, [vedtak]);
 
     return (
-        <DataViewer response={{ vedtak }}>
+        <DataViewer type={'vedtak'} response={{ vedtak }}>
             {({ vedtak }) => (
                 <Container>
                     <VarselVedtakIArena />

--- a/src/frontend/Sider/Behandling/Venstremeny/BehandlingOppsummering/BehandlingOppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/BehandlingOppsummering/BehandlingOppsummering.tsx
@@ -40,7 +40,7 @@ export const BehandlingOppsummering = () => {
     }
 
     return (
-        <DataViewer response={{ behandlingOppsummering }}>
+        <DataViewer type={'behandlingsoppsummering'} response={{ behandlingOppsummering }}>
             {({ behandlingOppsummering }) => (
                 <Container>
                     <StyledExpansionCard

--- a/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Dokumentoversikt/Dokumentoversikt.tsx
@@ -25,7 +25,7 @@ const Dokumentoversikt: React.FC = () => {
     }, [request, behandling]);
 
     return (
-        <DataViewer response={{ dokumenter }}>
+        <DataViewer type={'dokumenter'} response={{ dokumenter }}>
             {({ dokumenter }) => <Dokumentliste dokumenter={dokumenter} />}
         </DataViewer>
     );

--- a/src/frontend/Sider/Behandling/Venstremeny/Historikk/Historikk.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Historikk/Historikk.tsx
@@ -15,7 +15,7 @@ const Historikk: React.FC = () => {
     const { behandlingshistorikk } = useBehandling();
 
     return (
-        <DataViewer response={{ behandlingshistorikk }}>
+        <DataViewer type={'behandlingshistorikk'} response={{ behandlingshistorikk }}>
             {({ behandlingshistorikk }) => (
                 <Container>
                     {behandlingshistorikk.map((historikkElement, index) => {

--- a/src/frontend/Sider/Journalføring/Standard/Behandlinger.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Behandlinger.tsx
@@ -70,7 +70,7 @@ const Behandlinger: React.FC<Props> = ({ journalpostState, settFeilmelding }) =>
         journalføringsaksjon === Journalføringsaksjon.OPPRETT_BEHANDLING;
 
     return (
-        <DataViewer response={{ behandlinger }}>
+        <DataViewer type={'behandlinger'} response={{ behandlinger }}>
             {({ behandlinger }) => {
                 const behandlingstypePåNyBehandling =
                     behandlingTypeTilTekst[

--- a/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
+++ b/src/frontend/Sider/Journalføring/Standard/Journalføring.tsx
@@ -57,7 +57,7 @@ export const Journalføring: React.FC = () => {
     }
 
     return (
-        <DataViewer response={{ journalResponse }}>
+        <DataViewer type={'journalpost'} response={{ journalResponse }}>
             {({ journalResponse }) => (
                 <JournalføringSide oppgaveId={oppgaveId} journalResponse={journalResponse} />
             )}

--- a/src/frontend/Sider/Klage/Layout/BehandlingContainer.tsx
+++ b/src/frontend/Sider/Klage/Layout/BehandlingContainer.tsx
@@ -69,7 +69,7 @@ const BehandlingContainer: FC = () => {
     // eslint-disable-next-line
     useEffect(() => hentPersonopplysninger(behandlingId), [behandlingId]);
     return (
-        <DataViewer response={{ behandling, personopplysninger }}>
+        <DataViewer type={'behandlingsinformasjon'} response={{ behandling, personopplysninger }}>
             {({ behandling, personopplysninger }) => (
                 <KlagebehandlingProvider
                     behandling={behandling}

--- a/src/frontend/Sider/Klage/Layout/Høyremeny/Dokumenter.tsx
+++ b/src/frontend/Sider/Klage/Layout/Høyremeny/Dokumenter.tsx
@@ -22,7 +22,7 @@ export const Dokumenter: React.FC<{ hidden: boolean }> = ({ hidden }) => {
     }
 
     return (
-        <DataViewer response={{ dokumenter }}>
+        <DataViewer type={'dokumenter'} response={{ dokumenter }}>
             {({ dokumenter }) => {
                 const sortertDokumentliste = sorterDokumentlisten(dokumenter);
                 return (

--- a/src/frontend/Sider/Klage/Layout/Høyremeny/Historikk.tsx
+++ b/src/frontend/Sider/Klage/Layout/Høyremeny/Historikk.tsx
@@ -14,7 +14,7 @@ const Historikk: React.FC<{ hidden: boolean }> = ({ hidden }) => {
     }
 
     return (
-        <DataViewer response={{ behandlingHistorikk }}>
+        <DataViewer type={'behandlingshistorikk'} response={{ behandlingHistorikk }}>
             {({ behandlingHistorikk }) => (
                 <HistorikkContainer
                     behandling={behandling}

--- a/src/frontend/Sider/Klage/Steg/Brev/OmgjørVedtak.tsx
+++ b/src/frontend/Sider/Klage/Steg/Brev/OmgjørVedtak.tsx
@@ -93,7 +93,7 @@ export const OmgjørVedtak: React.FC<{
     }
 
     return (
-        <DataViewer response={{ kanOppretteRevurdering }}>
+        <DataViewer type={'revurderingsmulighet'} response={{ kanOppretteRevurdering }}>
             {({ kanOppretteRevurdering }) => (
                 <>
                     {behandlingErRedigerbar && (

--- a/src/frontend/Sider/Klage/Steg/Formkrav/Formkrav.tsx
+++ b/src/frontend/Sider/Klage/Steg/Formkrav/Formkrav.tsx
@@ -32,7 +32,7 @@ export const Formkrav: React.FC<{ behandling: Klagebehandling }> = ({ behandling
     }, [behandling, fagsystemVedtak, hentFagsystemVedtak]);
 
     return (
-        <DataViewer response={{ vilkårsvurderinger, fagsystemVedtak }}>
+        <DataViewer type={'vilkårsvurderinger'} response={{ vilkårsvurderinger, fagsystemVedtak }}>
             {({ vilkårsvurderinger, fagsystemVedtak }) => {
                 return (
                     <FormkravKomponent

--- a/src/frontend/Sider/Klage/Steg/Resultat/Resultat.tsx
+++ b/src/frontend/Sider/Klage/Steg/Resultat/Resultat.tsx
@@ -28,7 +28,7 @@ export const Resultat: React.FC = () => {
     const { behandling, behandlingHistorikk, åpenHøyremeny } = useKlagebehandling();
 
     return (
-        <DataViewer response={{ behandlingHistorikk }}>
+        <DataViewer type={'behandlingshistorikk'} response={{ behandlingHistorikk }}>
             {({ behandlingHistorikk }) => (
                 <>
                     <HeadingContainer>

--- a/src/frontend/Sider/Klage/Steg/Vurdering/Vurdering.tsx
+++ b/src/frontend/Sider/Klage/Steg/Vurdering/Vurdering.tsx
@@ -121,7 +121,7 @@ export const Vurdering: React.FC<{ behandlingId: string }> = ({ behandlingId }) 
     };
 
     return (
-        <DataViewer response={{ formkrav }}>
+        <DataViewer type={'formkrav'} response={{ formkrav }}>
             {({ formkrav }) => {
                 const skalViseVurderingsvalg =
                     påKlagetVedtakValgt(formkrav) && alleVilkårOppfylt(formkrav);

--- a/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
+++ b/src/frontend/Sider/Oppgavebenk/Oppgavebenk.tsx
@@ -41,7 +41,7 @@ const OppgavebenkContainer = () => {
     return (
         <Container>
             <Oppgavefiltrering />
-            <DataViewer response={{ oppgaver: oppgaveRessurs }}>
+            <DataViewer type={'oppgaver'} response={{ oppgaver: oppgaveRessurs }}>
                 {({ oppgaver }) => <Oppgavetabell oppgaverResponse={oppgaver} />}
             </DataViewer>
             <FeilmeldingHåndterOppgaveModal

--- a/src/frontend/Sider/Personoversikt/Aktivitetsoversikt/Aktivitetsoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Aktivitetsoversikt/Aktivitetsoversikt.tsx
@@ -18,7 +18,7 @@ const Aktivitetsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerson
 
     const hentAktiviter = useCallback(async () => {
         const response = request<AktiviteterDto, null>(
-            `/api/sak/register-aktivitet2/${fagsakPersonId}`,
+            `/api/sak/register-aktivitet/${fagsakPersonId}`,
             'GET'
         );
         settAktiviteter(await response);

--- a/src/frontend/Sider/Personoversikt/Aktivitetsoversikt/Aktivitetsoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Aktivitetsoversikt/Aktivitetsoversikt.tsx
@@ -18,7 +18,7 @@ const Aktivitetsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerson
 
     const hentAktiviter = useCallback(async () => {
         const response = request<AktiviteterDto, null>(
-            `/api/sak/register-aktivitet/${fagsakPersonId}`,
+            `/api/sak/register-aktivitet2/${fagsakPersonId}`,
             'GET'
         );
         settAktiviteter(await response);
@@ -29,7 +29,7 @@ const Aktivitetsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerson
     }, [fagsakPersonId, hentAktiviter]);
 
     return (
-        <DataViewer response={{ aktiviteter }}>
+        <DataViewer type={'aktiviteter'} response={{ aktiviteter }}>
             {({ aktiviteter }) => (
                 <>
                     <Heading size="small" spacing>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/Arena/VedtaksoversiktArena.tsx
@@ -29,7 +29,7 @@ export const VedtaksoversiktArena: React.FC<{ fagsakPersonId: string }> = ({ fag
     return (
         <>
             <Heading size="small">Vedtak i Arena</Heading>
-            <DataViewer response={{ vedtakArena }}>
+            <DataViewer type={'vedtaksperioder fra Arena'} response={{ vedtakArena }}>
                 {({ vedtakArena }) => (
                     <Vedtakstabell size={'small'}>
                         <Table.Header>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/BehandlingOversikt.tsx
@@ -25,7 +25,7 @@ const Behandlingsoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPerso
     return (
         <>
             <Heading size="small">Behandlinger i TS-sak</Heading>
-            <DataViewer response={{ behandlingsoversikt }}>
+            <DataViewer type={'behandlingsoversikt'} response={{ behandlingsoversikt }}>
                 {({ behandlingsoversikt }) => (
                     <>
                         {behandlingsoversikt.tilsynBarn && (

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/BarnTilRevurdering.tsx
@@ -45,7 +45,7 @@ const BarnTilRevurdering: React.FC<{
     }, [fagsakId]);
 
     return (
-        <DataViewer response={{ barnTilRevurdering }}>
+        <DataViewer type={'barn'} response={{ barnTilRevurdering }}>
             {({ barnTilRevurdering }) => {
                 const eksisterendeBarn = filterEksisterendeBarn(barnTilRevurdering);
                 const valgbareBarn = filterValgbareBarn(barnTilRevurdering);

--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -72,7 +72,7 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                 onToggleSelected={onToggleSelected}
                 selectedOptions={vedleggRequest.tema?.map(arkivtemaTilOption) ?? []}
             />
-            <DataViewer response={{ dokumenter }}>
+            <DataViewer type={'dokumenter'} response={{ dokumenter }}>
                 {({ dokumenter }) => <DokumentTabell dokumenter={dokumenter} />}
             </DataViewer>
         </>

--- a/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
+++ b/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrev.tsx
@@ -97,7 +97,7 @@ const FrittståendeBrev: React.FC<{
     };
 
     return (
-        <DataViewer response={{ brevmaler }}>
+        <DataViewer type={'brevmaler'} response={{ brevmaler }}>
             {({ brevmaler }) => (
                 <ToKolonner>
                     <VStack gap="8" align="start">
@@ -113,7 +113,7 @@ const FrittståendeBrev: React.FC<{
                             brevmal={brevmal}
                             settBrevmal={settBrevmal}
                         />
-                        <DataViewer response={{ malStruktur, mellomlagretBrev }}>
+                        <DataViewer type={'delmaler'} response={{ malStruktur, mellomlagretBrev }}>
                             {({ malStruktur, mellomlagretBrev }) => (
                                 <Brevmeny
                                     mal={malStruktur}

--- a/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrevFane.tsx
+++ b/src/frontend/Sider/Personoversikt/FrittståendeBrev/FrittståendeBrevFane.tsx
@@ -30,7 +30,7 @@ const FrittståendeBrevFane: React.FC<{ fagsakPersonId: string }> = ({ fagsakPer
     return (
         <Container>
             <Heading size="small">Frittstående brev til bruker</Heading>
-            <DataViewer response={{ fagsakPerson }}>
+            <DataViewer type={'fagsak'} response={{ fagsakPerson }}>
                 {({ fagsakPerson }) => (
                     <>
                         <Select

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Arena/OppgaverArena.tsx
@@ -29,7 +29,7 @@ const OppgaverArena: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId })
     return (
         <VStack gap="2">
             <Heading size={'xsmall'}>Arena</Heading>
-            <DataViewer response={{ oppgaveResponse }}>
+            <DataViewer type={'oppgaver'} response={{ oppgaveResponse }}>
                 {({ oppgaveResponse }) => (
                     <>
                         <OppgavelisteArena oppgaver={oppgaveResponse} />

--- a/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
+++ b/src/frontend/Sider/Personoversikt/Oppgaveoversikt/Oppgaver.tsx
@@ -59,7 +59,7 @@ const Oppgaver: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) => {
                     behandle noen typer oppgaver for tilsyn barn i TS-sak.
                 </HelpText>
             </HStack>
-            <DataViewer response={{ oppgaveResponse, mapper }}>
+            <DataViewer type={'oppgaver'} response={{ oppgaveResponse, mapper }}>
                 {({ oppgaveResponse, mapper }) => (
                     <>
                         <Oppgaveliste

--- a/src/frontend/Sider/Personoversikt/Personoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Personoversikt.tsx
@@ -29,7 +29,7 @@ const Personoversikt = () => {
     }, []);
 
     return (
-        <DataViewer response={{ personopplysninger }}>
+        <DataViewer type={'personopplysninger'} response={{ personopplysninger }}>
             {({ personopplysninger }) => (
                 <PersonopplysningerProvider personopplysninger={personopplysninger}>
                     <PersonHeader fagsakPersonId={fagsakPersonId} />

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -26,7 +26,10 @@ export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
             <Heading size="small" spacing>
                 Vedtaksperioder i TS-sak
             </Heading>
-            <DataViewer response={{ vedtaksperioderOversikt, arenaSakOgVedtak }}>
+            <DataViewer
+                type={'vedtaksperioder'}
+                response={{ vedtaksperioderOversikt, arenaSakOgVedtak }}
+            >
                 {({ vedtaksperioderOversikt, arenaSakOgVedtak }) => (
                     <VStack gap={'8'}>
                         {vedtaksperioderOversikt.tilsynBarn.length > 0 && (

--- a/src/frontend/Sider/Personoversikt/Ytelseoversikt/Ytelseoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Ytelseoversikt/Ytelseoversikt.tsx
@@ -33,7 +33,7 @@ const Ytelseoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }
     }, [fagsakPersonId, hentYtelser]);
 
     return (
-        <DataViewer response={{ ytelser }}>
+        <DataViewer type={'andre ytelser'} response={{ ytelser }}>
             {({ ytelser }) => (
                 <>
                     <Heading size={'small'}>

--- a/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
+++ b/src/frontend/komponenter/Brevmottakere/BrevMottakere.tsx
@@ -66,7 +66,7 @@ const BrevMottakere: React.FC<{
     const [visBrevmottakereModal, settVisBrevmottakereModal] = useState(false);
 
     return (
-        <DataViewer response={{ brevmottakere }}>
+        <DataViewer type={'brevmottakere'} response={{ brevmottakere }}>
             {({ brevmottakere }) => (
                 <>
                     <Brevmottakere

--- a/src/frontend/komponenter/Brevmottakere/SøkOrganisasjon.tsx
+++ b/src/frontend/komponenter/Brevmottakere/SøkOrganisasjon.tsx
@@ -47,7 +47,7 @@ export const SøkOrganisasjon: React.FC<Props> = ({ settValgteMottakere }) => {
                 value={organisasjonsnummer}
                 onChange={(e) => settOrganisasjonsnummer(e.target.value)}
             />
-            <DataViewer response={{ søkeresultat }}>
+            <DataViewer type={'søkeresultat'} response={{ søkeresultat }}>
                 {({ søkeresultat }) => {
                     return (
                         <Søkeresultat>

--- a/src/frontend/komponenter/Brevmottakere/SøkPerson.tsx
+++ b/src/frontend/komponenter/Brevmottakere/SøkPerson.tsx
@@ -40,7 +40,7 @@ export const SøkPerson: React.FC<Props> = ({ settValgteMottakere }) => {
                 value={søkIdent}
                 onChange={(e) => settSøkIdent(e.target.value)}
             />
-            <DataViewer response={{ søkeresultat }}>
+            <DataViewer type={'søkeresultat'} response={{ søkeresultat }}>
                 {({ søkeresultat }) => {
                     return (
                         <Søkeresultat>

--- a/src/frontend/komponenter/DataViewer.tsx
+++ b/src/frontend/komponenter/DataViewer.tsx
@@ -21,7 +21,7 @@ import { feiletRessursTilFeilmelding } from './Feil/feilmeldingUtils';
 interface DataViewerProps<T extends Record<string, unknown>> {
     children: ((data: T) => React.ReactElement | null) | ReactNode;
     response: { [P in keyof T]: Ressurs<T[P]> };
-    type?: string;
+    type: string;
 }
 
 // eslint-disable-next-line
@@ -47,12 +47,18 @@ function DataViewer<T extends Record<string, unknown>>(
         return (
             <>
                 {responses.filter(erFeilressurs).map((feilet, index) => {
-                    const tittelForFeil =
-                        feilet.frontendFeilmeldingUtenFeilkode === 'Ukjent feil'
-                            ? `Vi kan ikke vise ${type} akkurat nå på grunn av en teknisk feil. Prøv å laste siden på nytt`
-                            : undefined;
+                    const erUkjentFeil = feilet.frontendFeilmeldingUtenFeilkode === 'Ukjent feil';
+                    const tittelForFeil = erUkjentFeil
+                        ? `Vi kan ikke vise ${type} akkurat nå på grunn av en teknisk feil. Prøv å laste siden på nytt.`
+                        : undefined;
                     const feil = feiletRessursTilFeilmelding(feilet, tittelForFeil);
-                    return <Feilmelding key={index} feil={feil} />;
+                    const feilUtenFeilmeldingHvisUkjentFeil = tittelForFeil
+                        ? {
+                              ...feil,
+                              feilmelding: ' ',
+                          }
+                        : feil;
+                    return <Feilmelding key={index} feil={feilUtenFeilmeldingHvisUkjentFeil} />;
                 })}
             </>
         );

--- a/src/frontend/komponenter/DataViewer.tsx
+++ b/src/frontend/komponenter/DataViewer.tsx
@@ -21,6 +21,7 @@ import { feiletRessursTilFeilmelding } from './Feil/feilmeldingUtils';
 interface DataViewerProps<T extends Record<string, unknown>> {
     children: ((data: T) => React.ReactElement | null) | ReactNode;
     response: { [P in keyof T]: Ressurs<T[P]> };
+    type?: string;
 }
 
 // eslint-disable-next-line
@@ -39,15 +40,20 @@ const renderChildren = (children: any, response: any): ReactElement => {
 function DataViewer<T extends Record<string, unknown>>(
     props: DataViewerProps<T>
 ): ReactNode | null {
-    const { response, children } = props;
+    const { response, children, type } = props;
     const responses = Object.values(response);
 
     if (responses.some(erFeilressurs)) {
         return (
             <>
-                {responses.filter(erFeilressurs).map((feilet, index) => (
-                    <Feilmelding key={index} feil={feiletRessursTilFeilmelding(feilet)} />
-                ))}
+                {responses.filter(erFeilressurs).map((feilet, index) => {
+                    const tittelForFeil =
+                        feilet.frontendFeilmeldingUtenFeilkode === 'Ukjent feil'
+                            ? `Vi kan ikke vise ${type} akkurat nå på grunn av en teknisk feil. Prøv å laste siden på nytt`
+                            : undefined;
+                    const feil = feiletRessursTilFeilmelding(feilet, tittelForFeil);
+                    return <Feilmelding key={index} feil={feil} />;
+                })}
             </>
         );
     }

--- a/src/frontend/komponenter/PdfVisning.tsx
+++ b/src/frontend/komponenter/PdfVisning.tsx
@@ -55,7 +55,7 @@ const PdfVisning: React.FC<PdfVisningProps> = ({ pdfFilInnhold }) => {
     }
 
     return (
-        <DataViewer response={{ pdfFilInnhold }}>
+        <DataViewer type={'pdf'} response={{ pdfFilInnhold }}>
             {({ pdfFilInnhold }) => (
                 <DokumentWrapper>
                     <Pagination

--- a/src/frontend/komponenter/SettPåVent/SettPåVentContainer.tsx
+++ b/src/frontend/komponenter/SettPåVent/SettPåVentContainer.tsx
@@ -101,7 +101,7 @@ const SettPåVentContainer: React.FC<{
         }
         return (
             <Container>
-                <DataViewer response={{ statusResponse }}>
+                <DataViewer type={'sett på vent'} response={{ statusResponse }}>
                     {({ statusResponse }) => (
                         <>
                             <SettPåVentInformasjon


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Lagt til type på dataviewer for å kunne få med en tittel på feilmeldingen i tilfelle det er en "ukjent feil". 

<img width="951" alt="image" src="https://github.com/user-attachments/assets/7801493e-631b-4632-95f6-746ffa0950b5" />
