### PR TITLE
Endre type på beregningsresultat så den er klar for å ta i mot ulike …

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/innvilgeVedtak/Beregningsresultat.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/innvilgeVedtak/Beregningsresultat.tsx
@@ -34,7 +34,7 @@ interface Props {
 const Beregningsresultat: FC<Props> = ({ beregningsresultat }) => {
     return (
         <VStack gap={'6'}>
-            {beregningsresultat.reiser.map((reise, reiseIndex) => (
+            {beregningsresultat.offentligTransport?.reiser.map((reise, reiseIndex) => (
                 <Container key={`reise-${reiseIndex}`}>
                     <Grid>
                         <Label>Fra og med</Label>

--- a/src/frontend/typer/vedtak/vedtakDagligReise.ts
+++ b/src/frontend/typer/vedtak/vedtakDagligReise.ts
@@ -48,8 +48,12 @@ export type OpphørDagligReise = OpphørRequest & {
 };
 
 export interface BeregningsresultatDagligReise {
-    reiser: BeregningsresultatForReise[];
+    offentligTransport?: BeregningsresultatOffentligTransport;
     tidligsteEndring: string | undefined;
+}
+
+export interface BeregningsresultatOffentligTransport {
+    reiser: BeregningsresultatForReise[];
 }
 
 interface BeregningsresultatForReise {


### PR DESCRIPTION
…beregninger for alle transporttyper

### Hvorfor er denne endringen nødvendig? ✨
Ikke knekke pga. endringene som gjøres i backend ([PR-859](https://github.com/navikt/tilleggsstonader-sak/pull/859)