### PR TITLE
♻️ Rename `utgifterTilUtbetaling` -> `utgifter`

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatMedUtgift.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Boutgifter/innvilgeVedtak/BeregningsresultatMedUtgift.tsx
@@ -60,7 +60,7 @@ const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => (
                                 )}
                             </Table.DataCell>
                         </TableRow>
-                        {periode.utgifterTilUtbetaling.map((utgift, index, utgifter) => (
+                        {periode.utgifter.map((utgift, index, utgifter) => (
                             <TableRowGray
                                 key={utgift.fom + utgift.tom}
                                 borderbottom={index === utgifter.length - 1}

--- a/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
+++ b/src/frontend/komponenter/Brev/punktliste/lagInnvilgetPerioderPunktliste.ts
@@ -31,7 +31,7 @@ const lagPunktlisteInnvilgedePerioderForBoutgifter = (
     return `<ul style="margin: 0; padding-top: 0">
     ${beregningsresultat.perioder
         .map((periode) =>
-            periode.utgifterTilUtbetaling
+            periode.utgifter
                 .filter((utgift) => !utgift.erFørRevurderFra)
                 .map(
                     (utgift) =>

--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -37,7 +37,7 @@ const lagRaderForVedtakMidlertidigOvernatting = (
     }
     return beregningsresultat.perioder
         .map((periode) =>
-            periode.utgifterTilUtbetaling
+            periode.utgifter
                 .filter((utgift) => !utgift.erFørRevurderFra)
                 .map((utgift) =>
                     lagRadForVedtak(
@@ -102,5 +102,5 @@ const lagTekstForBegrensetAvMakssats = (beregningsresultat?: BeregningsresultatB
 const skalHaTekstForBegrensetAvMakssats = (beregningsresultat?: BeregningsresultatBoutgifter) =>
     beregningsresultat?.inneholderUtgifterOvernatting &&
     beregningsresultat.perioder.some((periode) =>
-        periode.utgifterTilUtbetaling.some((utgift) => utgift.tilUtbetaling < utgift.utgift)
+        periode.utgifter.some((utgift) => utgift.tilUtbetaling < utgift.utgift)
     );

--- a/src/frontend/typer/vedtak/vedtakBoutgifter.ts
+++ b/src/frontend/typer/vedtak/vedtakBoutgifter.ts
@@ -85,7 +85,7 @@ type Beregningsresultat = {
     tom: string;
     stønadsbeløp: number;
     sumUtgifter: number;
-    utgifterTilUtbetaling: BeregningsresultatUtgifter[];
+    utgifter: BeregningsresultatUtgifter[];
     makssatsBekreftet: boolean;
     delAvTidligereUtbetaling: boolean;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨  
Opprydding der vi tar i bruk `utgifter` på beregningsresultat for boutgifter slik at `utgifterTilUtbetaling` kan slettes i backend.

Er vidre jobbing på dette: https://github.com/navikt/tilleggsstonader-sak/pull/749