### PR TITLE
Tar i bruk nytt felt på vedtaksperiode, forrigeVedtaksperiode, for å kunne utlede status på vedtaksperioder i frontend

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/VedtaksperiodeRad.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/VedtaksperiodeRad.tsx
@@ -11,6 +11,7 @@ import DateInputMedLeservisning from '../../../../../komponenter/Skjema/DateInpu
 import SelectMedOptions from '../../../../../komponenter/Skjema/SelectMedOptions';
 import { FeilmeldingMaksBredde } from '../../../../../komponenter/Visningskomponenter/FeilmeldingFastBredde';
 import { BehandlingType } from '../../../../../typer/behandling/behandlingType';
+import { PeriodeStatus } from '../../../../../typer/behandling/periodeStatus';
 import { Vedtaksperiode } from '../../../../../typer/vedtak/vedtakperiode';
 import {
     faktiskMålgruppeTilTekst,
@@ -54,6 +55,21 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
     const erRevurdering = behandling.type === BehandlingType.REVURDERING;
 
     const valgbareAktiviteter = valgbareAktivitetTyperForVedtaksperiode(behandling.stønadstype);
+
+    const utledStatus = (vedtaksperiode: Vedtaksperiode) => {
+        if (!vedtaksperiode.forrigeVedtaksperiode) {
+            return PeriodeStatus.NY;
+        }
+
+        if (
+            vedtaksperiode.fom === vedtaksperiode.forrigeVedtaksperiode.fom &&
+            vedtaksperiode.tom === vedtaksperiode.forrigeVedtaksperiode.tom
+        ) {
+            return PeriodeStatus.UENDRET;
+        }
+
+        return PeriodeStatus.ENDRET;
+    };
 
     return (
         <>
@@ -116,16 +132,19 @@ export const VedtaksperiodeRad: React.FC<Props> = ({
                 />
             </FeilmeldingMaksBredde>
             <div>
-                {erLesevisning
-                    ? erRevurdering && <StatusTag status={vedtaksperiode.status} />
-                    : kanSlettePeriode && (
-                          <Button
-                              variant="tertiary"
-                              onClick={() => slettPeriode()}
-                              icon={<TrashIcon />}
-                              size="xsmall"
-                          />
-                      )}
+                {!erLesevisning && kanSlettePeriode && (
+                    <Button
+                        variant="tertiary"
+                        onClick={() => slettPeriode()}
+                        icon={<TrashIcon />}
+                        size="xsmall"
+                    />
+                )}
+            </div>
+            <div>
+                {erRevurdering && (
+                    <StatusTag status={utledStatus(vedtaksperiode)} lesevisning={erLesevisning} />
+                )}
             </div>
         </>
     );

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/Vedtaksperioder.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/Felles/vedtaksperioder/Vedtaksperioder.tsx
@@ -25,11 +25,11 @@ import { stønadstypeTilVedtakUrl } from '../stønadstypeTilVedtakUrl';
 
 const Grid = styled.div`
     display: grid;
-    grid-template-columns: repeat(5, max-content);
+    grid-template-columns: repeat(6, max-content);
     grid-gap: 0.5rem 1.5rem;
     align-items: start;
 
-    > :nth-child(5n) {
+    > :nth-child(5) {
         grid-column: 1;
     }
 `;

--- a/src/frontend/komponenter/PerioderStatusTag/StatusTag.tsx
+++ b/src/frontend/komponenter/PerioderStatusTag/StatusTag.tsx
@@ -11,7 +11,18 @@ const StyledTag = styled(Tag)`
     min-height: 20px;
 `;
 
-export const StatusTag: React.FC<{ status?: PeriodeStatus }> = ({ status }) => {
+export const StatusTag: React.FC<{ status?: PeriodeStatus; lesevisning: boolean }> = ({
+    status,
+    lesevisning,
+}) => {
+    if (status === PeriodeStatus.UENDRET) {
+        return (
+            <StyledTag size="small" variant="warning">
+                Fra tidligere vedtak
+            </StyledTag>
+        );
+    }
+
     if (status === PeriodeStatus.ENDRET) {
         return (
             <StyledTag size="small" variant="warning">
@@ -20,7 +31,7 @@ export const StatusTag: React.FC<{ status?: PeriodeStatus }> = ({ status }) => {
         );
     }
 
-    if (status === PeriodeStatus.NY) {
+    if (lesevisning && status === PeriodeStatus.NY) {
         return (
             <StyledTag size="small" variant="success">
                 Ny

--- a/src/frontend/typer/vedtak/vedtakperiode.ts
+++ b/src/frontend/typer/vedtak/vedtakperiode.ts
@@ -12,4 +12,11 @@ export interface Vedtaksperiode extends Periode {
     målgruppeType: FaktiskMålgruppe | '';
     aktivitetType: AktivitetType | '';
     status?: PeriodeStatus;
+    forrigeVedtaksperiode?: ForrigeVedtaksperiode;
+}
+
+export interface ForrigeVedtaksperiode extends Periode {
+    id: string;
+    målgruppeType: FaktiskMålgruppe | '';
+    aktivitetType: AktivitetType | '';
 }


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ifbm fjerning av revurder-fra. Gjøres for at saksbehandler enklere kan se hvilke perioder som kommer fra forrige vedtak, om de er endret eller om de er nye. 

Ref https://github.com/navikt/tilleggsstonader-sak/pull/783

I redigeringsmodus vises kun status på vedtaksperioder som endres. Enten `Fra tidligere vedtak` eller `Endret`:
<img width="914" height="224" alt="Skjermbilde 2025-08-06 kl  23 16 11" src="https://github.com/user-attachments/assets/14d0d94d-5537-45d9-b0fb-5a3ffc987c83" />

I lesemodus vises det om perioden er fra tidligere vedtak (uendret, samme status som over), er endret, eller om den er ny:

<img width="633" height="170" alt="Skjermbilde 2025-08-06 kl  23 17 14" src="https://github.com/user-attachments/assets/8ff30251-a7c5-40ee-9a41-aacd4df125f9" />
