### PR TITLE
Gjemme revurder-fra fane og vis varsel om testing uten revurder-fra

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -57,9 +57,15 @@ const BehandlingTabsInnhold = () => {
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
 
     const utledEndringsdatoAutomatisk = useFlag(Toggle.SKAL_UTLEDE_ENDRINGSDATO_AUTOMATISK);
+    const medRevurderFraFane = (): boolean => {
+        if (utledEndringsdatoAutomatisk) return false;
+        // Antar at man ser i en avsluttet behandling eller beslutter en behandling.
+        else if (!behandling.revurderFra && !behandlingErRedigerbar) return false;
+        else return true;
+    };
 
     const førsteFanePath =
-        behandling.type === BehandlingType.REVURDERING && !utledEndringsdatoAutomatisk
+        behandling.type === BehandlingType.REVURDERING && medRevurderFraFane()
             ? FanePath.REVURDER_FRA
             : FanePath.INNGANGSVILKÅR;
     const aktivFane = isFanePath(path) ? path : førsteFanePath;
@@ -80,7 +86,7 @@ const BehandlingTabsInnhold = () => {
         }
     };
 
-    const behandlingFaner = hentBehandlingfaner(behandling, !utledEndringsdatoAutomatisk);
+    const behandlingFaner = hentBehandlingfaner(behandling, medRevurderFraFane());
 
     return (
         <StegProvider

--- a/src/frontend/Sider/Behandling/Felles/VarselRevurderFraDatoMangler.tsx
+++ b/src/frontend/Sider/Behandling/Felles/VarselRevurderFraDatoMangler.tsx
@@ -6,7 +6,7 @@ import { useBehandling } from '../../../context/BehandlingContext';
 import { BehandlingType } from '../../../typer/behandling/behandlingType';
 
 export const VarselRevurderFraDatoMangler = () => {
-    const { behandling } = useBehandling();
+    const { behandling, behandlingErRedigerbar } = useBehandling();
 
     const erRevurdering = behandling.type === BehandlingType.REVURDERING;
     const revurderFraDatoErSatt = !!behandling.revurderFra;
@@ -15,9 +15,18 @@ export const VarselRevurderFraDatoMangler = () => {
         return null;
     }
 
-    return (
-        <Alert variant={'warning'} size={'small'}>
-            Du må sette revurder fra-dato før du kan gjøre endringer.
-        </Alert>
-    );
+    if (erRevurdering && !revurderFraDatoErSatt && !behandlingErRedigerbar) {
+        return (
+            <Alert variant={'warning'} size={'small'}>
+                I denne revurderingen er det testet ny funksjonalitet uten revurder-fra dato.
+                Systemet har her selv utledet datoen for endringen som brukes til beregningen.
+            </Alert>
+        );
+    } else {
+        return (
+            <Alert variant={'warning'} size={'small'}>
+                Du må sette revurder fra-dato før du kan gjøre endringer.
+            </Alert>
+        );
+    }
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Forberedelse for testing av fjerning av revurder-fra. Fjerner revurder-fra fanen og viser et varsel (tar gjerne forbedringsforslag på teksten..) om man er i en revurdering i lesemodus hvor revurder-fra ikke er satt. 

Dette for å gi tydelig varsel til beslutter om at denne behandlingen har blitt brukt til å teste ny funksjonalitet.