### PR TITLE
Fjerner revurderFra-fane når vi utleder endringsdato automatisk

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
@@ -15,6 +16,7 @@ import { SettPåVentSak } from '../../komponenter/SettPåVent/SettPåVentContain
 import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
 import { BehandlingType } from '../../typer/behandling/behandlingType';
 import { Toast } from '../../typer/toast';
+import { Toggle } from '../../utils/toggles';
 
 const StickyTablistContainer = styled(Sticky)`
     top: 97px;
@@ -54,8 +56,10 @@ const BehandlingTabsInnhold = () => {
     const path = useLocation().pathname.split('/')[3];
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
 
+    const utledEndringsdatoAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
+
     const førsteFanePath =
-        behandling.type === BehandlingType.REVURDERING
+        behandling.type === BehandlingType.REVURDERING && !utledEndringsdatoAutomatisk
             ? FanePath.REVURDER_FRA
             : FanePath.INNGANGSVILKÅR;
     const aktivFane = isFanePath(path) ? path : førsteFanePath;
@@ -76,7 +80,7 @@ const BehandlingTabsInnhold = () => {
         }
     };
 
-    const behandlingFaner = hentBehandlingfaner(behandling);
+    const behandlingFaner = hentBehandlingfaner(behandling, !utledEndringsdatoAutomatisk);
 
     return (
         <StegProvider

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Inngangsvilkår.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import { styled } from 'styled-components';
 
 import { VStack } from '@navikt/ds-react';
@@ -14,6 +15,7 @@ import DataViewer from '../../../komponenter/DataViewer';
 import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Stønadstype } from '../../../typer/behandling/behandlingTema';
 import { Steg } from '../../../typer/behandling/steg';
+import { Toggle } from '../../../utils/toggles';
 import { FanePath } from '../faner';
 import { VarselRevurderFraDatoMangler } from '../Felles/VarselRevurderFraDatoMangler';
 import { VarselVedtakIArena } from '../Felles/VarselVedtakIArena';
@@ -39,11 +41,12 @@ const Inngangsvilkår = () => {
     const { behandling } = useBehandling();
 
     const { vilkårperioderResponse, hentVilkårperioder } = useVilkårperioder(behandling.id);
+    const utledEndringsdatoAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
 
     return (
         <Container>
             <VarselVedtakIArena />
-            <VarselRevurderFraDatoMangler />
+            {!utledEndringsdatoAutomatisk && <VarselRevurderFraDatoMangler />}
 
             <DataViewer
                 type={'inngangsvilkår'}

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/Stønadsvilkår.tsx
@@ -1,5 +1,6 @@
 import React, { useEffect } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import { styled } from 'styled-components';
 
 import { VStack } from '@navikt/ds-react';
@@ -14,6 +15,7 @@ import DataViewer from '../../../komponenter/DataViewer';
 import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Stønadstype } from '../../../typer/behandling/behandlingTema';
 import { Steg } from '../../../typer/behandling/steg';
+import { Toggle } from '../../../utils/toggles';
 import { FanePath } from '../faner';
 import { VarselRevurderFraDatoMangler } from '../Felles/VarselRevurderFraDatoMangler';
 import { StønadsvilkårPassBarn } from './PassBarn/StønadsvilkårPassBarn';
@@ -39,10 +41,12 @@ const Stønadsvilkår: React.FC<{
         hentRegler();
     }, [hentRegler]);
 
+    const utledEndringsdatoAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
+
     return (
         <Container>
             <VarselVedtakIArena />
-            <VarselRevurderFraDatoMangler />
+            {!utledEndringsdatoAutomatisk && <VarselRevurderFraDatoMangler />}
             <DataViewer
                 type={'stønadsvilkår'}
                 response={{

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Beregningsresultat.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { BodyShort, Label, VStack } from '@navikt/ds-react';
@@ -7,7 +8,9 @@ import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 import '@navikt/ds-css';
 
 import { BeregningsresultatTilsynBarn } from '../../../../../typer/vedtak/vedtakTilsynBarn';
+import { formaterIsoDato } from '../../../../../utils/dato';
 import { formaterTallMedTusenSkille } from '../../../../../utils/fomatering';
+import { Toggle } from '../../../../../utils/toggles';
 
 const Container = styled.div`
     background-color: ${AWhite};
