### PR TITLE
🐛 Ikke vis astriks for statsendring hvis faktiske utgifter

### DIFF
--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -45,7 +45,8 @@ const lagRaderForVedtakMidlertidigOvernatting = (
                         utgift.utgift,
                         utgift.tilUtbetaling,
                         periode.makssatsBekreftet,
-                        utgift.utgift > utgift.tilUtbetaling
+                        utgift.utgift > utgift.tilUtbetaling,
+                        utgift.skalFåDekketFaktiskeUtgifter
                     )
                 )
                 .join('')
@@ -66,7 +67,8 @@ const lagRaderForVedtakLøpendeUtgifter = (
                 periode.sumUtgifter,
                 periode.stønadsbeløp,
                 periode.makssatsBekreftet,
-                false
+                false,
+                periode.skalFåDekketFaktiskeUtgifter
             )
         )
         .join('');
@@ -77,14 +79,15 @@ const lagRadForVedtak = (
     merutgift: number,
     stønadsbeløp: number,
     makssatsBekreftet: boolean,
-    begrensetAvMakssats: boolean
+    begrensetAvMakssats: boolean,
+    skalFåDekketFaktiskeUtgifter: boolean
 ) => {
     const datoperiodeString = formaterIsoPeriodeMedTankestrek(datoperiode);
     const merutgiftString = formaterTallMedTusenSkille(merutgift);
     const stønadsbeløpString = formaterTallMedTusenSkille(stønadsbeløp);
-    const asteriksForSatsendring = makssatsBekreftet ? '' : '*';
-    const asteriksForBegrensetAvMakssats = begrensetAvMakssats ? '*' : '';
-
+    const asteriksForSatsendring = !skalFåDekketFaktiskeUtgifter && !makssatsBekreftet ? '*' : '';
+    const asteriksForBegrensetAvMakssats =
+        !skalFåDekketFaktiskeUtgifter && begrensetAvMakssats ? '*' : '';
     return `<tr style="text-align: right;">
                         <td style="text-align: left; ${borderStylingCompact}">${datoperiodeString}</td>
                         <td style="${borderStyling}">${merutgiftString} kr</td>

--- a/src/frontend/typer/vedtak/vedtakBoutgifter.ts
+++ b/src/frontend/typer/vedtak/vedtakBoutgifter.ts
@@ -78,6 +78,7 @@ export type BeregningsresultatUtgifter = {
     utgift: number;
     tilUtbetaling: number;
     erFørRevurderFra: boolean;
+    skalFåDekketFaktiskeUtgifter: boolean;
 };
 
 type Beregningsresultat = {
@@ -88,4 +89,5 @@ type Beregningsresultat = {
     utgifter: BeregningsresultatUtgifter[];
     makssatsBekreftet: boolean;
     delAvTidligereUtbetaling: boolean;
+    skalFåDekketFaktiskeUtgifter: boolean;
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å skjule astriks for satsendringer hvis faktiske utgifter, da faktiske utgifter ikke påvirkes av satsendringer. 

Før:
<img width="1132" height="876" alt="image" src="https://github.com/user-attachments/assets/999f4354-9f1e-4abb-b981-c5a960b2b470" />

Nå:
<img width="572" height="262" alt="Screenshot 2025-08-22 at 13 10 06" src="https://github.com/user-attachments/assets/8cb867d8-77ab-4be1-b7b7-d552737a268e" />
