### PR TITLE
Vise vedtaksperioder i behandling

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -3,9 +3,10 @@ import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Alert, Button, Tabs } from '@navikt/ds-react';
+import { Accordion, Alert, BodyShort, Button, Tabs } from '@navikt/ds-react';
 import { ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 
+import { DetaljerteVedtaksperioderBehandling } from './DetaljerteVedtaksperioderBehandling';
 import { HamburgermenyBehandling } from './Fanemeny/HamburgermenyBehandling';
 import { faneErLåst, FanePath, hentBehandlingfaner, isFanePath } from './faner';
 import { useApp } from '../../context/AppContext';
@@ -121,7 +122,28 @@ const BehandlingTabsInnhold = () => {
                     statusPåVentRedigering={statusPåVentRedigering}
                     settStatusPåVentRedigering={settStatusPåVentRedigering}
                 />
-
+                <Accordion style={{ backgroundColor: '#FDFFE6' }}>
+                    <Accordion.Item defaultOpen>
+                        <Accordion.Header
+                            style={{
+                                padding: '0',
+                                border: 'none',
+                                boxShadow: 'none',
+                                flexDirection: 'row-reverse',
+                                fontSize: 'medium',
+                            }}
+                        >
+                            <BodyShort size={'small'} weight={'semibold'}>
+                                Vedtaksperioder
+                            </BodyShort>
+                        </Accordion.Header>
+                        <Accordion.Content style={{ padding: '0px', paddingBottom: '1.5rem' }}>
+                            <DetaljerteVedtaksperioderBehandling
+                                fagsakPersonId={behandling.fagsakPersonId}
+                            />
+                        </Accordion.Content>
+                    </Accordion.Item>
+                </Accordion>
                 {behandlingFaner
                     .filter((fane) => !fane.erLåst)
                     .map((tab) => (

--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -3,17 +3,18 @@ import React, { useEffect, useState } from 'react';
 import { useLocation, useNavigate } from 'react-router-dom';
 import styled from 'styled-components';
 
-import { Accordion, Alert, BodyShort, Button, Tabs } from '@navikt/ds-react';
+import { Alert, Button, Tabs } from '@navikt/ds-react';
 import { ATextSubtle } from '@navikt/ds-tokens/dist/tokens';
 
-import { DetaljerteVedtaksperioderBehandling } from './DetaljerteVedtaksperioderBehandling';
 import { HamburgermenyBehandling } from './Fanemeny/HamburgermenyBehandling';
 import { faneErLåst, FanePath, hentBehandlingfaner, isFanePath } from './faner';
+import { VedtaksperioderAccordion } from './Vilkårvurdering/VedtaksperioderAccordion';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
 import { StegProvider } from '../../context/StegContext';
 import { SettPåVentSak } from '../../komponenter/SettPåVent/SettPåVentContainer';
 import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
+import { BehandlingType } from '../../typer/behandling/behandlingType';
 import { Toast } from '../../typer/toast';
 
 const StickyTablistContainer = styled(Sticky)`
@@ -122,27 +123,9 @@ const BehandlingTabsInnhold = () => {
                     statusPåVentRedigering={statusPåVentRedigering}
                     settStatusPåVentRedigering={settStatusPåVentRedigering}
                 />
-                <Accordion style={{ backgroundColor: '#FDFFE6' }}>
-                    <Accordion.Item defaultOpen>
-                        <Accordion.Header
-                            style={{
-                                padding: '0.5rem',
-                                border: 'none',
-                                boxShadow: 'none',
-                                fontSize: 'medium',
-                            }}
-                        >
-                            <BodyShort size={'small'} weight={'semibold'}>
-                                Vedtaksperioder
-                            </BodyShort>
-                        </Accordion.Header>
-                        <Accordion.Content style={{ padding: '0px', paddingBottom: '1.5rem' }}>
-                            <DetaljerteVedtaksperioderBehandling
-                                fagsakPersonId={behandling.fagsakPersonId}
-                            />
-                        </Accordion.Content>
-                    </Accordion.Item>
-                </Accordion>
+                {behandling.type !== BehandlingType.FØRSTEGANGSBEHANDLING && (
+                    <VedtaksperioderAccordion behandling={behandling} />
+                )}
                 {behandlingFaner
                     .filter((fane) => !fane.erLåst)
                     .map((tab) => (

--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -126,10 +126,9 @@ const BehandlingTabsInnhold = () => {
                     <Accordion.Item defaultOpen>
                         <Accordion.Header
                             style={{
-                                padding: '0',
+                                padding: '0.5rem',
                                 border: 'none',
                                 boxShadow: 'none',
-                                flexDirection: 'row-reverse',
                                 fontSize: 'medium',
                             }}
                         >

--- a/src/frontend/Sider/Behandling/DetaljerteVedtaksperioderBehandling.tsx
+++ b/src/frontend/Sider/Behandling/DetaljerteVedtaksperioderBehandling.tsx
@@ -1,34 +1,91 @@
 import React from 'react';
 
+import styled from 'styled-components';
+
 import { Box } from '@navikt/ds-react';
+import { AGray500 } from '@navikt/ds-tokens/dist/tokens';
 
 import { useHentFullstendigVedtaksOversikt } from '../../hooks/useHentFullstendigVedtaksOversikt';
 import DataViewer from '../../komponenter/DataViewer';
+import { Behandling } from '../../typer/behandling/behandling';
+import { Stønadstype } from '../../typer/behandling/behandlingTema';
 import { VedtaksperioderOversiktBoutgifter } from '../Personoversikt/Vedtaksperioderoversikt/Boutgifter/VedtaksperioderOversiktBoutgifter';
+import { VedtaksperioderOversiktDagligReiseTso } from '../Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktDagligReiseTso';
+import { VedtaksperioderOversiktDagligReiseTsr } from '../Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktDagligReiseTsr';
+import { VedtaksperioderOversiktLæremidler } from '../Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktLæremidler';
+import { VedtaksperioderOversiktTilsynBarn } from '../Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktTilsynBarn';
+
+const Container = styled('div')`
+    margin-left: 2rem;
+`;
+
+const TableContainer = styled(Box)`
+    width: 920px;
+    background-color: white;
+    border: solid 1px ${AGray500};
+`;
 
 type Props = {
-    fagsakPersonId: string;
+    behandling: Behandling;
 };
 
-export function DetaljerteVedtaksperioderBehandling({ fagsakPersonId }: Props) {
-    const { vedtaksperioderOversikt } = useHentFullstendigVedtaksOversikt(fagsakPersonId);
+export function DetaljerteVedtaksperioderBehandling({ behandling }: Props) {
+    const { vedtaksperioderOversikt } = useHentFullstendigVedtaksOversikt(
+        behandling.fagsakPersonId
+    );
 
     return (
-        <DataViewer type={'vedtaksperioder'} response={{ vedtaksperioderOversikt }}>
-            {({ vedtaksperioderOversikt }) => (
-                <div style={{ marginLeft: '2rem' }}>
-                    {vedtaksperioderOversikt.boutgifter.length > 0 && (
-                        <Box
-                            width={'920px'}
-                            style={{ backgroundColor: 'white', border: 'solid 1px lightgray' }}
-                        >
-                            <VedtaksperioderOversiktBoutgifter
-                                vedtaksperioder={vedtaksperioderOversikt.boutgifter}
-                            />
-                        </Box>
-                    )}
-                </div>
-            )}
-        </DataViewer>
+        <Container>
+            <DataViewer type={'vedtaksperioder'} response={{ vedtaksperioderOversikt }}>
+                {({ vedtaksperioderOversikt }) => {
+                    switch (behandling.stønadstype) {
+                        case Stønadstype.BOUTGIFTER:
+                            return vedtaksperioderOversikt.boutgifter.length > 0 ? (
+                                <TableContainer>
+                                    <VedtaksperioderOversiktBoutgifter
+                                        vedtaksperioder={vedtaksperioderOversikt.boutgifter}
+                                    />
+                                </TableContainer>
+                            ) : null;
+
+                        case Stønadstype.BARNETILSYN:
+                            return vedtaksperioderOversikt.tilsynBarn.length > 0 ? (
+                                <TableContainer>
+                                    <VedtaksperioderOversiktTilsynBarn
+                                        vedtaksperioder={vedtaksperioderOversikt.tilsynBarn}
+                                    />
+                                </TableContainer>
+                            ) : null;
+
+                        case Stønadstype.LÆREMIDLER:
+                            return vedtaksperioderOversikt.læremidler.length > 0 ? (
+                                <TableContainer>
+                                    <VedtaksperioderOversiktLæremidler
+                                        vedtaksperioder={vedtaksperioderOversikt.læremidler}
+                                    />
+                                </TableContainer>
+                            ) : null;
+
+                        case Stønadstype.DAGLIG_REISE_TSO:
+                            return vedtaksperioderOversikt.dagligReiseTso.length > 0 ? (
+                                <TableContainer>
+                                    <VedtaksperioderOversiktDagligReiseTso
+                                        vedtaksperioder={vedtaksperioderOversikt.dagligReiseTso}
+                                    />
+                                </TableContainer>
+                            ) : null;
+
+                        case Stønadstype.DAGLIG_REISE_TSR:
+                            return vedtaksperioderOversikt.dagligReiseTsr.length > 0 ? (
+                                <TableContainer>
+                                    <VedtaksperioderOversiktDagligReiseTsr
+                                        vedtaksperioder={vedtaksperioderOversikt.dagligReiseTsr}
+                                    />
+                                </TableContainer>
+                            ) : null;
+                    }
+                }}
+            </DataViewer>
+        </Container>
     );
 }

--- a/src/frontend/Sider/Behandling/DetaljerteVedtaksperioderBehandling.tsx
+++ b/src/frontend/Sider/Behandling/DetaljerteVedtaksperioderBehandling.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { Box } from '@navikt/ds-react';
+
+import { useHentFullstendigVedtaksOversikt } from '../../hooks/useHentFullstendigVedtaksOversikt';
+import DataViewer from '../../komponenter/DataViewer';
+import { VedtaksperioderOversiktBoutgifter } from '../Personoversikt/Vedtaksperioderoversikt/Boutgifter/VedtaksperioderOversiktBoutgifter';
+
+type Props = {
+    fagsakPersonId: string;
+};
+
+export function DetaljerteVedtaksperioderBehandling({ fagsakPersonId }: Props) {
+    const { vedtaksperioderOversikt } = useHentFullstendigVedtaksOversikt(fagsakPersonId);
+
+    return (
+        <DataViewer type={'vedtaksperioder'} response={{ vedtaksperioderOversikt }}>
+            {({ vedtaksperioderOversikt }) => (
+                <div style={{ marginLeft: '2rem' }}>
+                    {vedtaksperioderOversikt.boutgifter.length > 0 && (
+                        <Box
+                            width={'920px'}
+                            style={{ backgroundColor: 'white', border: 'solid 1px lightgray' }}
+                        >
+                            <VedtaksperioderOversiktBoutgifter
+                                vedtaksperioder={vedtaksperioderOversikt.boutgifter}
+                            />
+                        </Box>
+                    )}
+                </div>
+            )}
+        </DataViewer>
+    );
+}

--- a/src/frontend/Sider/Behandling/Vilkårvurdering/VedtaksperioderAccordion.tsx
+++ b/src/frontend/Sider/Behandling/Vilkårvurdering/VedtaksperioderAccordion.tsx
@@ -1,0 +1,46 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { Accordion, BodyShort } from '@navikt/ds-react';
+import { ALimegreen50 } from '@navikt/ds-tokens/dist/tokens';
+
+import { Behandling } from '../../../typer/behandling/behandling';
+import { DetaljerteVedtaksperioderBehandling } from '../DetaljerteVedtaksperioderBehandling';
+
+const GulAccordion = styled(Accordion)`
+    background-color: ${ALimegreen50};
+`;
+
+const AccordionHeader = styled(Accordion.Header)`
+    padding: 0.5rem;
+    border: none;
+    box-shadow: none;
+    font-size: medium;
+`;
+
+const AccordionContent = styled(Accordion.Content)`
+    padding: 0;
+    padding-bottom: 1.5rem;
+`;
+
+type Props = {
+    behandling: Behandling;
+};
+
+export function VedtaksperioderAccordion({ behandling }: Props) {
+    return (
+        <GulAccordion>
+            <Accordion.Item defaultOpen>
+                <AccordionHeader>
+                    <BodyShort size={'small'} weight={'semibold'}>
+                        Vedtaksperioder
+                    </BodyShort>
+                </AccordionHeader>
+                <AccordionContent>
+                    <DetaljerteVedtaksperioderBehandling behandling={behandling} />
+                </AccordionContent>
+            </Accordion.Item>
+        </GulAccordion>
+    );
+}

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/Boutgifter/VedtaksperioderOversiktBoutgifter.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/Boutgifter/VedtaksperioderOversiktBoutgifter.tsx
@@ -31,6 +31,7 @@ export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperi
                     <Table.HeaderCell scope="col" align={'right'}>
                         Stønad
                     </Table.HeaderCell>
+                    <Table.HeaderCell scope="col" />
                 </Table.Row>
             </Table.Header>
             <Table.Body>

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/Boutgifter/VedtaksperioderOversiktBoutgifter.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/Boutgifter/VedtaksperioderOversiktBoutgifter.tsx
@@ -31,7 +31,6 @@ export const VedtaksperioderOversiktBoutgifter: React.FC<Props> = ({ vedtaksperi
                     <Table.HeaderCell scope="col" align={'right'}>
                         Stønad
                     </Table.HeaderCell>
-                    <Table.HeaderCell scope="col" />
                 </Table.Row>
             </Table.Header>
             <Table.Body>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For at saksbehandler kan ha oversikt over ferdigstilt vedtaksperioder inne på en behandling. 

**Ingen vedtaksperioder:**
<img width="1718" height="550" alt="Screenshot 2025-09-15 at 11 25 21" src="https://github.com/user-attachments/assets/fecc0763-b617-44e4-88a3-515c1c350a3c" />

**Revurdering av bolig overnatting med to ferdigstilte overnattinger**
<img width="1709" height="988" alt="Screenshot 2025-09-15 at 13 58 14" src="https://github.com/user-attachments/assets/519f8056-a3ff-46a3-bf64-064e6ba4b151" />
