### PR TITLE
Tilpasser oppsummering av vurdering for offentlig transport

### DIFF
--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/LesevisningVilkårDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/LesevisningVilkårDagligReise.tsx
@@ -15,6 +15,7 @@ import { formaterTallMedTusenSkilleEllerStrek } from '../../../../utils/fomateri
 import { VilkårsresultatTilTekst } from '../../Inngangsvilkår/Vilkårperioder/VilkårperiodeKort/tekstmapping';
 import { Vilkår } from '../../vilkår';
 import {
+    dagligReiseVilkårTypeTilTekst,
     regelIdTilSpørsmålKortversjon,
     svarIdTilTekstKorversjon,
 } from '../../Vilkårvurdering/tekster';
@@ -39,9 +40,6 @@ const LesevisningVilkårDagligReise: FC<{
 }> = ({ vilkår, vilkårIndex, startRedigering, skalViseRedigeringsknapp }) => {
     const { resultat, delvilkårsett, fom, tom, offentligTransport, vilkårType } = vilkår;
 
-    const vilkårTypeTilKortTekst: Record<string, string> = {
-        DAGLIG_REISE_OFFENTLIG_TRANSPORT: 'offentlig transport',
-    };
     return (
         <Container>
             <HGrid gap={{ md: '4', lg: '8' }} columns="minmax(auto, 234px) auto minmax(auto, 64px)">
@@ -95,7 +93,7 @@ const LesevisningVilkårDagligReise: FC<{
                         </BodyShort>
                     </HStack>
                     <Tag style={{ width: 'max-content' }} variant="neutral" icon={<BusIcon />}>
-                        {`Reise ${vilkårIndex} med ${vilkårTypeTilKortTekst[vilkårType]}`}
+                        {`Reise ${vilkårIndex} med ${dagligReiseVilkårTypeTilTekst[vilkårType]}`}
                     </Tag>
                 </VStack>
 

--- a/src/frontend/Sider/Behandling/Venstremeny/BehandlingOppsummering/OppsummeringVilkår.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/BehandlingOppsummering/OppsummeringVilkår.tsx
@@ -9,6 +9,8 @@ import { Stønadsvilkår } from '../../../../typer/behandling/behandlingOppsumme
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { formaterTallMedTusenSkilleEllerStrek } from '../../../../utils/fomatering';
 import { faneNavnStønadsvilkår } from '../../faner';
+import { StønadsvilkårType } from '../../vilkår';
+import { dagligReiseVilkårTypeTilTekst } from '../../Vilkårvurdering/tekster';
 
 export const OppsummeringVilkår: React.FC<{
     vilkår: Stønadsvilkår[];
@@ -34,7 +36,11 @@ export const OppsummeringVilkår: React.FC<{
                     fom={vilkår.fom}
                     tom={vilkår.tom}
                     resultat={vilkår.resultat}
-                    gjelder={`${formaterTallMedTusenSkilleEllerStrek(vilkår.utgift)} kr`}
+                    gjelder={
+                        etVilkår.type === StønadsvilkårType.DAGLIG_REISE_OFFENTLIG_TRANSPORT
+                            ? dagligReiseVilkårTypeTilTekst[etVilkår.type]
+                            : `${formaterTallMedTusenSkilleEllerStrek(vilkår.utgift)} kr`
+                    }
                 />
             ))}
         </VStack>

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/tekster.ts
@@ -99,5 +99,11 @@ export const vilkårTypeTilTekst: Record<StønadsvilkårType, string> = {
     UTGIFTER_OVERNATTING: 'Utgifter til overnatting',
     LØPENDE_UTGIFTER_EN_BOLIG: 'Løpende utgifter til en bolig',
     LØPENDE_UTGIFTER_TO_BOLIGER: 'Løpende utgifter til to boliger',
-    DAGLIG_REISE_OFFENTLIG_TRANSPORT: 'Daglig reise med offentlig transport',
+    DAGLIG_REISE_OFFENTLIG_TRANSPORT: 'Daglig reise',
+};
+
+export const dagligReiseVilkårTypeTilTekst: Record<string, string> = {
+    DAGLIG_REISE_OFFENTLIG_TRANSPORT: 'Offentlig transport',
+    DAGLIG_REISE_KJØRELISTE: 'Kjøreliste',
+    DAGLIG_REISE_TAXI: 'Taxi',
 };


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Oppdaterer **_"oppsummeringen av vurderingen"_** for å vise hvilke type daglig reise som er aktuell for perioden. 
[Oppgave i favro](https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-26190)

En reise:
<img width="1786" height="601" alt="Screenshot 2025-09-09 at 14 08 47" src="https://github.com/user-attachments/assets/7b9353f2-65ac-410f-ad17-a165046c033f" />


Flere reiseperioder:
<img width="1775" height="765" alt="Screenshot 2025-09-09 at 14 01 30" src="https://github.com/user-attachments/assets/6e194b98-f7ed-44e8-881b-b3557f8da3d0" />

