### PR TITLE
Status kjorelistebehandling

### DIFF
--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import { PencilIcon } from '@navikt/aksel-icons';
-import { BodyShort, Button, HStack, InlineMessage, Label, VStack } from '@navikt/ds-react';
+import { Button, HStack, InlineMessage, Label, VStack } from '@navikt/ds-react';
 
 import { RedigerAvklartDag } from './Dag/RedigerAvklartDag';
 import styles from './UkeInnhold.module.css';
@@ -102,10 +102,10 @@ export const UkeInnhold: FC<{
     const kanRedigereUke = erStegRedigerbart && !!uke.kjørelisteInnsendtDato && !!uke.avklartUkeId;
 
     return (
-        <VStack gap="space-16" data-color="neutral">
-            <BodyShort size="small">
+        <VStack gap="space-16">
+            <Label size="small">
                 Antall reisedager fra rammevedtak: {delperiodeForUke.reisedagerPerUke}
-            </BodyShort>
+            </Label>
             <div>
                 <div className={`${styles.borderToppBunn} ${styles.wrapper}`}>
                     <div className={styles.venstreGrid}>

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import { PencilIcon } from '@navikt/aksel-icons';
-import { Button, HStack, InlineMessage, Label, VStack } from '@navikt/ds-react';
+import { BodyShort, Button, HStack, InlineMessage, Label, VStack } from '@navikt/ds-react';
 
 import { RedigerAvklartDag } from './Dag/RedigerAvklartDag';
 import styles from './UkeInnhold.module.css';
@@ -29,8 +29,8 @@ import { RammeForReiseMedPrivatBilDelperiode } from '../../../../typer/vedtak/ve
 export const UkeInnhold: FC<{
     uke: UkeVurdering;
     oppdaterUke: (uke: UkeVurdering) => void;
-    delperioder: RammeForReiseMedPrivatBilDelperiode[];
-}> = ({ uke, oppdaterUke, delperioder }) => {
+    delperiodeForUke: RammeForReiseMedPrivatBilDelperiode;
+}> = ({ uke, oppdaterUke, delperiodeForUke }) => {
     const { request } = useApp();
     const { behandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
@@ -55,7 +55,7 @@ export const UkeInnhold: FC<{
         settValideringsfeilForDager(feil);
 
         const erAntallGodkjenteDagerInnenforRammevedtak =
-            validerAntallReisedagerInnenforRammevedtak(redigerbareDager, uke, delperioder);
+            validerAntallReisedagerInnenforRammevedtak(redigerbareDager, delperiodeForUke);
 
         settValideringsfeilForUke(
             erAntallGodkjenteDagerInnenforRammevedtak
@@ -102,7 +102,10 @@ export const UkeInnhold: FC<{
     const kanRedigereUke = erStegRedigerbart && !!uke.kjørelisteInnsendtDato && !!uke.avklartUkeId;
 
     return (
-        <VStack gap="space-16">
+        <VStack gap="space-16" data-color="neutral">
+            <BodyShort size="small">
+                Antall reisedager fra rammevedtak: {delperiodeForUke.reisedagerPerUke}
+            </BodyShort>
             <div>
                 <div className={`${styles.borderToppBunn} ${styles.wrapper}`}>
                     <div className={styles.venstreGrid}>

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.module.css
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.module.css
@@ -1,5 +1,5 @@
 .grid {
     display: grid;
-    grid-template-columns: 5rem auto;
+    grid-template-columns: 4.5rem auto;
     align-items: center;
 }

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
@@ -37,24 +37,22 @@ export const UkeRad: FC<{
                 <HStack justify="space-between" align="center">
                     <div className={styles.grid}>
                         <Heading size="small">{`Uke ${uke.ukenummer}`}</Heading>
-                        <HStack gap="space-24">
-                            <HStack gap="space-4" wrap={false}>
-                                <BodyShort size="small">
-                                    {formaterIsoPeriode(uke.fraDato, uke.tilDato)}
-                                </BodyShort>
-                            </HStack>
+                        <HStack gap="space-40">
+                            <BodyShort size="small">
+                                {formaterIsoPeriode(uke.fraDato, uke.tilDato)}
+                            </BodyShort>
                             <AutomatiskManuellEllerAvvikTag status={uke.status} />
                         </HStack>
                     </div>
-                    <HStack gap="space-16" align="center">
+                    <HStack gap="space-40" align="center">
                         <AvklartKjørtUkeStatusTag
                             avklartKjørtUkeStatus={uke.avklartKjørtUkeStatus}
                         />
-                        <BodyShort size="small">
-                            {uke.kjørelisteInnsendtDato
-                                ? `Levert ${formaterNullableIsoDato(uke.kjørelisteInnsendtDato)}`
-                                : 'Ikke innsendt'}
-                        </BodyShort>
+                        {uke.kjørelisteInnsendtDato && (
+                            <BodyShort size="small">
+                                Levert {formaterNullableIsoDato(uke.kjørelisteInnsendtDato)}
+                            </BodyShort>
+                        )}
                     </HStack>
                 </HStack>
             </TableHeaderCellSmall>

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeRad.tsx
@@ -1,33 +1,36 @@
 import React, { FC } from 'react';
 
-import { BodyShort, Heading, HStack, Label, Table, Tag } from '@navikt/ds-react';
+import {
+    CogRotationIcon,
+    ExclamationmarkTriangleIcon,
+    PersonHeadsetIcon,
+} from '@navikt/aksel-icons';
+import { BodyShort, Heading, HStack, Table, Tag } from '@navikt/ds-react';
 
 import { UkeInnhold } from './UkeInnhold';
 import styles from './UkeRad.module.css';
 import { TableHeaderCellSmall } from '../../../../komponenter/TabellSmall';
-import { UkeVurdering } from '../../../../typer/kjøreliste';
+import { AvklartKjørtUkeStatus, UkeStatus, UkeVurdering } from '../../../../typer/kjøreliste';
 import { RammeForReiseMedPrivatBilDelperiode } from '../../../../typer/vedtak/vedtakDagligReise';
-import {
-    formaterIsoPeriode,
-    formaterNullableIsoDato,
-    perioderOverlapper,
-} from '../../../../utils/dato';
-import { utledUkeTag } from '../utils';
+import { formaterIsoPeriode, formaterNullableIsoDato } from '../../../../utils/dato';
+import { finnDelperiodeForUke } from '../utils';
 
 export const UkeRad: FC<{
     uke: UkeVurdering;
     oppdaterUke: (uke: UkeVurdering) => void;
     delperioder: RammeForReiseMedPrivatBilDelperiode[];
 }> = ({ uke, oppdaterUke, delperioder }) => {
-    const ukeTagInfo = utledUkeTag(uke);
-
-    const relevantDelperiodeForUke = delperioder.find((delperiode) =>
-        perioderOverlapper(delperiode, { fom: uke.fraDato, tom: uke.tilDato })
-    );
+    const relevantDelperiodeForUke = finnDelperiodeForUke(delperioder, uke);
 
     return (
         <Table.ExpandableRow
-            content={<UkeInnhold uke={uke} oppdaterUke={oppdaterUke} delperioder={delperioder} />}
+            content={
+                <UkeInnhold
+                    uke={uke}
+                    oppdaterUke={oppdaterUke}
+                    delperiodeForUke={relevantDelperiodeForUke}
+                />
+            }
             defaultOpen={uke.status === 'AVVIK'}
         >
             <TableHeaderCellSmall>
@@ -36,25 +39,17 @@ export const UkeRad: FC<{
                         <Heading size="small">{`Uke ${uke.ukenummer}`}</Heading>
                         <HStack gap="space-24">
                             <HStack gap="space-4" wrap={false}>
-                                <Label size="small">Periode:</Label>
                                 <BodyShort size="small">
                                     {formaterIsoPeriode(uke.fraDato, uke.tilDato)}
                                 </BodyShort>
                             </HStack>
-                            <HStack gap="space-4" wrap={false}>
-                                <Label size="small">Reisedager ramme per uke:</Label>
-                                <BodyShort size="small">
-                                    {relevantDelperiodeForUke?.reisedagerPerUke ?? '-'}
-                                </BodyShort>
-                            </HStack>
+                            <AutomatiskManuellEllerAvvikTag status={uke.status} />
                         </HStack>
                     </div>
                     <HStack gap="space-16" align="center">
-                        {ukeTagInfo && (
-                            <Tag size="small" variant={ukeTagInfo.variant}>
-                                {ukeTagInfo.label}
-                            </Tag>
-                        )}
+                        <AvklartKjørtUkeStatusTag
+                            avklartKjørtUkeStatus={uke.avklartKjørtUkeStatus}
+                        />
                         <BodyShort size="small">
                             {uke.kjørelisteInnsendtDato
                                 ? `Levert ${formaterNullableIsoDato(uke.kjørelisteInnsendtDato)}`
@@ -65,4 +60,55 @@ export const UkeRad: FC<{
             </TableHeaderCellSmall>
         </Table.ExpandableRow>
     );
+};
+
+const AutomatiskManuellEllerAvvikTag: FC<{ status: UkeStatus }> = ({ status }) => {
+    switch (status) {
+        case UkeStatus.OK_AUTOMATISK:
+            return (
+                <HStack align="center" gap="space-4">
+                    <CogRotationIcon />
+                    <BodyShort size="small">Automatisk</BodyShort>
+                </HStack>
+            );
+        case UkeStatus.OK_MANUELT:
+            return (
+                <HStack align="center" gap="space-4">
+                    <PersonHeadsetIcon />
+                    <BodyShort size="small">Manuell</BodyShort>
+                </HStack>
+            );
+        case UkeStatus.AVVIK:
+            return (
+                <Tag size="small" data-color="danger" icon={<ExclamationmarkTriangleIcon />}>
+                    Avvik
+                </Tag>
+            );
+        default:
+            return null;
+    }
+};
+
+const AvklartKjørtUkeStatusTag: FC<{ avklartKjørtUkeStatus: AvklartKjørtUkeStatus }> = ({
+    avklartKjørtUkeStatus,
+}) => {
+    switch (avklartKjørtUkeStatus) {
+        case AvklartKjørtUkeStatus.NY:
+            return (
+                <Tag size="small" data-color="success">
+                    Ny
+                </Tag>
+            );
+        case AvklartKjørtUkeStatus.ENDRET:
+            return (
+                <Tag size="small" data-color="warning">
+                    Endret
+                </Tag>
+            );
+        case AvklartKjørtUkeStatus.UENDRET:
+            return <BodyShort size="small">Utbetalt</BodyShort>;
+
+        default:
+            return null;
+    }
 };

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/valideringAvklarteDager.ts
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/valideringAvklarteDager.ts
@@ -5,7 +5,6 @@ import {
     UkeVurdering,
 } from '../../../../typer/kjøreliste';
 import { RammeForReiseMedPrivatBilDelperiode } from '../../../../typer/vedtak/vedtakDagligReise';
-import { perioderOverlapper } from '../../../../utils/dato';
 import { harTallverdi } from '../../../../utils/tall';
 import { harIkkeVerdi, harVerdi } from '../../../../utils/utils';
 
@@ -59,18 +58,13 @@ export const validerAvklarteDager = (
 
 export const validerAntallReisedagerInnenforRammevedtak = (
     avklarteDager: RedigerbarAvklartDag[],
-    uke: UkeVurdering,
-    delperioder: RammeForReiseMedPrivatBilDelperiode[]
+    delperiodeForUke: RammeForReiseMedPrivatBilDelperiode
 ): boolean => {
     const antallDagerMedKjøring = avklarteDager.filter(
         (dag) => dag.godkjentGjennomførtKjøring === GodkjentGjennomførtKjøring.JA
     ).length;
 
-    const rammevedtakDelperiodeForUke = delperioder.filter((delperiode) =>
-        perioderOverlapper(delperiode, { fom: uke.fraDato, tom: uke.tilDato })
-    );
-
-    return antallDagerMedKjøring <= rammevedtakDelperiodeForUke[0].reisedagerPerUke;
+    return antallDagerMedKjøring <= delperiodeForUke.reisedagerPerUke;
 };
 
 const validerAvvikFraKjørelisteErBegrunnet = (

--- a/src/frontend/Sider/Behandling/Kjøreliste/utils.ts
+++ b/src/frontend/Sider/Behandling/Kjøreliste/utils.ts
@@ -3,27 +3,23 @@ import {
     Dag,
     GodkjentGjennomførtKjøring,
     TypeAvvikDag,
-    UkeStatus,
-    UkeVurdering,
     TypeAvvikUke,
+    UkeVurdering,
 } from '../../../typer/kjøreliste';
+import { RammeForReiseMedPrivatBilDelperiode } from '../../../typer/vedtak/vedtakDagligReise';
+import { perioderOverlapper } from '../../../utils/dato';
 
-interface TagInfo {
-    variant: 'success' | 'error' | 'warning' | 'neutral';
-    label: string;
-}
-
-export function utledUkeTag(uke: UkeVurdering): TagInfo | undefined {
-    switch (uke.status) {
-        case UkeStatus.OK_AUTOMATISK:
-            return { label: 'Automatisk ok', variant: 'success' };
-        case UkeStatus.OK_MANUELT:
-            return { label: 'Manuelt ok', variant: 'warning' };
-        case UkeStatus.AVVIK:
-            return { label: 'Avvik', variant: 'error' };
-        case UkeStatus.IKKE_MOTTATT_KJØRELISTE:
-            return undefined;
+export function finnDelperiodeForUke(
+    delperioder: RammeForReiseMedPrivatBilDelperiode[],
+    uke: UkeVurdering
+): RammeForReiseMedPrivatBilDelperiode {
+    const delperiode = delperioder.find((d) =>
+        perioderOverlapper(d, { fom: uke.fraDato, tom: uke.tilDato })
+    );
+    if (!delperiode) {
+        throw new Error(`Fant ingen delperiode for uke ${uke.ukenummer}`);
     }
+    return delperiode;
 }
 
 export function harAvvikPåParkeringsutgift(dag: Dag): boolean {

--- a/src/frontend/typer/kjøreliste.ts
+++ b/src/frontend/typer/kjøreliste.ts
@@ -18,6 +18,7 @@ export interface UkeVurdering {
     kjørelisteId?: string; // null hvis kjøreliste ikke er mottatt
     avklartUkeId?: string; // null hvis uke ikke er avklart
     dager: Dag[];
+    avklartKjørtUkeStatus: AvklartKjørtUkeStatus;
 }
 
 export interface AvvikUke {
@@ -56,6 +57,12 @@ export enum UkeStatus {
     OK_MANUELT = 'OK_MANUELT', // brukes hvis saksbehandler godtar avvik
     AVVIK = 'AVVIK', // parkeringsutgifter/for mange dager etc. saksbehandler må ta stilling til uka
     IKKE_MOTTATT_KJØRELISTE = 'IKKE_MOTTATT_KJØRELISTE',
+}
+
+export enum AvklartKjørtUkeStatus {
+    NY = 'NY', // Uke finnes ikke i forrige behandling
+    ENDRET = 'ENDRET', // Uke finnes i forrige behandling, men er endret av saksbehandler (inkl. tømt innhold → gir 0 kr)
+    UENDRET = 'UENDRET', // Uke er kopiert uendret fra forrige behandling
 }
 
 export enum UtfyltDagResultat {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Mål: gjøre det enklere å se hvilke uker som må behandles nå, er med fra tidligere og hva som evt. er endret av det eksisterende.

Endringer:
- Mindre "støy" på en ukerad (var mye info der)
   - Fjernet label på periode
   - Flyttet "antall reisedager fra rammevedtak" inn i raden så det kun vises hvis du åpner opp
- Tydeligere statuser
  - Egen kolonne som viser om uken er behandlet automatisk eller manuell. Her vises avvik dersom uken har et avvik
  - Egen kolonne som viser om uken er ny i denne behandlingen eller ikke. Dersom den er kopiert med fra tidligere får den "utbetalt" frem til den evt blir endret.

Uke 1-5 er utbetalt tidligere. 6 og 7 er nye nå og er satt til manuell behandling pga. avvik i uke 7:
<img width="1454" height="919" alt="image" src="https://github.com/user-attachments/assets/f50e38b3-c7d3-483f-82f4-797a11f29e4e" />

Behandler avvik i uke 7:
<img width="1442" height="540" alt="image" src="https://github.com/user-attachments/assets/8421087e-e7c3-44d2-8ef0-2a2c5f32fe4a" />

Gjør en endring på en tidligere automatisk godkjent uke (uke 2). Denne blir nå endret til manuell og får tag "Endret":
<img width="1442" height="540" alt="image" src="https://github.com/user-attachments/assets/a69eda21-0afc-4b50-bc43-6e893ff24518" />

 
