### PR TITLE
Oppdater hjelpetekster som tilhører henting av vilkårperiodegrunnlag

### DIFF
--- a/src/frontend/Sider/Behandling/Felles/grunnlagAntallMndBakITiden.ts
+++ b/src/frontend/Sider/Behandling/Felles/grunnlagAntallMndBakITiden.ts
@@ -6,7 +6,7 @@ import { Stønadstype } from '../../../typer/behandling/behandlingTema';
  *
  * Brukes bl.a. for å kunne sette fom på dato for INGEN_MÅLGRUPPE og INGEN_AKTIVITET
  */
-export const ingenMålgruppeAktivitetAntallMndBakITiden: Record<Stønadstype, number> = {
+export const maksMånederTilbakeFraSøknadsdato: Record<Stønadstype, number> = {
     BARNETILSYN: 3,
     LÆREMIDLER: 6,
     BOUTGIFTER: 6,

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteter.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/RegisterAktivteter.tsx
@@ -18,7 +18,7 @@ import { Behandling } from '../../../../typer/behandling/behandling';
 import { stønadstypeTilTekst } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../../utils/dato';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import { VilkårperioderGrunnlag } from '../typer/vilkårperiode/vilkårperiode';
 
 export const RegisterAktiviteter: React.FC<{
@@ -98,15 +98,15 @@ function Hjelpetekst({
                         I en førstegangsbehandling for{' '}
                         {stønadstypeTilTekst[behandling.stønadstype].toLowerCase()} hentes
                         aktiviteter fra og med mottatt dato minus{' '}
-                        {ingenMålgruppeAktivitetAntallMndBakITiden[behandling.stønadstype]} måneder
-                        tilbake i tid.
+                        {maksMånederTilbakeFraSøknadsdato[behandling.stønadstype]} måneder tilbake i
+                        tid.
                     </BodyLong>
                 ) : (
                     <BodyLong spacing>
                         Ved revurdering hentes aktiviteter fra den første datoen i forrige vedtak.
-                        Dersom {ingenMålgruppeAktivitetAntallMndBakITiden[behandling.stønadstype]}{' '}
-                        måneder tilbake fra opprettelsesdatoen gir en tidligere startdato, brukes
-                        den i stedet.
+                        Dersom {maksMånederTilbakeFraSøknadsdato[behandling.stønadstype]} måneder
+                        tilbake fra opprettelsesdatoen gir en tidligere startdato, brukes den i
+                        stedet.
                     </BodyLong>
                 )}
             </HelpText>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsBarnetilsyn.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsBarnetilsyn.ts
@@ -4,7 +4,7 @@ import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { dagensDato, førsteDagIMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
 import { harTallverdi } from '../../../../utils/tall';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import { AktivitetBarnetilsynFaktaOgSvar } from '../typer/vilkårperiode/aktivitetBarnetilsyn';
 import { AktivitetBarnetilsyn } from '../typer/vilkårperiode/aktivitetBarnetilsyn';
@@ -81,7 +81,7 @@ const resetPeriode = (
     if (nyType === AktivitetType.INGEN_AKTIVITET) {
         return {
             fom: førsteDagIMånederForut(
-                ingenMålgruppeAktivitetAntallMndBakITiden[Stønadstype.BARNETILSYN],
+                maksMånederTilbakeFraSøknadsdato[Stønadstype.BARNETILSYN],
                 søknadMottattTidspunkt
             ),
             tom: dagensDato(),

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsBoutgifter.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsBoutgifter.ts
@@ -3,7 +3,7 @@ import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { dagensDato, førsteDagIMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetBoutgifter,
@@ -71,7 +71,7 @@ const resetPeriode = (
     if (nyType === AktivitetType.INGEN_AKTIVITET) {
         return {
             fom: førsteDagIMånederForut(
-                ingenMålgruppeAktivitetAntallMndBakITiden[Stønadstype.BOUTGIFTER],
+                maksMånederTilbakeFraSøknadsdato[Stønadstype.BOUTGIFTER],
                 søknadMottattTidspunkt
             ),
             tom: dagensDato(),

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsDagligReiseTso.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsDagligReiseTso.ts
@@ -3,7 +3,7 @@ import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { dagensDato, førsteDagIMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetDagligReiseTso,
@@ -71,7 +71,7 @@ const resetPeriode = (
     if (nyType === AktivitetType.INGEN_AKTIVITET) {
         return {
             fom: førsteDagIMånederForut(
-                ingenMålgruppeAktivitetAntallMndBakITiden[Stønadstype.DAGLIG_REISE_TSO],
+                maksMånederTilbakeFraSøknadsdato[Stønadstype.DAGLIG_REISE_TSO],
                 søknadMottattTidspunkt
             ),
             tom: dagensDato(),

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsDagligReiseTsr.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsDagligReiseTsr.ts
@@ -3,7 +3,7 @@ import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { dagensDato, førsteDagIMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetDagligReiseTsr,
@@ -66,7 +66,7 @@ const resetPeriode = (
     if (nyType === AktivitetType.INGEN_AKTIVITET) {
         return {
             fom: førsteDagIMånederForut(
-                ingenMålgruppeAktivitetAntallMndBakITiden[Stønadstype.DAGLIG_REISE_TSR],
+                maksMånederTilbakeFraSøknadsdato[Stønadstype.DAGLIG_REISE_TSR],
                 søknadMottattTidspunkt
             ),
             tom: dagensDato(),

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsLæremidler.ts
@@ -6,7 +6,7 @@ import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
 import { dagensDato, førsteDagIMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 import {
     AktivitetLæremidler,
@@ -105,7 +105,7 @@ const resetPeriode = (
     if (nyType === AktivitetType.INGEN_AKTIVITET) {
         return {
             fom: førsteDagIMånederForut(
-                ingenMålgruppeAktivitetAntallMndBakITiden[Stønadstype.LÆREMIDLER],
+                maksMånederTilbakeFraSøknadsdato[Stønadstype.LÆREMIDLER],
                 søknadMottattTidspunkt
             ),
             tom: dagensDato(),

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/RegisterYtelser.tsx
@@ -18,7 +18,7 @@ import { Behandling } from '../../../../typer/behandling/behandling';
 import { stønadstypeTilTekst } from '../../../../typer/behandling/behandlingTema';
 import { registerYtelseTilTekstStorForbokstav } from '../../../../typer/registerytelser';
 import { formaterNullableIsoDato, formaterNullableIsoDatoTid } from '../../../../utils/dato';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import {
     VilkårperioderGrunnlag,
     YtelseGrunnlagPeriode,
@@ -108,16 +108,16 @@ function Hjelpetekst({
                             I en førstegangsbehandling for{' '}
                             {stønadstypeTilTekst[behandling.stønadstype].toLowerCase()} hentes
                             målgrupper fra og med mottatt dato minus{' '}
-                            {ingenMålgruppeAktivitetAntallMndBakITiden[behandling.stønadstype]}{' '}
-                            måneder tilbake i tid.
+                            {maksMånederTilbakeFraSøknadsdato[behandling.stønadstype]} måneder
+                            tilbake i tid.
                         </BodyLong>
                     ) : (
                         <BodyLong spacing>
                             Ved revurdering hentes målgrupper fra den første datoen i forrige
                             vedtak. Dersom{' '}
-                            {ingenMålgruppeAktivitetAntallMndBakITiden[behandling.stønadstype]}{' '}
-                            måneder tilbake fra opprettelsesdatoen gir en tidligere startdato,
-                            brukes den i stedet.
+                            {maksMånederTilbakeFraSøknadsdato[behandling.stønadstype]} måneder
+                            tilbake fra opprettelsesdatoen gir en tidligere startdato, brukes den i
+                            stedet.
                         </BodyLong>
                     )}
                 </HelpText>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/utils.ts
@@ -7,7 +7,7 @@ import {
 import { dagensDato, førsteDagIMånederForut } from '../../../../utils/dato';
 import { Periode } from '../../../../utils/periode';
 import { FaktiskMålgruppe } from '../../Felles/faktiskMålgruppe';
-import { ingenMålgruppeAktivitetAntallMndBakITiden } from '../../Felles/grunnlagAntallMndBakITiden';
+import { maksMånederTilbakeFraSøknadsdato } from '../../Felles/grunnlagAntallMndBakITiden';
 import { Aktivitet } from '../typer/vilkårperiode/aktivitet';
 import {
     MålgruppeFaktaOgSvar,
@@ -134,7 +134,7 @@ const resetPeriode = (
     if (nyType === MålgruppeType.INGEN_MÅLGRUPPE) {
         return {
             fom: førsteDagIMånederForut(
-                ingenMålgruppeAktivitetAntallMndBakITiden[stønadstype],
+                maksMånederTilbakeFraSøknadsdato[stønadstype],
                 søknadMottattTidspunkt
             ),
             tom: dagensDato(),


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Nåværende hjelpetekster kombinerer informasjon om førstegangsbehandling og revurdering. Har prøvd å gjøre den lettere å forstå ved å bruke informasjon vi har tilgjengelig (behandlingstype og stønadstype)

### Før
<img width="540" height="291" alt="image" src="https://github.com/user-attachments/assets/5dc944ab-beb3-4eeb-8b69-970b0ed07496" />

### Etter
Førstegangsbehandling - aktivitet:
<img width="540" height="194" alt="image" src="https://github.com/user-attachments/assets/d159c4e0-cb5d-4a27-b6c2-b39957a1cde7" />

Revurdering - aktivitet:
<img width="540" height="239" alt="image" src="https://github.com/user-attachments/assets/f42d13c9-0e61-4d2e-99b3-49585ba90d46" />

Målgruppe er lik bare at ordet "aktivitet" skal være byttet ut.