@@ -28,31 +31,42 @@ interface Props {
 }
 
 const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => {
+    const endringsdatoUtledesAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
     return (
-        <VStack gap={'8'}>
-            <Container>
-                <Grid>
-                    <Label>Periode</Label>
-                    <Label>Barn</Label>
-                    <Label>Månedlige utgifter</Label>
-                    <Label>Dagsats</Label>
-                    <Label>Stønadsbeløp</Label>
-                    {beregningsresultat.perioder.map((periode, indeks) => (
-                        <React.Fragment key={indeks}>
-                            <BodyShort size="small">{periode.grunnlag.måned}</BodyShort>
-                            <BodyShort size="small">{periode.grunnlag.antallBarn}</BodyShort>
-                            <BodyShort size="small">
-                                {formaterTallMedTusenSkille(periode.grunnlag.utgifterTotal)}
-                            </BodyShort>
-                            <BodyShort size="small">{periode.dagsats}</BodyShort>
-                            <BodyShort size="small">
-                                {formaterTallMedTusenSkille(periode.månedsbeløp)}
-                            </BodyShort>
-                        </React.Fragment>
-                    ))}
-                </Grid>
-            </Container>
-        </VStack>
+        <>
+            <VStack gap={'8'}>
+                <Container>
+                    <Grid>
+                        <Label>Periode</Label>
+                        <Label>Barn</Label>
+                        <Label>Månedlige utgifter</Label>
+                        <Label>Dagsats</Label>
+                        <Label>Stønadsbeløp</Label>
+                        {beregningsresultat.perioder.map((periode, indeks) => (
+                            <React.Fragment key={indeks}>
+                                <BodyShort size="small">{periode.grunnlag.måned}</BodyShort>
+                                <BodyShort size="small">{periode.grunnlag.antallBarn}</BodyShort>
+                                <BodyShort size="small">
+                                    {formaterTallMedTusenSkille(periode.grunnlag.utgifterTotal)}
+                                </BodyShort>
+                                <BodyShort size="small">{periode.dagsats}</BodyShort>
+                                <BodyShort size="small">
+                                    {formaterTallMedTusenSkille(periode.månedsbeløp)}
+                                </BodyShort>
+                            </React.Fragment>
+                        ))}
+                    </Grid>
+                </Container>
+            </VStack>
+            {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
+                <VStack gap="2">
+                    <Label size="small">Beregnet fra første endring i revurdering:</Label>
+                    <BodyShort size="small">
+                        {formaterIsoDato(beregningsresultat.beregnetFra)}
+                    </BodyShort>
+                </VStack>
+            )}
+        </>
     );
 };
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Barnetilsyn/InnvilgeVedtak/Beregningsresultat.tsx
@@ -58,11 +58,11 @@ const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => {
                     </Grid>
                 </Container>
             </VStack>
-            {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
+            {endringsdatoUtledesAutomatisk && beregningsresultat.tidligsteEndring && (
                 <VStack gap="2">
                     <Label size="small">Beregnet fra første endring i revurdering:</Label>
                     <BodyShort size="small">
-                        {formaterIsoDato(beregningsresultat.beregnetFra)}
+                        {formaterIsoDato(beregningsresultat.tidligsteEndring)}
                     </BodyShort>
                 </VStack>
             )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/Beregningsresultat.tsx
@@ -58,15 +58,15 @@ const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => {
                         ))}
                     </Grid>
                 </Container>
-                {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
-                    <VStack gap="2">
-                        <Label size="small">Beregnet fra første endring i revurdering:</Label>
-                        <BodyShort size="small">
-                            {formaterIsoDato(beregningsresultat.beregnetFra)}
-                        </BodyShort>
-                    </VStack>
-                )}
             </VStack>
