### PR TITLE
Dagpenger skal kun ligge inne som en registerytelse frem til vi vet hvordan den skal vilkårvurderes

### DIFF
--- a/src/frontend/Sider/Behandling/Felles/faktiskMålgruppe.ts
+++ b/src/frontend/Sider/Behandling/Felles/faktiskMålgruppe.ts
@@ -2,14 +2,12 @@ import { SelectOption } from '../../../komponenter/Skjema/SelectMedOptions';
 
 export enum FaktiskMålgruppe {
     NEDSATT_ARBEIDSEVNE = 'NEDSATT_ARBEIDSEVNE',
-    DAGPENGER = 'DAGPENGER',
     ENSLIG_FORSØRGER = 'ENSLIG_FORSØRGER',
     GJENLEVENDE = 'GJENLEVENDE',
 }
 
 export const FaktiskMålgruppeTilTekst: Record<FaktiskMålgruppe, string> = {
     NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
-    DAGPENGER: 'Dagpenger',
     ENSLIG_FORSØRGER: 'Enslig forsørger',
     GJENLEVENDE: 'Gjenlevende',
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -14,7 +14,6 @@ export interface Målgruppe extends VilkårPeriode {
 
 export enum MålgruppeType {
     AAP = 'AAP',
-    DAGPENGER = 'DAGPENGER',
     UFØRETRYGD = 'UFØRETRYGD',
     OMSTILLINGSSTØNAD = 'OMSTILLINGSSTØNAD',
     OVERGANGSSTØNAD = 'OVERGANGSSTØNAD',
@@ -26,7 +25,6 @@ export enum MålgruppeType {
 
 export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
     AAP: 'AAP',
-    DAGPENGER: 'Dagpenger',
     UFØRETRYGD: 'Uføretrygd',
     OMSTILLINGSSTØNAD: 'Omstillingsstønad',
     OVERGANGSSTØNAD: 'Overgangsstønad',
@@ -39,7 +37,6 @@ export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
 const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
     [Stønadstype.BARNETILSYN]: {
         AAP: true,
-        DAGPENGER: false,
         UFØRETRYGD: true,
         OMSTILLINGSSTØNAD: true,
         OVERGANGSSTØNAD: true,
@@ -50,7 +47,6 @@ const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
     },
     [Stønadstype.LÆREMIDLER]: {
         AAP: true,
-        DAGPENGER: false,
         UFØRETRYGD: true,
         OMSTILLINGSSTØNAD: true,
         OVERGANGSSTØNAD: true,
@@ -61,7 +57,6 @@ const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
     },
     [Stønadstype.BOUTGIFTER]: {
         AAP: true,
-        DAGPENGER: false,
         UFØRETRYGD: true,
         OMSTILLINGSSTØNAD: true,
         OVERGANGSSTØNAD: true,
@@ -78,12 +73,12 @@ const målgrupper: Record<Stønadstype, Record<MålgruppeType, boolean>> = {
         NEDSATT_ARBEIDSEVNE: true,
         INGEN_MÅLGRUPPE: true,
         GJENLEVENDE_GAMMELT_REGELVERK: true,
-        DAGPENGER: false,
+        // DAGPENGER: false,
         SYKEPENGER_100_PROSENT: false,
     },
 
     [Stønadstype.DAGLIG_REISE_TSR]: {
-        DAGPENGER: true,
+        // DAGPENGER: true,
         INGEN_MÅLGRUPPE: true,
         // KVALIFISERINGSPROGRAM: true,
         // TILTAKSPENGER: true

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppeTilFaktiskMålgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppeTilFaktiskMålgruppe.ts
@@ -15,7 +15,6 @@ export const målgruppeTilFaktiskMålgruppeEllerIngenMålgruppe: Record<
     FaktiskMålgruppeEllerIngenMålgruppe
 > = {
     AAP: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
-    DAGPENGER: FaktiskMålgruppe.DAGPENGER,
     UFØRETRYGD: FaktiskMålgruppe.NEDSATT_ARBEIDSEVNE,
     OMSTILLINGSSTØNAD: FaktiskMålgruppe.GJENLEVENDE,
     OVERGANGSSTØNAD: FaktiskMålgruppe.ENSLIG_FORSØRGER,

--- a/src/frontend/typer/registerytelser.ts
+++ b/src/frontend/typer/registerytelser.ts
@@ -34,7 +34,7 @@ export interface KildeResultatYtelse {
  */
 export type TypeRegisterYtelseForVilkårperiode = Exclude<
     TypeRegisterYtelse,
-    TypeRegisterYtelse.TILTAKSPENGER
+    TypeRegisterYtelse.TILTAKSPENGER | TypeRegisterYtelse.DAGPENGER
 >;
 
 export enum TypeRegisterYtelse {
@@ -50,7 +50,6 @@ export const typeRegisterYtelseTilMålgruppeType: Record<
     MålgruppeType
 > = {
     AAP: MålgruppeType.AAP,
-    DAGPENGER: MålgruppeType.DAGPENGER,
     ENSLIG_FORSØRGER: MålgruppeType.OVERGANGSSTØNAD,
     OMSTILLINGSSTØNAD: MålgruppeType.OMSTILLINGSSTØNAD,
 };


### PR DESCRIPTION
Lukket forrige pr fordi det hang med noen gamle commits som ble feil

Løser også problem vi har nå med at det er mulig å velge "dagpenger" i vedtaksperioder på eksisterende stønader