### PR TITLE
Viser navn og ident på bruker tilknyttet sak i oppfølgingsliste

### DIFF
--- a/src/frontend/Sider/Admin/Oppfølging/OppfølgingAdmin.tsx
+++ b/src/frontend/Sider/Admin/Oppfølging/OppfølgingAdmin.tsx
@@ -183,18 +183,10 @@ export const OppfølgingTabell = ({ oppfølgingerInit }: { oppfølgingerInit: Op
                         >
                             <HStack justify={'space-between'}>
                                 <HStack gap={'4'} align={'start'} justify={'start'}>
-                                    <StønadstypeTag
-                                        stønadstype={oppfølging.behandlingsdetaljer.stønadstype}
-                                    />
-                                    <Detail>
-                                        Saksnummer: {oppfølging.behandlingsdetaljer.saksnummer}
-                                    </Detail>
-                                    <Detail>
-                                        Vedtakstidspunkt:{' '}
-                                        {formaterIsoDatoTid(
-                                            oppfølging.behandlingsdetaljer.vedtakstidspunkt
-                                        )}
-                                    </Detail>
+                                    <Heading size={'small'}>
+                                        {oppfølging.behandlingsdetaljer.fagsakPersonNavn} -{' '}
+                                        {oppfølging.behandlingsdetaljer.fagsakPersonIdent}
+                                    </Heading>
                                 </HStack>
                                 <HStack gap={'2'}>
                                     {oppfølging.behandlingsdetaljer.harNyereBehandling && (
@@ -207,6 +199,22 @@ export const OppfølgingTabell = ({ oppfølgingerInit }: { oppfølgingerInit: Op
                                             Viktig
                                         </Tag>
                                     )}
+                                </HStack>
+                            </HStack>
+                            <HStack justify={'space-between'}>
+                                <HStack gap={'4'} align={'start'} justify={'start'}>
+                                    <StønadstypeTag
+                                        stønadstype={oppfølging.behandlingsdetaljer.stønadstype}
+                                    />
+                                    <Detail>
+                                        Saksnummer: {oppfølging.behandlingsdetaljer.saksnummer}
+                                    </Detail>
+                                    <Detail>
+                                        Vedtakstidspunkt:{' '}
+                                        {formaterIsoDatoTid(
+                                            oppfølging.behandlingsdetaljer.vedtakstidspunkt
+                                        )}
+                                    </Detail>
                                 </HStack>
                             </HStack>
                             <HStack gap={'6'} align={'start'}>

--- a/src/frontend/Sider/Admin/Oppfølging/oppfølgingTyper.ts
+++ b/src/frontend/Sider/Admin/Oppfølging/oppfølgingTyper.ts
@@ -17,6 +17,8 @@ export interface Oppfølging {
     behandlingsdetaljer: {
         saksnummer: number;
         fagsakPersonId: string;
+        fagsakPersonIdent: string;
+        fagsakPersonNavn: string;
         stønadstype: Stønadstype;
         vedtakstidspunkt: string;
         harNyereBehandling: boolean;


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Viser navn og ident på en oppfølging. Backend-endring: https://github.com/navikt/tilleggsstonader-sak/pull/864
Favro: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=NAV-26306

<img width="1199" height="304" alt="Skjermbilde 2025-09-24 kl  21 33 57" src="https://github.com/user-attachments/assets/a4007209-c40b-49b0-9bfa-84f7ff6c2219" />

(ignorer at fødselsnummer står to ganger på oversikriften, første er egentlig fornavn pga testdataoppsett ved lokal kjøring 😛 )