### PR TITLE
✨ Gjør det mulig å bruke Dagpenger og Tiltakspenger fra register ytelser

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelserTabell.tsx
@@ -6,6 +6,7 @@ import { Button, Table } from '@navikt/ds-react';
 import { ABorderDivider } from '@navikt/ds-tokens/dist/tokens';
 
 import { kanRegisterYtelseBrukes, utledYtelseTekst } from './utils';
+import { useBehandling } from '../../../../context/BehandlingContext';
 import { useSteg } from '../../../../context/StegContext';
 import { formaterIsoDato, formaterNullableIsoDato } from '../../../../utils/dato';
 import { YtelseGrunnlagPeriode } from '../typer/vilkårperiode/vilkårperiode';
@@ -22,6 +23,7 @@ const RegisterYtelserTabell: React.FC<{
     lagRadForPeriode: (valgPeriode: YtelseGrunnlagPeriode) => void;
 }> = ({ perioderMedYtelse, lagRadForPeriode }) => {
     const { erStegRedigerbart } = useSteg();
+    const { behandling } = useBehandling();
 
     return (
         <HvitTabell size="small">
@@ -41,11 +43,15 @@ const RegisterYtelserTabell: React.FC<{
                             <Table.DataCell>{formaterIsoDato(ytelse.fom)}</Table.DataCell>
                             <Table.DataCell>{formaterNullableIsoDato(ytelse.tom)}</Table.DataCell>
                             <Table.DataCell>
-                                {erStegRedigerbart && kanRegisterYtelseBrukes(ytelse) && (
-                                    <Button size="xsmall" onClick={() => lagRadForPeriode(ytelse)}>
-                                        Bruk
-                                    </Button>
-                                )}
+                                {erStegRedigerbart &&
+                                    kanRegisterYtelseBrukes(ytelse, behandling.stønadstype) && (
+                                        <Button
+                                            size="xsmall"
+                                            onClick={() => lagRadForPeriode(ytelse)}
+                                        >
+                                            Bruk
+                                        </Button>
+                                    )}
                             </Table.DataCell>
                         </Table.Row>
                     );

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -14,6 +14,7 @@ import {
     Målgruppe,
     MålgruppeType,
     SvarMålgruppe,
+    målgrupperForStønad,
 } from '../typer/vilkårperiode/målgruppe';
 import { målgruppeTilFaktiskMålgruppeEllerIngenMålgruppe } from '../typer/vilkårperiode/målgruppeTilFaktiskMålgruppe';
 import {
@@ -221,9 +222,12 @@ export const utledYtelseTekst = (periode: YtelseGrunnlagPeriode): string => {
 
 export const kanRegisterYtelseBrukes = (
     ytelse: YtelseGrunnlagPeriode,
+    stønadstype: Stønadstype,
     revurderFra?: string
 ): boolean => {
     if (ytelse.subtype === SubtypeYtelseGrunnlag.AAP_FERDIG_AVKLART) return false;
+    if (!målgrupperForStønad[stønadstype].includes(typeRegisterYtelseTilMålgruppeType[ytelse.type]))
+        return false;
 
     return kanRegisterperiodeBrukes(ytelse, revurderFra);
 };

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/vilkårperiode.ts
@@ -1,7 +1,7 @@
 import { Aktivitet, AktivitetType, AktivitetTypeTilTekst } from './aktivitet';
 import { Målgruppe, MålgruppeType, MålgruppeTypeTilTekst } from './målgruppe';
 import { Registeraktivitet } from '../../../../../typer/registeraktivitet';
-import { TypeRegisterYtelseForVilkårperiode } from '../../../../../typer/registerytelser';
+import { TypeRegisterYtelse } from '../../../../../typer/registerytelser';
 import { Periode } from '../../../../../utils/periode';
 
 export interface VilkårperioderResponse {
@@ -29,12 +29,12 @@ interface YtelseGrunnlag {
 }
 
 interface KildeResultatYtelse {
-    type: TypeRegisterYtelseForVilkårperiode;
+    type: TypeRegisterYtelse;
     resultat: 'OK' | 'FEILET';
 }
 
 export interface YtelseGrunnlagPeriode {
-    type: TypeRegisterYtelseForVilkårperiode;
+    type: TypeRegisterYtelse;
     fom: string;
     tom?: string;
     subtype?: SubtypeYtelseGrunnlag;

--- a/src/frontend/typer/registerytelser.ts
+++ b/src/frontend/typer/registerytelser.ts
@@ -29,14 +29,6 @@ export interface KildeResultatYtelse {
     resultat: 'OK' | 'FEILET';
 }
 
-/**
- * Beskriver hvilke registerytelser som kan brukes for å opprette en vilkårperiode (målgruppe) i en behandling.
- */
-export type TypeRegisterYtelseForVilkårperiode = Exclude<
-    TypeRegisterYtelse,
-    TypeRegisterYtelse.TILTAKSPENGER | TypeRegisterYtelse.DAGPENGER
->;
-
 export enum TypeRegisterYtelse {
     AAP = 'AAP',
     DAGPENGER = 'DAGPENGER',
@@ -45,13 +37,12 @@ export enum TypeRegisterYtelse {
     OMSTILLINGSSTØNAD = 'OMSTILLINGSSTØNAD',
 }
 
-export const typeRegisterYtelseTilMålgruppeType: Record<
-    TypeRegisterYtelseForVilkårperiode,
-    MålgruppeType
-> = {
+export const typeRegisterYtelseTilMålgruppeType: Record<TypeRegisterYtelse, MålgruppeType> = {
     AAP: MålgruppeType.AAP,
     ENSLIG_FORSØRGER: MålgruppeType.OVERGANGSSTØNAD,
     OMSTILLINGSSTØNAD: MålgruppeType.OMSTILLINGSSTØNAD,
+    TILTAKSPENGER: MålgruppeType.TILTAKSPENGER,
+    DAGPENGER: MålgruppeType.DAGPENGER,
 };
 
 export const registerYtelseTilTekst: Record<TypeRegisterYtelse, string> = {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Ønsker å kunne bruke Dagpenger og Tiltakspenger fra register ytelser så SB slipper å kopiere dette manuelt. 

Det er kun mulig å bruke ytelser som er relevante for stønaden. E.g: 
Dagpenger og Tiltakspenger for Daglig Reise Tsr
AAP, EF og Omstillingsstønad for Daglig Reise Tso
AAP, EF og Omstillingsstønad for Bolig og overnatting
osv.

<img width="1355" height="604" alt="image" src="https://github.com/user-attachments/assets/bbe76651-bd22-45fe-b622-b7446afa5c71" />
