### PR TITLE
Potential fix for code scanning alert no. 16: Missing CSRF middleware

### DIFF
--- a/src/backend/auth/local.ts
+++ b/src/backend/auth/local.ts
@@ -4,6 +4,7 @@ import session from 'express-session';
 import * as oauth from 'oauth4webapi';
 import * as client from 'openid-client';
 import { TokenEndpointResponseHelpers } from 'openid-client';
+import { csrf } from 'lusca';
 
 import { getConfig } from './client';
 import logger from '../logger';
@@ -23,6 +24,7 @@ export const setupLocalAuth = async (app: Express) => {
             secret: 'DUMMY_SECRET',
         })
     );
+    app.use(csrf());
 
     const config = await getConfig();
 

--- a/src/backend/auth/local.ts
+++ b/src/backend/auth/local.ts
@@ -1,10 +1,10 @@
 import cookieParser from 'cookie-parser';
 import { Express, NextFunction, Request, Response } from 'express';
 import session from 'express-session';
+import { csrf } from 'lusca';
 import * as oauth from 'oauth4webapi';
 import * as client from 'openid-client';
 import { TokenEndpointResponseHelpers } from 'openid-client';
-import { csrf } from 'lusca';
 
 import { getConfig } from './client';
 import logger from '../logger';

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -20,16 +20,17 @@
     "express-session": "^1.18.1",
     "http-proxy-middleware": "^3.0.5",
     "jose": "^6.1.0",
+    "lusca": "^1.7.0",
     "node-cache": "^5.1.2",
     "openid-client": "^6.8.1",
     "uuid": "^13.0.0",
-    "winston": "^3.19.0",
-    "lusca": "^1.7.0"
+    "winston": "^3.19.0"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.9",
     "@types/express": "^5.0.3",
     "@types/express-session": "^1.18.2",
+    "@types/lusca": "^1.7.5",
     "@types/node": "^24.9.2",
     "@types/uuid": "^11.0.0",
     "@types/webpack-hot-middleware": "^2.25.9",

--- a/src/backend/package.json
+++ b/src/backend/package.json
@@ -23,7 +23,8 @@
     "node-cache": "^5.1.2",
     "openid-client": "^6.8.1",
     "uuid": "^13.0.0",
-    "winston": "^3.19.0"
+    "winston": "^3.19.0",
+    "lusca": "^1.7.0"
   },
   "devDependencies": {
     "@types/cookie-parser": "^1.4.9",

--- a/src/backend/yarn.lock
+++ b/src/backend/yarn.lock
@@ -1425,6 +1425,13 @@ lower-case@^2.0.2:
   dependencies:
     tslib "^2.0.3"
 
+lusca@^1.7.0:
+  version "1.7.0"
+  resolved "https://registry.yarnpkg.com/lusca/-/lusca-1.7.0.tgz#a5d979f1b51776e60d41e0ca98f886f1b8b95502"
+  integrity sha512-msnrplCfY7zaqlZBDEloCIKld+RUeMZVeWzSPaGUKeRXFlruNSdKg2XxCyR+zj6BqzcXhXlRnvcvx6rAGgsvMA==
+  dependencies:
+    tsscmp "^1.0.5"
+
 make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
@@ -2031,6 +2038,11 @@ tslib@^2.0.0, tslib@^2.0.3:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.7.0.tgz#d9b40c5c40ab59e8738f297df3087bf1a2690c01"
   integrity sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==
+
+tsscmp@^1.0.5:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/tsscmp/-/tsscmp-1.0.6.tgz#85b99583ac3589ec4bfef825b5000aa911d605eb"
+  integrity sha512-LxhtAkPDTkVCMQjt2h6eBVY28KCjikZqZfMcC15YBeNjkgUpdCfBu5HoiOTDu86v6smE8yOjyEktJ8hlbANHQA==
 
 type-is@^2.0.1:
   version "2.0.1"

--- a/src/backend/yarn.lock
+++ b/src/backend/yarn.lock
@@ -232,6 +232,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.15.tgz#596a1747233694d50f6ad8a7869fcb6f56cf5841"
   integrity sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==
 
+"@types/lusca@^1.7.5":
+  version "1.7.5"
+  resolved "https://registry.yarnpkg.com/@types/lusca/-/lusca-1.7.5.tgz#6fff257dc11176bd3150afba90790e626a12cd0f"
+  integrity sha512-l49gAf8pu2iMzbKejLcz6Pqj+51H2na6BgORv1ElnE8ByPFcBdh/eZ0WNR1Va/6ZuNSZa01Hoy1DTZ3IZ+y+kA==
+  dependencies:
+    "@types/express" "*"
+
 "@types/mime@^1":
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/@types/mime/-/mime-1.3.5.tgz#1ef302e01cf7d2b5a0fa526790c9123bf1d06690"


### PR DESCRIPTION
Potential fix for [https://github.com/navikt/tilleggsstonader-sak-frontend/security/code-scanning/16](https://github.com/navikt/tilleggsstonader-sak-frontend/security/code-scanning/16)

To generally fix this problem in an Express app that uses cookie-based sessions, you should add a CSRF protection middleware right after session and cookie middleware, and then ensure that any state-changing requests include and validate a CSRF token (for example, via headers, form fields, or double-submit cookies). A well-known approach in Node/Express is to use the `lusca` package’s `csrf` middleware (as suggested in the background) or `csurf`. Since the guidance explicitly mentions `lusca.csrf`, we’ll use that.

In this specific file (`src/backend/auth/local.ts`), the minimal, non-breaking change is:
- Import the `csrf` middleware from `lusca`.
- After `app.use(cookieParser())` and the `session` setup, add `app.use(csrf());`.

This ensures that any subsequent routes (including `/oauth2/login`, `/oauth2/callback`, `/oauth2/logout`, and particularly `/api/sak` and its handlers) are protected by CSRF checks. We are not changing any existing logic; we are only enriching the middleware chain. Front-end code (not shown) will need to read/submit the CSRF token as required by `lusca`, but that’s outside the scope of edits allowed here.

Concretely:
- At the top of `src/backend/auth/local.ts`, add `import { csrf } from 'lusca';`.
- Inside `setupLocalAuth`, immediately after the `session` middleware registration, add `app.use(csrf());`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
