### PR TITLE
👔 Skjul 'bruk'-knapp for utdanning for Daglig Reise Tsr

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/BrukAktivitetKnapp.tsx
@@ -6,7 +6,10 @@ import { Button, Tag } from '@navikt/ds-react';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useSteg } from '../../../../context/StegContext';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
-import { kanRegisterperiodeBrukes } from '../Vilkårperioder/vilkårperiodeUtil';
+import {
+    kanRegisterAktivitetBrukes,
+    kanRegisterperiodeBrukes,
+} from '../Vilkårperioder/vilkårperiodeUtil';
 
 export function BrukAktivitetKnapp({
     registerAktivitet,
@@ -20,7 +23,9 @@ export function BrukAktivitetKnapp({
     const { erStegRedigerbart } = useSteg();
     const { behandling } = useBehandling();
 
-    const aktivitetKanBrukes = kanRegisterperiodeBrukes(registerAktivitet, behandling.revurderFra);
+    const aktivitetKanBrukes =
+        kanRegisterAktivitetBrukes(registerAktivitet, behandling.stønadstype) &&
+        kanRegisterperiodeBrukes(registerAktivitet, behandling.revurderFra);
 
     if (harBruktAktivitet) {
         return (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/vilkårperiodeUtil.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/vilkårperiodeUtil.ts
@@ -1,3 +1,4 @@
+import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { erDatoFørEllerLik } from '../../../../utils/dato';
 import { YtelseGrunnlagPeriode } from '../typer/vilkårperiode/vilkårperiode';
@@ -16,3 +17,8 @@ export const kanRegisterperiodeBrukes = (
 
     return !registerPeriode.tom || erDatoFørEllerLik(revurderFra, registerPeriode.tom);
 };
+
+export const kanRegisterAktivitetBrukes = (
+    registerAktivtet: Registeraktivitet,
+    stønadstype: Stønadstype
+): boolean => !(stønadstype === Stønadstype.DAGLIG_REISE_TSR && registerAktivtet.erUtdanning);


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Utdanning er ikke en relevant aktivitet for Daglig Reise Tsr. Skjuler derfor 'bruk'-knappen slik at SB ikke bruker aktiviteter av typen utdanning.

<img width="1372" height="446" alt="image" src="https://github.com/user-attachments/assets/531551d1-dc0e-4c50-baa1-13648baf30da" />
