### PR TITLE
Tydliggjør ingen data i vedtaksperioder- og dokumentoversikt-fane

### DIFF
--- a/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Dokumentoversikt/Dokumentoversikt.tsx
@@ -10,6 +10,7 @@ import DataViewer from '../../../komponenter/DataViewer';
 import { Arkivtema, arkivtemaerTilTekst, relevanteArkivtemaer } from '../../../typer/arkivtema';
 import { DokumentInfo, VedleggRequest } from '../../../typer/dokument';
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../../../typer/ressurs';
+import { formaterDatoMedTidspunkt } from '../../../utils/dato';
 
 const ComboBox = styled(UNSAFE_Combobox)`
     width: 35rem;
@@ -25,6 +26,8 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
         tema: [Arkivtema.TSO, Arkivtema.TSR],
     });
 
+    const [hentetTidspunkt, settHentetTidspunkt] = useState<Date | undefined>();
+
     const hentDokumenter = useCallback(
         (fagsakPersonId: string) => {
             settDokumenter(byggHenterRessurs());
@@ -36,7 +39,10 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                     tema:
                         vedleggRequest.tema.length > 0 ? vedleggRequest.tema : relevanteArkivtemaer,
                 }
-            ).then(settDokumenter);
+            ).then((res) => {
+                settDokumenter(res);
+                settHentetTidspunkt(new Date());
+            });
         },
         [request, vedleggRequest]
     );
@@ -73,7 +79,12 @@ const Dokumentoversikt: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId
                 selectedOptions={vedleggRequest.tema?.map(arkivtemaTilOption) ?? []}
             />
             <DataViewer type={'dokumenter'} response={{ dokumenter }}>
-                {({ dokumenter }) => <DokumentTabell dokumenter={dokumenter} />}
+                {({ dokumenter }) => (
+                    <>
+                        <DokumentTabell dokumenter={dokumenter} />
+                        <Detail>Oppdatert: {formaterDatoMedTidspunkt(hentetTidspunkt)}</Detail>
+                    </>
+                )}
             </DataViewer>
         </>
     );

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/IngenVedtaksperioderInfo.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/IngenVedtaksperioderInfo.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { BodyShort, HStack } from '@navikt/ds-react';
+
+import Info from '../../../komponenter/Ikoner/Vurderingsresultat/Info';
+import { formaterDatoMedTidspunkt } from '../../../utils/dato';
+
+const StyledInfo = styled(Info)`
+    width: 1.125rem;
+    height: 1.125rem;
+`;
+
+export const IngenVedtaksperioderInfo = ({
+    hentetTidspunkt,
+}: {
+    hentetTidspunkt: Date | undefined;
+}) => {
+    return (
+        <HStack gap={'2'} align={'center'}>
+            <StyledInfo />
+            <BodyShort>
+                Ingen vedtaksperioder funnet. Oppdatert: {formaterDatoMedTidspunkt(hentetTidspunkt)}
+            </BodyShort>
+        </HStack>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 
 import { Detail, Heading, VStack } from '@navikt/ds-react';
 
+import { ArenaSakOgVedtak } from './Arena/vedtakArena';
 import { VedtaksperioderOversiktBoutgifter } from './Boutgifter/VedtaksperioderOversiktBoutgifter';
 import { IngenVedtaksperioderInfo } from './IngenVedtaksperioderInfo';
 import { OversiktKort } from './OversiktKort';
@@ -15,7 +16,6 @@ import {
 import DataViewer from '../../../komponenter/DataViewer';
 import { VedtakperioderOversiktResponse } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
 import { formaterDatoMedTidspunkt } from '../../../utils/dato';
-import { ArenaSakOgVedtak } from './Arena/vedtakArena';
 
 interface Props {
     fagsakPersonId: string;

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversikt.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
-import { Heading, VStack } from '@navikt/ds-react';
+import { Detail, Heading, VStack } from '@navikt/ds-react';
 
 import { VedtaksperioderOversiktBoutgifter } from './Boutgifter/VedtaksperioderOversiktBoutgifter';
+import { IngenVedtaksperioderInfo } from './IngenVedtaksperioderInfo';
 import { OversiktKort } from './OversiktKort';
 import { VedtaksperioderOversiktArena } from './VedtaksperioderOversiktArena';
 import { VedtaksperioderOversiktLæremidler } from './VedtaksperioderOversiktLæremidler';
@@ -12,14 +13,19 @@ import {
     useVedtaksperioderOversiktArena,
 } from '../../../hooks/useHentFullstendigVedtaksOversikt';
 import DataViewer from '../../../komponenter/DataViewer';
+import { VedtakperioderOversiktResponse } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
+import { formaterDatoMedTidspunkt } from '../../../utils/dato';
+import { ArenaSakOgVedtak } from './Arena/vedtakArena';
 
 interface Props {
     fagsakPersonId: string;
 }
 
 export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
-    const { vedtaksperioderOversikt } = useHentFullstendigVedtaksOversikt(fagsakPersonId);
-    const { arenaSakOgVedtak } = useVedtaksperioderOversiktArena(fagsakPersonId);
+    const { vedtaksperioderOversikt, hentetTidspunkt } =
+        useHentFullstendigVedtaksOversikt(fagsakPersonId);
+    const { arenaSakOgVedtak, hentetTidspunkt: hentetTidspunktArena } =
+        useVedtaksperioderOversiktArena(fagsakPersonId);
 
     return (
         <>
@@ -30,35 +36,68 @@ export function VedtaksperioderOversikt({ fagsakPersonId }: Props) {
                 type={'vedtaksperioder'}
                 response={{ vedtaksperioderOversikt, arenaSakOgVedtak }}
             >
-                {({ vedtaksperioderOversikt, arenaSakOgVedtak }) => (
-                    <VStack gap={'8'}>
-                        {vedtaksperioderOversikt.tilsynBarn.length > 0 && (
-                            <OversiktKort tittel={'Tilsyn Barn'}>
-                                <VedtaksperioderOversiktTilsynBarn
-                                    vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
-                                />
-                            </OversiktKort>
-                        )}
-                        {vedtaksperioderOversikt.læremidler.length > 0 && (
-                            <OversiktKort tittel={'Læremidler'}>
-                                <VedtaksperioderOversiktLæremidler
-                                    vedtaksperioder={vedtaksperioderOversikt.læremidler}
-                                />
-                            </OversiktKort>
-                        )}
-                        {vedtaksperioderOversikt.boutgifter.length > 0 && (
-                            <OversiktKort tittel={'Boutgifter'}>
-                                <VedtaksperioderOversiktBoutgifter
-                                    vedtaksperioder={vedtaksperioderOversikt.boutgifter}
-                                />
-                            </OversiktKort>
-                        )}
-                        {arenaSakOgVedtak.vedtak.length > 0 && (
-                            <VedtaksperioderOversiktArena arenaSakOgVedtak={arenaSakOgVedtak} />
-                        )}
-                    </VStack>
-                )}
+                {({ vedtaksperioderOversikt, arenaSakOgVedtak }) =>
+                    finnesIngenVedtaksperioder(vedtaksperioderOversikt, arenaSakOgVedtak) ? (
+                        <IngenVedtaksperioderInfo hentetTidspunkt={hentetTidspunkt} />
+                    ) : (
+                        <VStack gap={'8'}>
+                            {vedtaksperioderOversikt.tilsynBarn.length > 0 && (
+                                <OversiktKort tittel={'Tilsyn Barn'}>
+                                    <VedtaksperioderOversiktTilsynBarn
+                                        vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
+                                    />
+                                    <Detail>
+                                        Oppdatert: {formaterDatoMedTidspunkt(hentetTidspunkt)}
+                                    </Detail>
+                                </OversiktKort>
+                            )}
+                            {vedtaksperioderOversikt.læremidler.length > 0 && (
+                                <OversiktKort tittel={'Læremidler'}>
+                                    <VedtaksperioderOversiktLæremidler
+                                        vedtaksperioder={vedtaksperioderOversikt.læremidler}
+                                    />
+                                    <Detail>
+                                        Oppdatert: {formaterDatoMedTidspunkt(hentetTidspunkt)}
+                                    </Detail>
+                                </OversiktKort>
+                            )}
+                            {vedtaksperioderOversikt.boutgifter.length > 0 && (
+                                <OversiktKort tittel={'Boutgifter'}>
+                                    <VedtaksperioderOversiktBoutgifter
+                                        vedtaksperioder={vedtaksperioderOversikt.boutgifter}
+                                    />
+                                    <Detail>
+                                        Oppdatert: {formaterDatoMedTidspunkt(hentetTidspunkt)}
+                                    </Detail>
+                                </OversiktKort>
+                            )}
+                            {arenaSakOgVedtak.vedtak.length > 0 && (
+                                <OversiktKort
+                                    tittel={'TS vedtak i Arena'}
+                                    tagTittel={'Arena'}
+                                    tagVariant={'info'}
+                                >
+                                    <VedtaksperioderOversiktArena
+                                        arenaSakOgVedtak={arenaSakOgVedtak}
+                                    />
+                                    <Detail>
+                                        Oppdatert: {formaterDatoMedTidspunkt(hentetTidspunktArena)}
+                                    </Detail>
+                                </OversiktKort>
+                            )}
+                        </VStack>
+                    )
+                }
             </DataViewer>
         </>
     );
 }
+
+const finnesIngenVedtaksperioder = (
+    vedtaksperioderOversikt: VedtakperioderOversiktResponse,
+    arenaSakOgVedtak: ArenaSakOgVedtak
+): boolean =>
+    vedtaksperioderOversikt.boutgifter.length === 0 &&
+    vedtaksperioderOversikt.læremidler.length === 0 &&
+    vedtaksperioderOversikt.tilsynBarn.length === 0 &&
+    arenaSakOgVedtak.vedtak.length === 0;

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktArena.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktArena.tsx
@@ -4,48 +4,45 @@ import { Table } from '@navikt/ds-react';
 
 import { ArenaSakOgVedtak } from './Arena/vedtakArena';
 import { Vedtaksdetaljer } from './Arena/Vedtaksdetaljer';
-import { OversiktKort } from './OversiktKort';
 import { formaterNullableIsoDato, formaterNullablePeriode } from '../../../utils/dato';
 
 export const VedtaksperioderOversiktArena: React.FC<{ arenaSakOgVedtak: ArenaSakOgVedtak }> = ({
     arenaSakOgVedtak,
 }) => {
     return (
-        <OversiktKort tittel={'TS vedtak i Arena'} tagTittel={'Arena'} tagVariant={'info'}>
-            <Table size={'small'}>
-                <Table.Header>
-                    <Table.Row>
-                        <Table.HeaderCell scope="col">Rettighetstype</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Type</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Utfall</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Periode</Table.HeaderCell>
-                        <Table.HeaderCell scope="col">Dato innstillt</Table.HeaderCell>
-                        <Table.HeaderCell scope="col"></Table.HeaderCell>
-                    </Table.Row>
-                </Table.Header>
-                <Table.Body>
-                    {arenaSakOgVedtak.vedtak.map((vedtak, index) => {
-                        const sak = arenaSakOgVedtak.saker[vedtak.sakId];
-                        return (
-                            <Table.ExpandableRow
-                                key={index}
-                                content={<Vedtaksdetaljer vedtak={vedtak} sak={sak} />}
-                                togglePlacement={'right'}
-                            >
-                                <Table.DataCell>{vedtak.rettighet}</Table.DataCell>
-                                <Table.DataCell>{vedtak.type}</Table.DataCell>
-                                <Table.DataCell>{vedtak.utfall}</Table.DataCell>
-                                <Table.DataCell>
-                                    {formaterNullablePeriode(vedtak.fom, vedtak.tom)}
-                                </Table.DataCell>
-                                <Table.DataCell>
-                                    {formaterNullableIsoDato(vedtak.datoInnstillt)}
-                                </Table.DataCell>
-                            </Table.ExpandableRow>
-                        );
-                    })}
-                </Table.Body>
-            </Table>
-        </OversiktKort>
+        <Table size={'small'}>
+            <Table.Header>
+                <Table.Row>
+                    <Table.HeaderCell scope="col">Rettighetstype</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Type</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Utfall</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Periode</Table.HeaderCell>
+                    <Table.HeaderCell scope="col">Dato innstillt</Table.HeaderCell>
+                    <Table.HeaderCell scope="col"></Table.HeaderCell>
+                </Table.Row>
+            </Table.Header>
+            <Table.Body>
+                {arenaSakOgVedtak.vedtak.map((vedtak, index) => {
+                    const sak = arenaSakOgVedtak.saker[vedtak.sakId];
+                    return (
+                        <Table.ExpandableRow
+                            key={index}
+                            content={<Vedtaksdetaljer vedtak={vedtak} sak={sak} />}
+                            togglePlacement={'right'}
+                        >
+                            <Table.DataCell>{vedtak.rettighet}</Table.DataCell>
+                            <Table.DataCell>{vedtak.type}</Table.DataCell>
+                            <Table.DataCell>{vedtak.utfall}</Table.DataCell>
+                            <Table.DataCell>
+                                {formaterNullablePeriode(vedtak.fom, vedtak.tom)}
+                            </Table.DataCell>
+                            <Table.DataCell>
+                                {formaterNullableIsoDato(vedtak.datoInnstillt)}
+                            </Table.DataCell>
+                        </Table.ExpandableRow>
+                    );
+                })}
+            </Table.Body>
+        </Table>
     );
 };

--- a/src/frontend/hooks/useHentFullstendigVedtaksOversikt.tsx
+++ b/src/frontend/hooks/useHentFullstendigVedtaksOversikt.tsx
@@ -7,35 +7,46 @@ import { VedtakperioderOversiktResponse } from '../typer/vedtak/vedtaksperiodeOp
 
 export const useHentFullstendigVedtaksOversikt = (
     fagsakPersonId: string
-): { vedtaksperioderOversikt: Ressurs<VedtakperioderOversiktResponse> } => {
+): {
+    hentetTidspunkt: Date | undefined;
+    vedtaksperioderOversikt: Ressurs<VedtakperioderOversiktResponse>;
+} => {
     const { request } = useApp();
 
     const [vedtakOversiktResponse, settVedtakOversiktResponse] =
         useState<Ressurs<VedtakperioderOversiktResponse>>(byggTomRessurs());
 
+    const [hentetTidspunkt, settHentetTidspunkt] = useState<Date | undefined>();
+
     useEffect(() => {
         settVedtakOversiktResponse(byggHenterRessurs());
         request<VedtakperioderOversiktResponse, null>(
             `/api/sak/vedtak/fullstendig-oversikt/${fagsakPersonId}`
-        ).then(settVedtakOversiktResponse);
+        ).then((res) => {
+            settVedtakOversiktResponse(res);
+            settHentetTidspunkt(new Date());
+        });
     }, [request, fagsakPersonId]);
 
-    return { vedtaksperioderOversikt: vedtakOversiktResponse };
+    return { hentetTidspunkt: hentetTidspunkt, vedtaksperioderOversikt: vedtakOversiktResponse };
 };
 
 export const useVedtaksperioderOversiktArena = (
     fagsakPersonId: string
-): { arenaSakOgVedtak: Ressurs<ArenaSakOgVedtak> } => {
+): { arenaSakOgVedtak: Ressurs<ArenaSakOgVedtak>; hentetTidspunkt: Date | undefined } => {
     const { request } = useApp();
 
     const [vedtakArena, settVedtakArena] = useState<Ressurs<ArenaSakOgVedtak>>(byggTomRessurs());
 
+    const [hentetTidspunkt, settHentetTidspunkt] = useState<Date | undefined>();
+
     useEffect(() => {
         settVedtakArena(byggHenterRessurs());
-        request<ArenaSakOgVedtak, null>(`/api/sak/arena/vedtak/${fagsakPersonId}`).then(
-            settVedtakArena
-        );
+        request<ArenaSakOgVedtak, null>(`/api/sak/arena/vedtak/${fagsakPersonId}`).then((res) => {
+            settVedtakArena(res);
+            settHentetTidspunkt(new Date());
+        });
     }, [request, fagsakPersonId]);
 
-    return { arenaSakOgVedtak: vedtakArena };
+    return { arenaSakOgVedtak: vedtakArena, hentetTidspunkt: hentetTidspunkt };
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Gjøre det tydligere at TS-sak funker når det ikke finnes data.

Hvis ingen vedtaksperioder:
<img width="880" alt="Screenshot 2025-06-29 at 19 30 10" src="https://github.com/user-attachments/assets/da630a57-7ac8-433e-8b41-3199b5f146ba" />

Hvis ingen dokumenter så vises oppdatert tidspunkt:
<img width="1516" alt="Screenshot 2025-06-29 at 19 30 56" src="https://github.com/user-attachments/assets/6a3b2258-0377-4559-883c-9c64687a2768" />

(La også til oppdatert tidspunkt på vedtaksperioder)
<img width="1306" alt="Screenshot 2025-06-29 at 19 31 54" src="https://github.com/user-attachments/assets/5e9d645f-df80-4d9c-90f3-2bad00ac5151" />