+            {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
+                <VStack gap="2">
+                    <Label size="small">Beregnet fra første endring i revurdering:</Label>
+                    <BodyShort size="small">
+                        {formaterIsoDato(beregningsresultat.beregnetFra)}
+                    </BodyShort>
+                </VStack>
+            )}
         </>
     );
 };

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/Beregningsresultat.tsx
@@ -59,11 +59,11 @@ const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => {
                     </Grid>
                 </Container>
             </VStack>
-            {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
+            {endringsdatoUtledesAutomatisk && beregningsresultat.tidligsteEndring && (
                 <VStack gap="2">
                     <Label size="small">Beregnet fra første endring i revurdering:</Label>
                     <BodyShort size="small">
-                        {formaterIsoDato(beregningsresultat.beregnetFra)}
+                        {formaterIsoDato(beregningsresultat.tidligsteEndring)}
                     </BodyShort>
                 </VStack>
             )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/Beregningsresultat.tsx
@@ -1,5 +1,6 @@
 import React, { FC } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
 import { Alert, BodyShort, Label, VStack } from '@navikt/ds-react';
@@ -8,6 +9,7 @@ import '@navikt/ds-css';
 
 import { BeregningsresultatBoutgifter } from '../../../../../typer/vedtak/vedtakBoutgifter';
 import { formaterIsoDato } from '../../../../../utils/dato';
+import { Toggle } from '../../../../../utils/toggles';
 
 const Container = styled.div`
     background-color: ${AWhite};
@@ -28,33 +30,44 @@ interface Props {
 }
 
 const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => {
+    const endringsdatoUtledesAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
     return (
-        <VStack gap={'8'}>
-            <Container>
-                <Grid>
-                    <Label>Fra og med</Label>
-                    <Label>Til og med</Label>
-                    <Label>Merutgift</Label>
-                    <Label>Stønadsbeløp</Label>
-                    <div />
-                    {beregningsresultat.perioder.map((periode, indeks) => (
-                        <React.Fragment key={indeks}>
-                            <BodyShort size="small">{formaterIsoDato(periode.fom)}</BodyShort>
-                            <BodyShort size="small">{formaterIsoDato(periode.tom)}</BodyShort>
-                            <BodyShort size="small">{periode.sumUtgifter}</BodyShort>
-                            <BodyShort size="small">{periode.stønadsbeløp}</BodyShort>
-                            <div>
-                                {periode.delAvTidligereUtbetaling && (
-                                    <Alert variant="info" size={'small'} inline>
-                                        Treffer allerede utbetalt periode
-                                    </Alert>
-                                )}
-                            </div>
-                        </React.Fragment>
-                    ))}
-                </Grid>
-            </Container>
-        </VStack>
+        <>
+            <VStack gap={'8'}>
+                <Container>
+                    <Grid>
+                        <Label>Fra og med</Label>
+                        <Label>Til og med</Label>
+                        <Label>Merutgift</Label>
+                        <Label>Stønadsbeløp</Label>
+                        <div />
+                        {beregningsresultat.perioder.map((periode, indeks) => (
+                            <React.Fragment key={indeks}>
+                                <BodyShort size="small">{formaterIsoDato(periode.fom)}</BodyShort>
+                                <BodyShort size="small">{formaterIsoDato(periode.tom)}</BodyShort>
+                                <BodyShort size="small">{periode.sumUtgifter}</BodyShort>
+                                <BodyShort size="small">{periode.stønadsbeløp}</BodyShort>
+                                <div>
+                                    {periode.delAvTidligereUtbetaling && (
+                                        <Alert variant="info" size={'small'} inline>
+                                            Treffer allerede utbetalt periode
+                                        </Alert>
+                                    )}
+                                </div>
+                            </React.Fragment>
+                        ))}
+                    </Grid>
+                </Container>
+                {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
+                    <VStack gap="2">
+                        <Label size="small">Beregnet fra første endring i revurdering:</Label>
+                        <BodyShort size="small">
+                            {formaterIsoDato(beregningsresultat.beregnetFra)}
+                        </BodyShort>
+                    </VStack>
+                )}
+            </VStack>
+        </>
     );
 };
 

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
@@ -66,11 +66,11 @@ export const Beregningsresultat: FC<{ beregningsresultat: BeregningsresultatLær
                     ))}
                 </Grid>
             </Container>
-            {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
+            {endringsdatoUtledesAutomatisk && beregningsresultat.tidligsteEndring && (
                 <VStack gap="2">
                     <Label size={'small'}>Beregnet fra første endring i revurdering:</Label>
                     <BodyShort size="small">
-                        {formaterIsoDato(beregningsresultat.beregnetFra)}
+                        {formaterIsoDato(beregningsresultat.tidligsteEndring)}
                     </BodyShort>
                 </VStack>
             )}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Læremidler/InnvilgeVedtak/Beregningsresultat.tsx
@@ -1,14 +1,16 @@
 import React, { FC } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
 import styled from 'styled-components';
 
-import { Alert, BodyShort, Label } from '@navikt/ds-react';
+import { Alert, BodyShort, Label, VStack } from '@navikt/ds-react';
 import { AWhite } from '@navikt/ds-tokens/dist/tokens';
 import '@navikt/ds-css';
 
 import { BeregningsresultatLæremidler } from '../../../../../typer/vedtak/vedtakLæremidler';
 import { formaterIsoDato } from '../../../../../utils/dato';
 import { formaterTallMedTusenSkille } from '../../../../../utils/fomatering';
+import { Toggle } from '../../../../../utils/toggles';
 import { studienivåTilTekst } from '../../../Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
 
 const Container = styled.div`
@@ -24,41 +26,56 @@ const Grid = styled.div`
 
 export const Beregningsresultat: FC<{ beregningsresultat: BeregningsresultatLæremidler }> = ({
     beregningsresultat,
-}) => (
-    <Container>
-        <Grid>
-            <Label>Fom</Label>
-            <Label>Tom</Label>
-            <Label>Ant. måneder</Label>
-            <Label>Studienivå</Label>
-            <Label>Prosent</Label>
-            <Label>Månedsbeløp</Label>
-            <Label>Stønadsbeløp</Label>
-            <div />
-            {beregningsresultat.perioder.map((periode, indeks) => (
-                <React.Fragment key={indeks}>
-                    <BodyShort size="small">{formaterIsoDato(periode.fom)}</BodyShort>
-                    <BodyShort size="small">{formaterIsoDato(periode.tom)}</BodyShort>
-                    <BodyShort size="small">{periode.antallMåneder}</BodyShort>
-                    <BodyShort size="small">{studienivåTilTekst[periode.studienivå]}</BodyShort>
-                    <BodyShort size="small">{periode.studieprosent}%</BodyShort>
+}) => {
+    const endringsdatoUtledesAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
+    return (
+        <>
+            <Container>
+                <Grid>
+                    <Label>Fom</Label>
+                    <Label>Tom</Label>
+                    <Label>Ant. måneder</Label>
+                    <Label>Studienivå</Label>
+                    <Label>Prosent</Label>
+                    <Label>Månedsbeløp</Label>
+                    <Label>Stønadsbeløp</Label>
+                    <div />
+                    {beregningsresultat.perioder.map((periode, indeks) => (
+                        <React.Fragment key={indeks}>
+                            <BodyShort size="small">{formaterIsoDato(periode.fom)}</BodyShort>
+                            <BodyShort size="small">{formaterIsoDato(periode.tom)}</BodyShort>
+                            <BodyShort size="small">{periode.antallMåneder}</BodyShort>
+                            <BodyShort size="small">
+                                {studienivåTilTekst[periode.studienivå]}
+                            </BodyShort>
+                            <BodyShort size="small">{periode.studieprosent}%</BodyShort>
+                            <BodyShort size="small">
+                                {formaterTallMedTusenSkille(periode.stønadsbeløpPerMåned)} kr
+                            </BodyShort>
+                            <BodyShort size="small">
+                                {formaterTallMedTusenSkille(periode.stønadsbeløpForPeriode)} kr
+                            </BodyShort>
+                            <div>
+                                {periode.delAvTidligereUtbetaling && (
+                                    <Alert variant="info" size={'small'} inline>
+                                        Treffer allerede utbetalt mnd
+                                    </Alert>
+                                )}
+                            </div>
+                        </React.Fragment>
+                    ))}
+                </Grid>
+            </Container>
+            {endringsdatoUtledesAutomatisk && beregningsresultat.beregnetFra && (
+                <VStack gap="2">
+                    <Label size={'small'}>Beregnet fra første endring i revurdering:</Label>
                     <BodyShort size="small">
-                        {formaterTallMedTusenSkille(periode.stønadsbeløpPerMåned)} kr
+                        {formaterIsoDato(beregningsresultat.beregnetFra)}
                     </BodyShort>
-                    <BodyShort size="small">
-                        {formaterTallMedTusenSkille(periode.stønadsbeløpForPeriode)} kr
-                    </BodyShort>
-                    <div>
-                        {periode.delAvTidligereUtbetaling && (
-                            <Alert variant="info" size={'small'} inline>
-                                Treffer allerede utbetalt mnd
-                            </Alert>
-                        )}
-                    </div>
-                </React.Fragment>
-            ))}
-        </Grid>
-    </Container>
-);
+                </VStack>
+            )}
+        </>
+    );
+};
 
 export default Beregningsresultat;

--- a/src/frontend/Sider/Behandling/faner.tsx
+++ b/src/frontend/Sider/Behandling/faner.tsx
@@ -180,9 +180,12 @@ const stønadsvilkårFane = (behandling: Behandling): FanerMedRouter[] => {
     }
 };
 
-export const hentBehandlingfaner = (behandling: Behandling): FanerMedRouter[] => {
+export const hentBehandlingfaner = (
+    behandling: Behandling,
+    medRevurdering: boolean
+): FanerMedRouter[] => {
     return [
-        ...revurderingFraFane(behandling),
+        ...(medRevurdering ? revurderingFraFane(behandling) : []),
         {
             navn: FaneNavn.INNGANGSVILKÅR,
             path: FanePath.INNGANGSVILKÅR,

--- a/src/frontend/context/StegContext.ts
+++ b/src/frontend/context/StegContext.ts
@@ -1,8 +1,10 @@
+import { useFlag } from '@unleash/proxy-client-react';
 import constate from 'constate';
 
 import { FanePath, faneTilSteg } from '../Sider/Behandling/faner';
 import { Behandling } from '../typer/behandling/behandling';
 import { BehandlingType } from '../typer/behandling/behandlingType';
+import { Toggle } from '../utils/toggles';
 
 interface Props {
     fane: FanePath | undefined;
@@ -12,10 +14,13 @@ interface Props {
 
 export const [StegProvider, useSteg] = constate(
     ({ fane, behandling, behandlingErRedigerbar }: Props) => {
+        const utledEndringsdatoAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
         const erISteg = fane && behandling.steg === faneTilSteg[fane];
 
         const revurderFraDatoMangler =
-            behandling.type === BehandlingType.REVURDERING && !behandling.revurderFra;
+            behandling.type === BehandlingType.REVURDERING &&
+            !behandling.revurderFra &&
+            !utledEndringsdatoAutomatisk;
 
         const erStegRedigerbart = erISteg && behandlingErRedigerbar && !revurderFraDatoMangler;
 

--- a/src/frontend/typer/vedtak/vedtakBoutgifter.ts
+++ b/src/frontend/typer/vedtak/vedtakBoutgifter.ts
@@ -63,6 +63,7 @@ export type BeregnBoutgifterRequest = {
 export type BeregningsresultatBoutgifter = {
     perioder: Beregningsresultat[];
     inneholderUtgifterOvernatting: boolean;
+    beregnetFra: string | undefined;
 };
 
 export enum BeregningsresultatUtgifterKeys {

--- a/src/frontend/typer/vedtak/vedtakBoutgifter.ts
+++ b/src/frontend/typer/vedtak/vedtakBoutgifter.ts
@@ -63,7 +63,7 @@ export type BeregnBoutgifterRequest = {
 export type BeregningsresultatBoutgifter = {
     perioder: Beregningsresultat[];
     inneholderUtgifterOvernatting: boolean;
-    beregnetFra: string | undefined;
+    tidligsteEndring: string | undefined;
 };
 
 export enum BeregningsresultatUtgifterKeys {

--- a/src/frontend/typer/vedtak/vedtakLæremidler.ts
+++ b/src/frontend/typer/vedtak/vedtakLæremidler.ts
@@ -34,7 +34,7 @@ export interface InnvilgelseLæremidler {
 
 export interface BeregningsresultatLæremidler {
     perioder: BeregningsresultatForPeriode[];
-    beregnetFra: string | undefined;
+    tidligsteEndring: string | undefined;
 }
 
 interface BeregningsresultatForPeriode {

--- a/src/frontend/typer/vedtak/vedtakLæremidler.ts
+++ b/src/frontend/typer/vedtak/vedtakLæremidler.ts
@@ -34,6 +34,7 @@ export interface InnvilgelseLæremidler {
 
 export interface BeregningsresultatLæremidler {
     perioder: BeregningsresultatForPeriode[];
+    beregnetFra: string | undefined;
 }
 
 interface BeregningsresultatForPeriode {

--- a/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
+++ b/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
@@ -44,7 +44,7 @@ export type BeregningsresultatTilsynBarn = {
     vedtaksperioder: VedtaksperiodeBeregningsresultat[];
     gjelderFraOgMed?: string;
     gjelderTilOgMed?: string;
-    beregnetFra: string | undefined;
+    tidligsteEndring: string | undefined;
 };
 
 type Beregningsresultat = {

--- a/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
+++ b/src/frontend/typer/vedtak/vedtakTilsynBarn.ts
@@ -44,6 +44,7 @@ export type BeregningsresultatTilsynBarn = {
     vedtaksperioder: VedtaksperiodeBeregningsresultat[];
     gjelderFraOgMed?: string;
     gjelderTilOgMed?: string;
+    beregnetFra: string | undefined;
 };
 
 type Beregningsresultat = {

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -22,4 +22,5 @@ export enum Toggle {
      */
     TILLATER_NULLVEDAK = `sak.tillater_nullvedtak`,
     SKAL_VISE_VEDTAKSPERIODER_TAB = `sak.frontend.skal-vise-vedtaksperiode-tab`,
+    SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK = `sak.utled-endringsdato-revurdering`,
 }

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -8,6 +8,7 @@ import { Toggle } from './toggles';
  */
 const featureFlags: Partial<Record<Toggle, boolean>> = {
     [Toggle.KAN_SAKSBEHANDLE_LÆREMIDLER]: true,
+    [Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK]: true,
 };
 
 export const mockFlags: IToggle[] = Object.values(Toggle).map((toggle) => {

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -8,7 +8,7 @@ import { Toggle } from './toggles';
  */
 const featureFlags: Partial<Record<Toggle, boolean>> = {
     [Toggle.KAN_SAKSBEHANDLE_LÆREMIDLER]: true,
-    [Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK]: true,
+    [Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK]: false,
 };
 
 export const mockFlags: IToggle[] = Object.values(Toggle).map((toggle) => {


### PR DESCRIPTION
Revurder-fra fane skjules når `sak.utled-endringsdato-revurdering` er skrudd på.

Legger også til nytt felt `beregnetFra` på beregningsresultat for de forskjellige stønader, som viser datoen vedtaket er beregnet fra hvis det er en revurdering

https://github.com/navikt/tilleggsstonader-sak/pull/750