### PR TITLE
Tydeliggjører foreslå vedtaksperioder då det er ønskelig at saksbehan…

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/Vedtaksperioder.tsx
@@ -153,20 +153,20 @@ export const Vedtaksperioder: React.FC<Props> = ({
                     <HStack gap={'2'}>
                         <Button
                             size="small"
-                            onClick={leggTilPeriode}
+                            onClick={foreslåVedtaksperioder}
                             style={{ maxWidth: 'fit-content' }}
-                            variant="secondary"
-                            icon={<PlusCircleIcon />}
+                            variant="primary"
                         >
-                            Legg til vedtaksperiode
+                            Få forslag til vedtaksperioder
                         </Button>
                         <Button
                             size="small"
-                            onClick={foreslåVedtaksperioder}
+                            onClick={leggTilPeriode}
                             style={{ maxWidth: 'fit-content' }}
                             variant="tertiary"
+                            icon={<PlusCircleIcon />}
                         >
-                            Foreslå vedtaksperioder
+                            Legg til periode manuellt
                         </Button>
                     </HStack>
                     {foreslåPeriodeFeil && <Feilmelding feil={foreslåPeriodeFeil} />}

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/vedtaksperiodeUtils.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/vedtaksperiodeUtils.ts
@@ -5,7 +5,7 @@ import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakperiode';
 export const initialiserVedtaksperioder = (
     vedtaksperioder: Vedtaksperiode[] | undefined
 ): Vedtaksperiode[] => {
-    return vedtaksperioder?.length ? vedtaksperioder : [tomVedtaksperiode()];
+    return vedtaksperioder?.length ? vedtaksperioder : [];
 };
 
 export const tomVedtaksperiode = (): Vedtaksperiode => ({


### PR DESCRIPTION
…dler skal bruke foreslå

- Foreslå blir Primary knapp
- Legg til periode manuellt blir tertiary
- Hvis man ikke har noen perioder fra tidligere legges det ikke inn en tom periode

### Hvorfor er denne endringen nødvendig? ✨

Det er ønskelig at saksbehandler bruker foreslå vedtaksperioder

Ble enig med Lars om at dette kunde være en grei løsning, en kombinasjon av de alternativ som lå inne i oppgaven

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-25404

<img width="760" height="453" alt="image" src="https://github.com/user-attachments/assets/0894017e-2601-4a6e-afb0-55843320c192" />

<img width="991" height="520" alt="image" src="https://github.com/user-attachments/assets/c404faf7-e634-4289-8029-de0bae0a43c6" />

