### PR TITLE
💄 Småendringer på brevfanen

### DIFF
--- a/src/frontend/komponenter/Brev/Brevmeny.tsx
+++ b/src/frontend/komponenter/Brev/Brevmeny.tsx
@@ -56,7 +56,7 @@ const oppdaterStateForId =
 const FlexColumn = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 1rem;
+    gap: 1.5rem;
 `;
 
 const initialiserInkluderteDelmaler = (

--- a/src/frontend/komponenter/Brev/Delmal.tsx
+++ b/src/frontend/komponenter/Brev/Delmal.tsx
@@ -1,6 +1,5 @@
 import React, { SetStateAction } from 'react';
 
-import { PortableText } from '@portabletext/react';
 import styled from 'styled-components';
 
 import { ExclamationmarkTriangleIcon } from '@navikt/aksel-icons';
@@ -22,18 +21,6 @@ const Background = styled.div`
 const Container = styled.div`
     display: flex;
     flex-direction: column;
-    gap: 1rem;
-`;
-
-const Innhold = styled.div`
-    background-color: white;
-    padding: 1rem;
-`;
-
-const DelmalPreview = styled.div`
-    display: flex;
-    flex-direction: column;
-    flex-grow: 1;
     gap: 1rem;
 `;
 
@@ -114,27 +101,6 @@ const Delmal: React.FC<Props> = ({
                             inkluderIBrev={inkluderIBrev}
                             settInkluderIBrev={settInkluderIBrev}
                         />
-                        <ExpansionCard aria-label={'Forhåndvis delmal'} size="small">
-                            <ExpansionCard.Header>
-                                <ExpansionCard.Title size="small">
-                                    Generert brevtekst
-                                </ExpansionCard.Title>
-                            </ExpansionCard.Header>
-                            <ExpansionCard.Content>
-                                <DelmalPreview>
-                                    <Innhold>
-                                        <PortableText
-                                            value={delmal.blocks}
-                                            components={CustomComponets(
-                                                valgfelt,
-                                                variabler,
-                                                fritekst
-                                            )}
-                                        />
-                                    </Innhold>
-                                </DelmalPreview>
-                            </ExpansionCard.Content>
-                        </ExpansionCard>
                     </Container>
                 </ExpansionCard.Content>
             </ExpansionCard>

--- a/src/frontend/komponenter/Brev/DelmalMeny.tsx
+++ b/src/frontend/komponenter/Brev/DelmalMeny.tsx
@@ -27,6 +27,7 @@ const FlexColumn = styled.div`
     display: flex;
     flex-direction: column;
     gap: 1rem;
+    margin-bottom: 1rem;
 `;
 
 export const DelmalMeny: React.FC<Props> = ({

--- a/src/frontend/komponenter/Brev/DelmalMeny.tsx
+++ b/src/frontend/komponenter/Brev/DelmalMeny.tsx
@@ -85,7 +85,7 @@ export const DelmalMeny: React.FC<Props> = ({
                         return (
                             <Fritekst
                                 key={index}
-                                avsnitt={fritekst[delmal._id] || [lagTomtAvsnitt()]}
+                                alleAvsnitt={fritekst[delmal._id]}
                                 settAvsnitt={(utledNextState) => {
                                     const prevState = fritekst[delmal._id] || [lagTomtAvsnitt()];
                                     const nextState =

--- a/src/frontend/komponenter/Brev/Fritekst.tsx
+++ b/src/frontend/komponenter/Brev/Fritekst.tsx
@@ -30,11 +30,11 @@ const KnappeWrapper = styled.div`
 export const lagTomtAvsnitt = (): FritekstAvsnitt => ({ deloverskrift: '', innhold: '' });
 
 interface Props {
-    avsnitt: FritekstAvsnitt[];
+    alleAvsnitt: FritekstAvsnitt[] | undefined;
     settAvsnitt: React.Dispatch<SetStateAction<FritekstAvsnitt[]>>;
 }
 
-const Fritekst: React.FC<Props> = ({ avsnitt, settAvsnitt }) => {
+const Fritekst: React.FC<Props> = ({ alleAvsnitt, settAvsnitt }) => {
     const oppdaterAvsnitt = (indeks: number, oppdatertAvsnitt: FritekstAvsnitt) =>
         settAvsnitt((prevState) =>
             prevState.map((avsnitt, i) => (i === indeks ? oppdatertAvsnitt : avsnitt))
@@ -43,7 +43,10 @@ const Fritekst: React.FC<Props> = ({ avsnitt, settAvsnitt }) => {
     const fjernAvsnitt = (indeks: number) =>
         settAvsnitt((prevState) => prevState.filter((_, i) => i !== indeks));
 
-    const leggTilNyttAvsnitt = () => settAvsnitt((prevState) => [...prevState, lagTomtAvsnitt()]);
+    const leggTilNyttAvsnitt = () =>
+        settAvsnitt((prevState) =>
+            alleAvsnitt ? [...prevState, lagTomtAvsnitt()] : [lagTomtAvsnitt()]
+        );
 
     const flyttAvsnittOpp = (indeks: number) => {
         if (indeks === 0) return;
@@ -57,7 +60,7 @@ const Fritekst: React.FC<Props> = ({ avsnitt, settAvsnitt }) => {
     };
 
     const flyttAvsnittNed = (indeks: number) => {
-        if (indeks === avsnitt.length - 1) return;
+        if (alleAvsnitt && indeks === alleAvsnitt.length - 1) return;
 
         settAvsnitt((prevState) => [
             ...prevState.slice(0, indeks),
@@ -70,56 +73,62 @@ const Fritekst: React.FC<Props> = ({ avsnitt, settAvsnitt }) => {
     return (
         <FlexColumn>
             <Heading size={'small'}>Fritekst</Heading>
-            {avsnitt.map((avsnitt, indeks) => {
-                return (
-                    <FritekstAvsnittContainer key={indeks}>
-                        <TextField
-                            size={'small'}
-                            value={avsnitt.deloverskrift}
-                            label={'Deloverskrift'}
-                            onChange={(e) =>
-                                oppdaterAvsnitt(indeks, {
-                                    deloverskrift: e.target.value,
-                                    innhold: avsnitt.innhold,
-                                })
-                            }
-                            autoComplete="off"
-                        />
-                        <Textarea
-                            label={'Innhold'}
-                            size={'small'}
-                            value={avsnitt.innhold}
-                            onChange={(e) =>
-                                oppdaterAvsnitt(indeks, {
-                                    deloverskrift: avsnitt.deloverskrift,
-                                    innhold: e.target.value,
-                                })
-                            }
-                        />
-                        <KnappeWrapper>
-                            <Tooltip content="Slett avsnitt">
-                                <SøppelbøtteKnapp onClick={() => fjernAvsnitt(indeks)} />
-                            </Tooltip>
-                            <Tooltip content="Flytt avsnitt ned">
-                                <Button
-                                    size={'small'}
-                                    variant={'tertiary'}
-                                    icon={<ArrowDownIcon />}
-                                    onClick={() => flyttAvsnittNed(indeks)}
-                                />
-                            </Tooltip>
-                            <Tooltip content="Flytt avsnitt opp">
-                                <Button
-                                    size={'small'}
-                                    variant={'tertiary'}
-                                    icon={<ArrowUpIcon />}
-                                    onClick={() => flyttAvsnittOpp(indeks)}
-                                />
-                            </Tooltip>
-                        </KnappeWrapper>
-                    </FritekstAvsnittContainer>
-                );
-            })}
+            {alleAvsnitt &&
+                alleAvsnitt.map((avsnitt, indeks) => {
+                    return (
+                        <FritekstAvsnittContainer key={indeks}>
+                            <TextField
+                                size={'small'}
+                                value={avsnitt.deloverskrift}
+                                label={'Deloverskrift'}
+                                onChange={(e) =>
+                                    oppdaterAvsnitt(indeks, {
+                                        deloverskrift: e.target.value,
+                                        innhold: avsnitt.innhold,
+                                    })
+                                }
+                                autoComplete="off"
+                            />
+                            <Textarea
+                                label={'Innhold'}
+                                size={'small'}
+                                value={avsnitt.innhold}
+                                onChange={(e) =>
+                                    oppdaterAvsnitt(indeks, {
+                                        deloverskrift: avsnitt.deloverskrift,
+                                        innhold: e.target.value,
+                                    })
+                                }
+                            />
+                            <KnappeWrapper>
+                                <Tooltip content="Slett avsnitt">
+                                    <SøppelbøtteKnapp onClick={() => fjernAvsnitt(indeks)} />
+                                </Tooltip>
+                                <Tooltip content="Flytt avsnitt ned">
+                                    <Button
+                                        size={'small'}
+                                        variant={'tertiary'}
+                                        icon={<ArrowDownIcon />}
+                                        onClick={() => flyttAvsnittNed(indeks)}
+                                        disabled={
+                                            indeks === alleAvsnitt.length - 1 ||
+                                            alleAvsnitt.length === 1
+                                        }
+                                    />
+                                </Tooltip>
+                                <Tooltip content="Flytt avsnitt opp">
+                                    <Button
+                                        size={'small'}
+                                        variant={'tertiary'}
+                                        icon={<ArrowUpIcon />}
+                                        onClick={() => flyttAvsnittOpp(indeks)}
+                                        disabled={indeks === 0 && alleAvsnitt.length === 1}
+                                    />
+                                </Tooltip>
+                            </KnappeWrapper>
+                        </FritekstAvsnittContainer>
+                    );
+                })}
             <Button
                 size="small"
                 variant="tertiary"

--- a/src/frontend/komponenter/Brev/Fritekst.tsx
+++ b/src/frontend/komponenter/Brev/Fritekst.tsx
@@ -131,7 +131,7 @@ const Fritekst: React.FC<Props> = ({ alleAvsnitt, settAvsnitt }) => {
                 })}
             <Button
                 size="small"
-                variant="tertiary"
+                variant="secondary"
                 icon={<PlusIcon fontSize="1.5rem" />}
                 onClick={leggTilNyttAvsnitt}
                 style={{ width: 'fit-content' }}

--- a/src/frontend/komponenter/Brev/Valgfelt.tsx
+++ b/src/frontend/komponenter/Brev/Valgfelt.tsx
@@ -84,7 +84,7 @@ const Valgfelt: React.FC<Props> = ({
             {valgtBlock &&
                 (valgtBlock._type == 'fritekst' ? (
                     <Fritekst
-                        avsnitt={fritekst[valgfelt._id] || [lagTomtAvsnitt()]}
+                        alleAvsnitt={fritekst[valgfelt._id] || [lagTomtAvsnitt()]}
                         settAvsnitt={(utledNextState) => {
                             const prevState = fritekst[valgfelt._id] || [lagTomtAvsnitt()];
                             const nextState =


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Blåfargen på kortene forsvant i oppdatering og ting gikk litt mer i ett, så vi trengte noen små tilpasninger for å gjøre det enklere å se hva som hørte sammen:

- Litt mer space mellom hvert kort
- Fritekst-felt blir først synlig hvis man trykker på "legg til fritekst". Bare knapp som default
- "Generert brevtekst" er fjernet fordi den ikke blir brukt, har bugs knyttet til seg og er bare en ekstra ramme i ramma som man ikke trenger.

|**Før**|**Etter**|
|---|---|
|<img width="682" height="879" alt="image" src="https://github.com/user-attachments/assets/ea9cf2b5-ead2-430d-8238-f1b6896c08b8" />|<img width="682" height="634" alt="image" src="https://github.com/user-attachments/assets/bcf8fbab-34bb-40fb-81f9-4a53b55c4fda" />|

⚠️ ❓ Skjønner ikke hvorfor alle knappene og checkboksene er "neutral" og ikke blå??