### PR TITLE
Lagt til at man skal kunne få dekket faktiske utgifter hvis man har e…

### DIFF
--- a/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/EndreVilkår/EndreVilkår.tsx
@@ -1,5 +1,6 @@
 import React, { FC, useEffect, useId, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { TrashIcon } from '@navikt/aksel-icons';
@@ -29,6 +30,7 @@ import {
 } from '../../vilkår';
 import { Feilmeldinger, ingen, ingenFeil, validerVilkårsvurderinger } from '../validering';
 import EndreUtgift from './EndreUtgift';
+import { Toggle } from '../../../../utils/toggles';
 
 const StyledForm = styled.form`
     background: white;
@@ -71,6 +73,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = ({
 }) => {
     const { nullstillUlagretKomponent, settUlagretKomponent } = useApp();
     const { behandling } = useBehandling();
+
+    const skalTillateIngenHøyereUtgifter = useFlag(Toggle.BOUTGIFTER_TILLAT_HOYERE_UTGIFTER);
 
     const [detFinnesUlagredeEndringer, settDetFinnesUlagredeEndringer] = useState<boolean>(false);
     const [komponentId] = useId();
@@ -117,7 +121,8 @@ export const EndreVilkår: FC<EndreVilkårProps> = ({
             fom,
             tom,
             behandling.revurderFra,
-            erFremtidigUtgift
+            erFremtidigUtgift,
+            skalTillateIngenHøyereUtgifter
         );
 
         settFeilmeldinger(valideringsfeil);

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/LesevisningVilkår.tsx
@@ -3,10 +3,11 @@ import React, { FC } from 'react';
 import { styled } from 'styled-components';
 
 import { PencilIcon } from '@navikt/aksel-icons';
-import { BodyShort, HGrid, HStack, Label, VStack } from '@navikt/ds-react';
+import { BodyShort, HGrid, HStack, Label, Tag, VStack } from '@navikt/ds-react';
 import { AShadowXsmall } from '@navikt/ds-tokens/dist/tokens';
 
 import LesevisningFremtidigUtgift from './LesevisningFremtidigUtgift';
+import { skalFåDekketFaktiskeUtgifter } from './utils';
 import { useBehandling } from '../../../context/BehandlingContext';
 import { VilkårsresultatIkon } from '../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
@@ -70,6 +71,11 @@ const LesevisningVilkår: FC<{
                         <BodyShort size="small">
                             {`kr ${formaterTallMedTusenSkilleEllerStrek(utgift)}`}
                         </BodyShort>
+                        {skalFåDekketFaktiskeUtgifter(vilkår) && (
+                            <Tag variant="alt1" size={'xsmall'} style={{ maxWidth: 'fit-content' }}>
+                                Faktiske utgifter
+                            </Tag>
+                        )}
                     </VStack>
                     <HGrid gap={'1 4'} columns="minmax(100px, max-content) 1fr">
                         {!erFremtidigUtgift &&

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/utils.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/utils.ts
@@ -7,7 +7,7 @@ import {
     Svaralternativ,
 } from '../../../typer/regel';
 import { harIkkeVerdi, harVerdi } from '../../../utils/utils';
-import { Delvilkår, Vilkårsresultat, Vurdering } from '../vilkår';
+import { Delvilkår, Vilkår, Vilkårsresultat, Vurdering } from '../vilkår';
 
 export function begrunnelseErPåkrevdOgUtfyllt(
     svarsalternativ: Svaralternativ,
@@ -136,3 +136,12 @@ export const lagTomtDelvilkårsett = (
                 vurderinger: [utledVurdering(regel)],
             };
         });
+
+export const skalFåDekketFaktiskeUtgifter = (vilkår: Vilkår) =>
+    vilkår.delvilkårsett.some((delvilkår) =>
+        delvilkår.vurderinger.some(
+            (vurdering) =>
+                vurdering.regelId === 'HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER' &&
+                vurdering.svar === 'JA'
+        )
+    );

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
@@ -19,10 +19,11 @@ export const validerVilkårsvurderinger = (
     delvilkårsett: Delvilkår[],
     lagredeFelter: RedigerbareVilkårfelter,
     regler: Regler,
-    fom?: string,
-    tom?: string,
-    revurderesFraDato?: string,
-    erFremtidigUtgift?: boolean
+    fom: string | undefined,
+    tom: string | undefined,
+    revurderesFraDato: string | undefined,
+    erFremtidigUtgift: boolean | undefined,
+    skalTillateIngenHøyereUtgifter: boolean
 ): Feilmeldinger => {
     const valideringsfeil: Feilmeldinger = { delvilkårsvurderinger: {} };
 
@@ -43,6 +44,18 @@ export const validerVilkårsvurderinger = (
             .flatMap((delvilkår) => delvilkår.vurderinger)
             .forEach((vurdering) => {
                 const gjeldendeRegel = vurdering.regelId;
+
+                if (!skalTillateIngenHøyereUtgifter) {
+                    // I MVPen krever vi at svarer på "Har søker høyere utgifter grunnet helsemessige årsaker?" er "Nei" da vi ikke har støtte for å beregne dette
+                    if (
+                        gjeldendeRegel === 'HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER' &&
+                        vurdering.svar === 'JA'
+                    ) {
+                        valideringsfeil.delvilkårsvurderinger[gjeldendeRegel] =
+                            'Løsningen støtter ikke dette valget enda. Ta kontakt med Tilleggsstønader-teamet.';
+                        return;
+                    }
+                }
 
                 if (!vurdering.svar) {
                     valideringsfeil.delvilkårsvurderinger[gjeldendeRegel] = 'Du må ta et valg';

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/validering.ts
@@ -44,16 +44,6 @@ export const validerVilkårsvurderinger = (
             .forEach((vurdering) => {
                 const gjeldendeRegel = vurdering.regelId;
 
-                // I MVPen krever vi at svarer på "Har søker høyere utgifter grunnet helsemessige årsaker?" er "Nei" da vi ikke har støtte for å beregne dette
-                if (
-                    gjeldendeRegel === 'HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER' &&
-                    vurdering.svar === 'JA'
-                ) {
-                    valideringsfeil.delvilkårsvurderinger[gjeldendeRegel] =
-                        'Løsningen støtter ikke dette valget enda. Ta kontakt med Tilleggsstønader-teamet.';
-                    return;
-                }
-
                 if (!vurdering.svar) {
                     valideringsfeil.delvilkårsvurderinger[gjeldendeRegel] = 'Du må ta et valg';
                     return;

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -23,4 +23,5 @@ export enum Toggle {
     TILLATER_NULLVEDAK = `sak.tillater_nullvedtak`,
     SKAL_VISE_DETALJERT_BEREGNINGSRESULTAT = `sak.detaljert_beregningsresultat`,
     SKAL_VISE_VEDTAKSPERIODER_TAB = `sak.frontend.skal-vise-vedtaksperiode-tab`,
+    BOUTGIFTER_TILLAT_HOYERE_UTGIFTER = `sak.boutgifter-tillat-hoyere-utgifter`,
 }


### PR DESCRIPTION
…t vilkår i perioden som har oppfylt HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER

### Hvorfor er denne endringen nødvendig? ✨
Vi har behov for å kunne innvilge dette nå

* Lars sa at vi ikke trengte tag på beregningsresultatet eller behandlingsoppsummeringen https://www.figma.com/design/a6qlyarKG3xG2A1yjkZzMz/Bolig-og-overnatting---TS-sak?node-id=3345-15180&t=y4Mfm8vSWAZMzkZ9-4

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-24821

* https://github.com/navikt/tilleggsstonader-sak/pull/745

<img width="636" alt="image" src="https://github.com/user-attachments/assets/bffcc156-ad6c-4866-baee-198df5957718" />

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/7b139a82-2f6d-4c74-8779-9644b272dfe5" />

<img width="627" alt="image" src="https://github.com/user-attachments/assets/8c322fea-8b8e-4c82-8bc0-969e8243e888" />
