### PR TITLE
🔥 Fjern asteriks for satsendring

### DIFF
--- a/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/lagVedtakstabellBoutgifter.ts
@@ -49,7 +49,6 @@ const lagRaderForVedtakMidlertidigOvernatting = (periode: Beregningsresultat): s
                 { fom: utgift.fom, tom: utgift.tom },
                 utgift.utgift,
                 utgift.tilUtbetaling,
-                periode.makssatsBekreftet,
                 utgift.utgift > utgift.tilUtbetaling,
                 utgift.skalFåDekketFaktiskeUtgifter
             )
@@ -62,7 +61,6 @@ const lagRaderForVedtakLøpendeUtgifter = (periode: Beregningsresultat): string 
         periode,
         periode.sumUtgifter,
         periode.stønadsbeløp,
-        periode.makssatsBekreftet,
         false,
         periode.skalFåDekketFaktiskeUtgifter
     );
@@ -72,20 +70,18 @@ const lagRadForVedtak = (
     datoperiode: Periode,
     merutgift: number,
     stønadsbeløp: number,
-    makssatsBekreftet: boolean,
     begrensetAvMakssats: boolean,
     skalFåDekketFaktiskeUtgifter: boolean
 ) => {
     const datoperiodeString = formaterIsoPeriodeMedTankestrek(datoperiode);
     const merutgiftString = formaterTallMedTusenSkille(merutgift);
     const stønadsbeløpString = formaterTallMedTusenSkille(stønadsbeløp);
-    const asteriksForSatsendring = !skalFåDekketFaktiskeUtgifter && !makssatsBekreftet ? '*' : '';
     const asteriksForBegrensetAvMakssats =
         !skalFåDekketFaktiskeUtgifter && begrensetAvMakssats ? '*' : '';
     return `<tr style="text-align: right;">
                         <td style="text-align: left; ${borderStylingCompact}">${datoperiodeString}</td>
                         <td style="${borderStyling}">${merutgiftString} kr</td>
-                        <td style="${borderStyling}">${stønadsbeløpString} kr ${asteriksForSatsendring}${asteriksForBegrensetAvMakssats}</td>
+                        <td style="${borderStyling}">${stønadsbeløpString} kr ${asteriksForBegrensetAvMakssats}</td>
                     </tr>`;
 };
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Før:
<img width="537" height="217" alt="image" src="https://github.com/user-attachments/assets/3ed8e4a6-eb27-4697-a783-09e8494c2a18" />

Nå: 
<img width="512" height="217" alt="image" src="https://github.com/user-attachments/assets/0e08ed8f-e3f5-490a-bfb0-dffd3b920d8a" />
