### PR TITLE
Legger til lesevisning av vilkårsvurdering

### DIFF
--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/LesevisningVilkårDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/LesevisningVilkårDagligReise.tsx
@@ -1,0 +1,142 @@
+import React, { FC, Fragment } from 'react';
+
+import { styled } from 'styled-components';
+
+import { BusIcon, PencilIcon } from '@navikt/aksel-icons';
+import { BodyShort, HGrid, HStack, Label, Tag, VStack } from '@navikt/ds-react';
+import { AShadowXsmall } from '@navikt/ds-tokens/dist/tokens';
+
+import { VilkårsresultatIkon } from '../../../../komponenter/Ikoner/Vurderingsresultat/VilkårsresultatIkon';
+import SmallButton from '../../../../komponenter/Knapper/SmallButton';
+import { Skillelinje } from '../../../../komponenter/Skillelinje';
+import { FlexColumn } from '../../../../komponenter/Visningskomponenter/Flex';
+import { formaterNullablePeriode } from '../../../../utils/dato';
+import { formaterTallMedTusenSkilleEllerStrek } from '../../../../utils/fomatering';
+import { VilkårsresultatTilTekst } from '../../Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping';
+import { Vilkår } from '../../vilkår';
+import {
+    regelIdTilSpørsmålKortversjon,
+    svarIdTilTekstKorversjon,
+} from '../../Vilkårvurdering/tekster';
+
+const Container = styled(FlexColumn)`
+    position: relative;
+    background: white;
+    padding: 1rem;
+    box-shadow: ${AShadowXsmall};
+`;
+
+const Redigeringsknapp = styled(SmallButton)`
+    max-height: 24px;
+    align-self: end;
+`;
+
+const LesevisningVilkårDagligReise: FC<{
+    vilkår: Vilkår;
+    skalViseRedigeringsknapp?: boolean;
+    startRedigering?: () => void;
+    vilkårIndex: number;
+}> = ({ vilkår, vilkårIndex, startRedigering, skalViseRedigeringsknapp }) => {
+    const { resultat, delvilkårsett, fom, tom, offentligTransport, vilkårType } = vilkår;
+
+    const vilkårTypeTilKortTekst: Record<string, string> = {
+        DAGLIG_REISE_OFFENTLIG_TRANSPORT: 'offentlig transport',
+    };
+    return (
+        <Container>
+            <HGrid gap={{ md: '4', lg: '8' }} columns="minmax(auto, 234px) auto minmax(auto, 64px)">
+                <VStack gap="3">
+                    <Label size="small">{formaterNullablePeriode(fom, tom)}</Label>
+                    <HStack gap="3" align="center">
+                        <VilkårsresultatIkon vilkårsresultat={resultat} height={14} width={14} />
+                        <BodyShort size="small">{VilkårsresultatTilTekst[resultat]}</BodyShort>
+                    </HStack>
+                    <HStack gap={'4'} justify={'space-between'}>
+                        <BodyShort weight="semibold" size="small">
+                            {'Reisedager pr uke'}
+                        </BodyShort>
+                        <BodyShort size="small">
+                            {offentligTransport?.reisedagerPerUke
+                                ? `${offentligTransport.reisedagerPerUke}`
+                                : '-'}
+                        </BodyShort>
+                    </HStack>
+
+                    <HStack gap={'4'} justify={'space-between'}>
+                        <BodyShort weight="semibold" size="small">
+                            {'Pris enkeltbillett'}
+                        </BodyShort>
+                        <BodyShort size="small">
+                            {offentligTransport?.prisEnkelbillett
+                                ? `${formaterTallMedTusenSkilleEllerStrek(offentligTransport.prisEnkelbillett)} kr`
+                                : '-'}
+                        </BodyShort>
+                    </HStack>
+
+                    <HStack gap={'4'} justify={'space-between'}>
+                        <BodyShort weight="semibold" size="small">
+                            {'Pris 7 dagers billett'}
+                        </BodyShort>
+                        <BodyShort size="small">
+                            {offentligTransport?.prisSyvdagersbillett
+                                ? `${formaterTallMedTusenSkilleEllerStrek(offentligTransport.prisSyvdagersbillett)} kr`
+                                : '-'}
+                        </BodyShort>
+                    </HStack>
+
+                    <HStack gap={'4'} justify={'space-between'}>
+                        <BodyShort weight="semibold" size="small">
+                            {'Pris 30 dagers billett'}
+                        </BodyShort>
+                        <BodyShort size="small">
+                            {offentligTransport?.prisTrettidagersbillett
+                                ? `${formaterTallMedTusenSkilleEllerStrek(offentligTransport.prisTrettidagersbillett)} kr`
+                                : '-'}
+                        </BodyShort>
+                    </HStack>
+                    <Tag style={{ width: 'max-content' }} variant="neutral" icon={<BusIcon />}>
+                        {`Reise ${vilkårIndex} med ${vilkårTypeTilKortTekst[vilkårType]}`}
+                    </Tag>
+                </VStack>
+
+                <HGrid gap={'1 4'} columns="minmax(100px, max-content) 1fr">
+                    {delvilkårsett.map((delvilkår, index) => (
+                        <React.Fragment key={index}>
+                            <VStack>
+                                {delvilkår.vurderinger.map((vurdering, index) => (
+                                    <Fragment key={index}>
+                                        <HStack gap="3" key={vurdering.regelId}>
+                                            <BodyShort weight="semibold" size="small">
+                                                {regelIdTilSpørsmålKortversjon[vurdering.regelId]}
+                                            </BodyShort>
+                                            {vurdering.svar && (
+                                                <BodyShort size="small">
+                                                    {svarIdTilTekstKorversjon[vurdering.svar]}
+                                                </BodyShort>
+                                            )}
+                                            <BodyShort size="small">
+                                                {vurdering.begrunnelse}
+                                            </BodyShort>
+                                        </HStack>
+                                        {delvilkår.vurderinger.length > 1 && (
+                                            <Skillelinje style={{ gridColumn: 'span 2' }} />
+                                        )}
+                                    </Fragment>
+                                ))}
+                            </VStack>
+                        </React.Fragment>
+                    ))}
+                </HGrid>
+                {skalViseRedigeringsknapp && (
+                    <Redigeringsknapp
+                        variant="tertiary"
+                        onClick={startRedigering}
+                        icon={<PencilIcon />}
+                    />
+                )}
+            </HGrid>
+        </Container>
+    );
+};
+
+export default LesevisningVilkårDagligReise;

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/StønadsvilkårDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/StønadsvilkårDagligReise.tsx
@@ -2,13 +2,13 @@ import React from 'react';
 
 import { BriefcaseIcon } from '@navikt/aksel-icons';
 
