### PR TITLE
La saksbehandler sette opphørsdato i vedtakssteg når man opphører et vedtak

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/Opphørsvedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/Opphørsvedtak.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 import { useFlag } from '@unleash/proxy-client-react';
 
-import { Checkbox, CheckboxGroup, Label, Textarea, VStack } from '@navikt/ds-react';
+import { Checkbox, CheckboxGroup, Textarea, VStack } from '@navikt/ds-react';
 
 import { FeilmeldingVedtak, valider } from './validering';
 import { useApp } from '../../../../context/AppContext';
@@ -45,13 +45,15 @@ const OpphørVedtak: React.FC<{
 
     return (
         <VStack gap="4">
-            <Label size={'small'}>Opphørsdato</Label>
             {skalSetteOpphørsdato && (
                 <DateInputMedLeservisning
                     label="Opphørsdato"
-                    hideLabel={true}
+                    hideLabel={false}
                     value={opphørsdato}
-                    onChange={(e) => settOpphørsdato(e)}
+                    onChange={(e) => {
+                        settOpphørsdato(e);
+                        settUlagretKomponent(UlagretKomponent.BEREGNING_OPPHØR);
+                    }}
                     erLesevisning={!erStegRedigerbart}
                     feil={feilmeldinger.opphørsdato}
                     size="small"

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/validering.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/validering.ts
@@ -4,11 +4,14 @@ import { harIkkeVerdi } from '../../../../utils/utils';
 export interface FeilmeldingVedtak {
     årsaker?: string;
     begrunnelse?: string;
+    opphørsdato?: string;
 }
 
 export const valider = (
     årsaker: ÅrsakAvslag[] | ÅrsakOpphør[],
-    begrunnelse?: string
+    begrunnelse?: string,
+    opphørsdato?: string | undefined,
+    skalSetteOpphørsdato?: boolean
 ): FeilmeldingVedtak => {
     const feilmeldinger: FeilmeldingVedtak = {};
 
@@ -18,6 +21,10 @@ export const valider = (
 
     if (harIkkeVerdi(begrunnelse)) {
         feilmeldinger.begrunnelse = 'Begrunnelse må fylles ut';
+    }
+
+    if (skalSetteOpphørsdato && !opphørsdato) {
+        feilmeldinger.opphørsdato = 'Opphørsdato må fylles ut';
     }
 
     return feilmeldinger;

--- a/src/frontend/Sider/Behandling/Venstremeny/BehandlingOppsummering/VedtakOppsummering.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/BehandlingOppsummering/VedtakOppsummering.tsx
@@ -3,7 +3,6 @@ import React from 'react';
 import { VStack, Label, BodyShort } from '@navikt/ds-react';
 
 import { VilkårOppsummeringRad } from './OppsummeringRad';
-import { useBehandling } from '../../../../context/BehandlingContext';
 import { OppsummertVedtak } from '../../../../typer/behandling/behandlingOppsummering';
 import {
     TypeVedtak,
@@ -28,7 +27,8 @@ export const VedtakOppsummering: React.FC<{ vedtak: OppsummertVedtak | undefined
         case TypeVedtak.AVSLAG:
             return <OppsummeringAvslag årsaker={vedtak.årsaker} />;
         case TypeVedtak.OPPHØR:
-            return <OppsummeringOpphør årsaker={vedtak.årsaker} />;
+            // vedtak.opphørsdato er revurderFra fra api om opphørsdato ikke er satt
+            return <OppsummeringOpphør årsaker={vedtak.årsaker} opphørsdato={vedtak.opphørsdato} />;
     }
 };
 
@@ -71,11 +71,13 @@ const OppsummeringAvslag: React.FC<{
     );
 };
 
-const OppsummeringOpphør: React.FC<{ årsaker: ÅrsakOpphør[] }> = ({ årsaker }) => {
-    const { behandling } = useBehandling();
+const OppsummeringOpphør: React.FC<{ årsaker: ÅrsakOpphør[]; opphørsdato: string }> = ({
+    årsaker,
+    opphørsdato,
+}) => {
     return (
         <VStack gap="2">
-            <Label size="small">Opphørt fra og med {formaterDato(behandling.revurderFra)}</Label>
+            <Label size="small">Opphørt fra og med {formaterDato(opphørsdato)}</Label>
             <BodyShort size={'small'}>
                 Årsaker: {årsaker.map((årsak) => årsakOpphørTilTekst[årsak]).join(', ')}
             </BodyShort>

--- a/src/frontend/hooks/useLagreOpphør.ts
+++ b/src/frontend/hooks/useLagreOpphør.ts
@@ -23,7 +23,12 @@ export const useLagreOpphør = () => {
         request<null, OpphørRequest>(
             `/api/sak/vedtak/${stønadstypeTilVedtakUrl[stønadstype]}/${id}/opphor`,
             'POST',
-            { type: TypeVedtak.OPPHØR, årsakerOpphør, begrunnelse, opphørsdato }
+            {
+                type: TypeVedtak.OPPHØR,
+                årsakerOpphør: årsakerOpphør,
+                begrunnelse: begrunnelse,
+                opphørsdato: opphørsdato,
+            }
         );
 
     return { lagreOpphør };

--- a/src/frontend/hooks/useLagreOpphør.ts
+++ b/src/frontend/hooks/useLagreOpphør.ts
@@ -7,6 +7,7 @@ export type OpphørRequest = {
     type: TypeVedtak.OPPHØR;
     årsakerOpphør: ÅrsakOpphør[];
     begrunnelse: string;
+    opphørsdato?: string | undefined;
 };
 
 export const useLagreOpphør = () => {
@@ -14,11 +15,15 @@ export const useLagreOpphør = () => {
     const { behandling } = useBehandling();
     const { id, stønadstype } = behandling;
 
-    const lagreOpphør = (årsakerOpphør: ÅrsakOpphør[], begrunnelse: string) =>
+    const lagreOpphør = (
+        årsakerOpphør: ÅrsakOpphør[],
+        begrunnelse: string,
+        opphørsdato: string | undefined
+    ) =>
         request<null, OpphørRequest>(
             `/api/sak/vedtak/${stønadstypeTilVedtakUrl[stønadstype]}/${id}/opphor`,
             'POST',
-            { type: TypeVedtak.OPPHØR, årsakerOpphør, begrunnelse }
+            { type: TypeVedtak.OPPHØR, årsakerOpphør, begrunnelse, opphørsdato }
         );
 
     return { lagreOpphør };

--- a/src/frontend/typer/behandling/behandlingOppsummering.ts
+++ b/src/frontend/typer/behandling/behandlingOppsummering.ts
@@ -53,4 +53,5 @@ export interface OppsummertVedtakAvslag {
 export interface OppsummertVedtakOpphør {
     resultat: TypeVedtak.OPPHØR;
     årsaker: ÅrsakOpphør[];
+    opphørsdato: string;
 }


### PR DESCRIPTION
Backend: https://github.com/navikt/tilleggsstonader-sak/pull/756

Nytt felt ved opprettelse av vedtak `opphørsdato`, for å tilpasse ved fjerning av revurder-fra.

![image](https://github.com/user-attachments/assets/375464d3-ad30-42af-86e9-94facada9dec)
