### PR TITLE
Endrer typer for å matche responsen fra back-end

### DIFF
--- a/src/frontend/Sider/Behandling/RevurderFra/RevurderFra.tsx
+++ b/src/frontend/Sider/Behandling/RevurderFra/RevurderFra.tsx
@@ -12,7 +12,6 @@ import { Feilmelding } from '../../../komponenter/Feil/Feilmelding';
 import { Feil, feiletRessursTilFeilmelding } from '../../../komponenter/Feil/feilmeldingUtils';
 import SmallButton from '../../../komponenter/Knapper/SmallButton';
 import DateInputMedLeservisning from '../../../komponenter/Skjema/DateInputMedLeservisning';
-import { Behandling } from '../../../typer/behandling/behandling';
 import { RessursStatus } from '../../../typer/ressurs';
 import { erEtter, formaterNullableTilTekstligDato } from '../../../utils/dato';
 import { FanePath } from '../faner';
@@ -50,7 +49,7 @@ export function RevurderFra() {
             return;
         }
 
-        const response = await request<Behandling, null>(
+        const response = await request<null, null>(
             `/api/sak/behandling/${behandling.id}/revurder-fra/${revurderFraDato}`,
             'POST'
         );

--- a/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
+++ b/src/frontend/Sider/EksternOmruting/EksternOmrutingBehandling.tsx
@@ -5,7 +5,6 @@ import { useNavigate, useParams } from 'react-router-dom';
 import { useApp } from '../../context/AppContext';
 import { Feilmelding } from '../../komponenter/Feil/Feilmelding';
 import { Feil, feiletRessursTilFeilmelding } from '../../komponenter/Feil/feilmeldingUtils';
-import { Behandling } from '../../typer/behandling/behandling';
 import { RessursStatus } from '../../typer/ressurs';
 
 /*
@@ -19,10 +18,10 @@ export const EksternOmrutingBehandling = () => {
     const [feilmelding, settFeilmelding] = useState<Feil>();
 
     useEffect(() => {
-        request<Behandling, null>(`/api/sak/behandling/ekstern/${eksternBehandlingId}`).then(
+        request<string, null>(`/api/sak/behandling/ekstern/${eksternBehandlingId}`).then(
             (resultat) => {
                 if (resultat.status === RessursStatus.SUKSESS) {
-                    navigate(`/behandling/${resultat.data.id}`);
+                    navigate(`/behandling/${resultat.data}`);
                 } else {
                     settFeilmelding(feiletRessursTilFeilmelding(resultat));
                 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å matche de nye typene back-end returnerer.

BehandlingId -> String
NoContent -> null

/henlegg endepunktet returnerer riktig type
