### PR TITLE
✨ Filtrer ut perioder fra tidligere vedtak i privat bil-beregning

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/BeregningFaneDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/BeregningFaneDagligReise.tsx
@@ -1,7 +1,7 @@
-import React, { FC } from 'react';
+import React, { FC, useState } from 'react';
 
 import { CalculatorIcon } from '@navikt/aksel-icons';
-import { VStack } from '@navikt/ds-react';
+import { Heading, HStack, Switch, VStack } from '@navikt/ds-react';
 
 import { DagligReisePrivatBilBeregningsresultatTabell } from './DagligReisePrivatBilBeregningsresultatTabell';
 import { PrivatBilOppsummertBeregning } from './typer';
@@ -32,15 +32,51 @@ export const BeregningFaneDagligReise: FC = () => {
 const Beregning: FC<{ oppsummertBeregning: PrivatBilOppsummertBeregning }> = ({
     oppsummertBeregning,
 }) => {
+    const [visTidligerePerioder, setVisTidligerePerioder] = useState(false);
+
+    const harPerioderFraTidligereVedtak = oppsummertBeregning.reiser.some((reise) =>
+        reise.perioder.some((periode) => periode.fraTidligereVedtak)
+    );
+
     return (
         <Panel ikon={<CalculatorIcon />} tittel="Beregningsresultat inkludert kjøreliste">
             <VStack gap="space-16">
-                {oppsummertBeregning.reiser.map((reise) => (
-                    <DagligReisePrivatBilBeregningsresultatTabell
-                        key={reise.reiseId}
-                        oppsummertBeregning={reise}
-                    />
-                ))}
+                <HStack justify="space-between">
+                    <Heading spacing size="xsmall" level="4">
+                        Beregningsresultat
+                    </Heading>
+                    {harPerioderFraTidligereVedtak && (
+                        <Switch
+                            position="left"
+                            size="small"
+                            checked={visTidligerePerioder}
+                            onChange={() => setVisTidligerePerioder((prev) => !prev)}
+                        >
+                            Vis upåvirkede perioder
+                        </Switch>
+                    )}
+                </HStack>
+                {oppsummertBeregning.reiser.map((reise) => {
+                    const relevantePerioder = reise.perioder.filter(
+                        (periode) => visTidligerePerioder || !periode.fraTidligereVedtak
+                    );
+                    if (relevantePerioder.length === 0) {
+                        return null;
+                    }
+                    const totaltStønadsbeløp = visTidligerePerioder
+                        ? reise.totaltStønadsbeløpMedPerioderFraForrigeVedtak
+                        : reise.totaltStønadsbeløpUtenPerioderFraForrigeVedtak;
+                    return (
+                        <DagligReisePrivatBilBeregningsresultatTabell
+                            key={reise.reiseId}
+                            oppsummertBeregning={{
+                                ...reise,
+                                perioder: relevantePerioder,
+                                totaltStønadsbeløp,
+                            }}
+                        />
+                    );
+                })}
             </VStack>
         </Panel>
     );

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/typer.ts
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/typer.ts
@@ -10,6 +10,8 @@ export interface OppsummertBeregningForReise {
     aktivitetsadresse: string | undefined;
     perioder: OppsummertBeregningForPeriode[];
     totaltStønadsbeløp: number;
+    totaltStønadsbeløpMedPerioderFraForrigeVedtak: number;
+    totaltStønadsbeløpUtenPerioderFraForrigeVedtak: number;
 }
 
 export interface OppsummertBeregningForPeriode {
@@ -22,6 +24,7 @@ export interface OppsummertBeregningForPeriode {
     satser: RammeForReiseMedPrivatBilSatsForDelperiode[];
     parkeringskostnadTotalt: number;
     stønadsbeløp: number;
+    fraTidligereVedtak: boolean;
 }
 
 export interface FormatertSats {


### PR DESCRIPTION
## Beskrivelse

`OppsummertBeregningForPeriode` har fått et nytt felt `fraTidligereVedtak`. Denne PRen utnytter feltet til å vise kun nye uker i beregningsvisningen for privat bil.

### Endringer
- Legger til `fraTidligereVedtak: boolean` på `OppsummertBeregningForPeriode`
- Legger til `totaltStønadsbeløpMedPerioderFraForrigeVedtak` og `totaltStønadsbeløpUtenPerioderFraForrigeVedtak` på `OppsummertBeregningForReise`
- Beregningsvisningen viser kun nye perioder (`fraTidligereVedtak=false`) som standard
- Viser en toggle ("Vis upåvirkede perioder") kun når det finnes perioder fra tidligere vedtak
- Totalbeløpet i tabellen oppdateres korrekt basert på toggle-state

Samme mønster som `BeregningOffentligTransport` i `OffentligTransport.tsx`.

Backend: https://github.com/navikt/tilleggsstonader-sak/pull/1188

Kun nye uker:
<img width="1457" height="647" alt="image" src="https://github.com/user-attachments/assets/499cb795-0aa4-4034-9b79-08408b2bbddc" />

Med eksisterende uker:
<img width="1456" height="736" alt="image" src="https://github.com/user-attachments/assets/3e0ba525-1c9f-40d0-84c3-61e7a11495a5" />
