### PR TITLE
Styling. Kjørelistebehandling -  Endre overskrifter og tilpass oppsummering av rammevedtak per uke vs reise

### DIFF
--- a/src/frontend/Sider/Behandling/Kjøreliste/OppsummeringRammevedtak.module.css
+++ b/src/frontend/Sider/Behandling/Kjøreliste/OppsummeringRammevedtak.module.css
@@ -1,5 +1,5 @@
 .grid {
     display: grid;
-    grid-template-columns: repeat(7, max-content);
-    gap: 1rem 2rem;
+    grid-template-columns: repeat(2, max-content);
+    gap: 0.5rem 2rem;
 }

--- a/src/frontend/Sider/Behandling/Kjøreliste/ReiseKort.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/ReiseKort.tsx
@@ -24,9 +24,7 @@ export const ReiseKort: FC<{
     return (
         <div className={styles.container}>
             <div className={styles.header}>
-                <Heading size="small">
-                    <u>{reisevurdering.rammevedtak.aktivitetsadresse}</u>
-                </Heading>
+                <Heading size="small">{reisevurdering.rammevedtak.aktivitetsadresse}</Heading>
                 <OppsummeringRammevedtak rammeForReise={reisevurdering.rammevedtak} />
             </div>
             <div className={styles.innhold}>

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.module.css
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.module.css
@@ -1,10 +1,10 @@
 :root {
     --kolonne-1: 1.75rem;
     --kolonne-2: 4.5rem;
-    --kolonne-3: 4rem;
-    --kolonne-4: 4.25rem;
+    --kolonne-3: 2.5rem;
+    --kolonne-4: 7.75rem;
     --kolonne-5: 5.5rem;
-    --kolonne-6: 7.75rem;
+    --kolonne-6: 8.5rem;
     --kolonne-7: auto;
     --kolonne-5-redigering: 7rem;
 }

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -108,12 +108,12 @@ export const UkeInnhold: FC<{
                     <div className={styles.venstreGrid}>
                         <Label size="small">Dag</Label>
                         <Label size="small">Dato</Label>
-                        <Label size="small">Har kjørt</Label>
-                        <Label size="small">Parking</Label>
+                        <Label size="small">Kjørt</Label>
+                        <Label size="small">Parkering levert</Label>
                     </div>
                     <div className={redigerer ? styles.høyreGridRedigering : styles.høyreGrid}>
                         <Label size="small">Status</Label>
-                        <Label size="small">Parkeringsutgifter</Label>
+                        <Label size="small">Parkering godkjent</Label>
                         <Label size="small">Kommentar</Label>
                     </div>
                 </div>

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.module.css
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.module.css
@@ -1,0 +1,5 @@
+.grid {
+    display: grid;
+    grid-template-columns: 5rem auto;
+    align-items: center;
+}

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
@@ -44,7 +44,7 @@ export const UkeRad: FC<{
                             <HStack gap="space-4" wrap={false}>
                                 <Label size="small">Reisedager per uke:</Label>
                                 <BodyShort size="small">
-{relevantDelperiodeForUke?.reisedagerPerUke ?? "-"}
+                                    {relevantDelperiodeForUke?.reisedagerPerUke ?? '-'}
                                 </BodyShort>
                             </HStack>
                         </HStack>
@@ -62,29 +62,6 @@ export const UkeRad: FC<{
                         </BodyShort>
                     </HStack>
                 </HStack>
-                {/* <HStack justify="space-between" align="center">
-                    <HStack gap="space-16" align="center">
-                        <Heading size="small">{`Uke ${uke.ukenummer}`}</Heading>
-                        <HStack gap="space-4">
-                            <Label size="small">Periode:</Label>
-                            <BodyShort size="small">
-                                {formaterIsoPeriode(uke.fraDato, uke.tilDato)}
-                            </BodyShort>
-                        </HStack>
-                    </HStack>
-                    <HStack gap="space-16" align="center">
-                        {ukeTagInfo && (
-                            <Tag size="small" variant={ukeTagInfo.variant}>
-                                {ukeTagInfo.label}
-                            </Tag>
-                        )}
-                        <BodyShort size="small">
-                            {uke.kjørelisteInnsendtDato
-                                ? `Levert ${formaterNullableIsoDato(uke.kjørelisteInnsendtDato)}`
-                                : 'Ikke innsendt'}
-                        </BodyShort>
-                    </HStack>
-                </HStack> */}
             </TableHeaderCellSmall>
         </Table.ExpandableRow>
     );

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
@@ -1,12 +1,17 @@
 import React, { FC } from 'react';
 
-import { BodyShort, Heading, HStack, Table, Tag } from '@navikt/ds-react';
+import { BodyShort, Heading, HStack, Label, Table, Tag } from '@navikt/ds-react';
 
 import { UkeInnhold } from './UkeInnhold';
+import styles from './UkeRad.module.css';
 import { TableHeaderCellSmall } from '../../../../komponenter/TabellSmall';
 import { UkeVurdering } from '../../../../typer/kjøreliste';
 import { RammeForReiseMedPrivatBilDelperiode } from '../../../../typer/vedtak/vedtakDagligReise';
-import { formaterNullableIsoDato } from '../../../../utils/dato';
+import {
+    formaterIsoPeriode,
+    formaterNullableIsoDato,
+    perioderOverlapper,
+} from '../../../../utils/dato';
 import { utledUkeTag } from '../utils';
 
 export const UkeRad: FC<{
@@ -16,6 +21,10 @@ export const UkeRad: FC<{
 }> = ({ uke, oppdaterUke, delperioder }) => {
     const ukeTagInfo = utledUkeTag(uke);
 
+    const relevantDelperiodeForUke = delperioder.find((delperiode) =>
+        perioderOverlapper(delperiode, { fom: uke.fraDato, tom: uke.tilDato })
+    );
+
     return (
         <Table.ExpandableRow
             content={<UkeInnhold uke={uke} oppdaterUke={oppdaterUke} delperioder={delperioder} />}
@@ -23,7 +32,23 @@ export const UkeRad: FC<{
         >
             <TableHeaderCellSmall>
                 <HStack justify="space-between" align="center">
-                    <Heading size="small">{`Uke ${uke.ukenummer}`}</Heading>
+                    <div className={styles.grid}>
+                        <Heading size="small">{`Uke ${uke.ukenummer}`}</Heading>
+                        <HStack gap="space-24">
+                            <HStack gap="space-4" wrap={false}>
+                                <Label size="small">Periode:</Label>
+                                <BodyShort size="small">
+                                    {formaterIsoPeriode(uke.fraDato, uke.tilDato)}
+                                </BodyShort>
+                            </HStack>
+                            <HStack gap="space-4" wrap={false}>
+                                <Label size="small">Reisedager per uke:</Label>
+                                <BodyShort size="small">
+                                    {relevantDelperiodeForUke?.reisedagerPerUke}
+                                </BodyShort>
+                            </HStack>
+                        </HStack>
+                    </div>
                     <HStack gap="space-16" align="center">
                         {ukeTagInfo && (
                             <Tag size="small" variant={ukeTagInfo.variant}>
@@ -37,6 +62,29 @@ export const UkeRad: FC<{
                         </BodyShort>
                     </HStack>
                 </HStack>
+                {/* <HStack justify="space-between" align="center">
+                    <HStack gap="space-16" align="center">
+                        <Heading size="small">{`Uke ${uke.ukenummer}`}</Heading>
+                        <HStack gap="space-4">
+                            <Label size="small">Periode:</Label>
+                            <BodyShort size="small">
+                                {formaterIsoPeriode(uke.fraDato, uke.tilDato)}
+                            </BodyShort>
+                        </HStack>
+                    </HStack>
+                    <HStack gap="space-16" align="center">
+                        {ukeTagInfo && (
+                            <Tag size="small" variant={ukeTagInfo.variant}>
+                                {ukeTagInfo.label}
+                            </Tag>
+                        )}
+                        <BodyShort size="small">
+                            {uke.kjørelisteInnsendtDato
+                                ? `Levert ${formaterNullableIsoDato(uke.kjørelisteInnsendtDato)}`
+                                : 'Ikke innsendt'}
+                        </BodyShort>
+                    </HStack>
+                </HStack> */}
             </TableHeaderCellSmall>
         </Table.ExpandableRow>
     );

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
@@ -44,7 +44,7 @@ export const UkeRad: FC<{
                             <HStack gap="space-4" wrap={false}>
                                 <Label size="small">Reisedager per uke:</Label>
                                 <BodyShort size="small">
-                                    {relevantDelperiodeForUke?.reisedagerPerUke}
+{relevantDelperiodeForUke?.reisedagerPerUke ?? "-"}
                                 </BodyShort>
                             </HStack>
                         </HStack>


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Litt div småfikser etter tilbakemelding fra lars:
- Nye overskrifter per uke (parkering)
- Flytte informasjon som nå ligger i delperioder ned til uke-raden og ikke som oppsummering øverst

<img width="1346" height="745" alt="image" src="https://github.com/user-attachments/assets/24a1c1a6-9946-4f63-850a-10cb4da47ebf" />