+import { VisEllerEndreVilkårDagligReise } from './VisEllerEndreVilkårDagligReise';
 import { useVilkår } from '../../../../context/VilkårContext';
 import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
 import { ReglerResponse } from '../../../../typer/regel';
 import { StønadsvilkårType } from '../../vilkår';
 import { NyttVilkår } from '../../Vilkårvurdering/NyttVilkår';
 import { lagTomtDelvilkårsett, tomVurdering } from '../../Vilkårvurdering/utils';
-import { VisEllerEndreVilkår } from '../../Vilkårvurdering/VisEllerEndreVilkår';
 
 type Props = {
     regler: ReglerResponse;
@@ -23,8 +23,13 @@ export const StønadsvilkårDagligReise = ({ regler }: Props) => {
 
     return (
         <VilkårPanel tittel={'Daglig Reise'} ikon={<BriefcaseIcon />}>
-            {vilkårsett.map((vilkår) => (
-                <VisEllerEndreVilkår key={vilkår.id} regler={vilkårsregler} vilkår={vilkår} />
+            {vilkårsett.map((vilkår, index) => (
+                <VisEllerEndreVilkårDagligReise
+                    key={vilkår.id}
+                    regler={vilkårsregler}
+                    vilkår={vilkår}
+                    vilkårIndex={index + 1}
+                />
             ))}
             <NyttVilkår
                 vilkårtype={StønadsvilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT}

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/VisEllerEndreVilkårDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/VisEllerEndreVilkårDagligReise.tsx
@@ -1,0 +1,66 @@
+import React, { FC, useState } from 'react';
+
+import LesevisningVilkårDagligReise from './LesevisningVilkårDagligReise';
+import { useSteg } from '../../../../context/StegContext';
+import { useVilkår } from '../../../../context/VilkårContext';
+import { Regler } from '../../../../typer/regel';
+import { PeriodeStatus } from '../../Inngangsvilkår/typer/vilkårperiode/vilkårperiode';
+import { Vilkår, Vilkårsresultat } from '../../vilkår';
+import { EndreVilkår } from '../../Vilkårvurdering/EndreVilkår/EndreVilkår';
+
+type LesEllerEndreDelvilkårProps = {
+    regler: Regler;
+    vilkår: Vilkår;
+    vilkårIndex: number;
+};
+
+export const VisEllerEndreVilkårDagligReise: FC<LesEllerEndreDelvilkårProps> = ({
+    regler,
+    vilkår,
+    vilkårIndex,
+}) => {
+    const { erStegRedigerbart } = useSteg();
+    const { lagreVilkår } = useVilkår();
+
+    const [redigerer, settRedigerer] = useState<boolean>(
+        vilkår.resultat === Vilkårsresultat.IKKE_TATT_STILLING_TIL
+    );
+
+    const kanVæreFremtidigUtgift =
+        vilkår.status === PeriodeStatus.NY ||
+        vilkår.resultat === Vilkårsresultat.IKKE_TATT_STILLING_TIL;
+
+    const skalViseRedigeringsknapp = erStegRedigerbart && vilkår.status !== PeriodeStatus.SLETTET;
+
+    return erStegRedigerbart && redigerer ? (
+        <EndreVilkår
+            lagretVilkår={vilkår}
+            regler={regler}
+            redigerbareVilkårfelter={{
+                delvilkårsett: vilkår.delvilkårsett,
+                fom: vilkår.fom,
+                tom: vilkår.tom,
+                utgift: vilkår.utgift,
+                erFremtidigUtgift: vilkår.erFremtidigUtgift,
+                offentligTransport: vilkår.offentligTransport,
+            }}
+            lagreVurdering={(redigerbareVilkårfelter) =>
+                lagreVilkår({
+                    id: vilkår.id,
+                    behandlingId: vilkår.behandlingId,
+                    ...redigerbareVilkårfelter,
+                })
+            }
+            avsluttRedigering={() => settRedigerer(false)}
+            vilkårtype={vilkår.vilkårType}
+            kanVæreFremtidigUtgift={kanVæreFremtidigUtgift}
+        />
+    ) : (
+        <LesevisningVilkårDagligReise
+            vilkår={vilkår}
+            skalViseRedigeringsknapp={skalViseRedigeringsknapp}
+            startRedigering={() => settRedigerer(true)}
+            vilkårIndex={vilkårIndex}
+        />
+    );
+};

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -56,6 +56,9 @@ export const regelIdTilSpørsmålKortversjon: Record<RegelId, string> = {
     HØYERE_UTGIFTER_HELSEMESSIG_ÅRSAKER: 'Høyere utgift av helsemessige årsak?',
     DOKUMENTERT_UTGIFTER_BOLIG: 'Dokumentert utgift tilfredsstillende?',
     DOKUMENTERT_DELTAKELSE: `Dokumentert samling e.l.?`,
+    AVSTAND_OVER_SEKS_KM: 'Reiseavstand over seks kilometer?',
+    KAN_BRUKER_REISE_MED_OFFENTLIG_TRANSPORT: 'Kan benytte offentlig transport?',
+    KAN_BRUKER_KJØRE_SELV: 'Kan bruker kjøre selv?',
 };
 
 export const hjelpetekster: Record<RegelId, string[]> = {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For å vise vurderingen av vilkårene for daglig reise offentlig transport. 
[Oppgave i favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-26152)

Eksempel med to reiser:
<img width="1340" height="853" alt="Screenshot 2025-09-09 at 11 01 35" src="https://github.com/user-attachments/assets/a59e85fb-3357-44d8-8d87-7f763756c072" />

De ulike statene som støttes pr nå:
<img width="1674" height="1283" alt="Screenshot 2025-09-09 at 11 03 21" src="https://github.com/user-attachments/assets/6e0c3f08-3614-4a0f-874c-b93543412de7" />
