### PR TITLE
Legger til muligheten for å opprette manuell kjørelistebehandling

### DIFF
--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/FagsakOversikt.tsx
@@ -68,6 +68,7 @@ export const FagsakOversikt: React.FC<Props> = ({
                 <OpprettNyBehandlingModal
                     fagsakId={fagsakId}
                     stønadstype={stønadstype}
+                    behandlinger={behandlinger}
                     hentKlagebehandlinger={hentKlagebehandlinger}
                     hentBehandlinger={hentBehandlinger}
                 />

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKjørelisteBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKjørelisteBehandling.tsx
@@ -4,7 +4,6 @@ import { useFlag } from '@unleash/proxy-client-react';
 
 import { Button, HelpText, HStack, Label, Select, VStack } from '@navikt/ds-react';
 
-import BarnTilRevurdering, { BarnTilRevurderingResponse } from './BarnTilRevurdering';
 import MetadataNyeOpplysninger from './MetadataNyeOpplysninger';
 import { OpprettNyBehandlingType } from './OpprettNyBehandlingUtils';
 import { useValiderNyeOpplysningerMetadata } from './validerNyeOpplysningerMetadata';
@@ -16,16 +15,14 @@ import {
     lagFeilmelding,
 } from '../../../../komponenter/Feil/feilmeldingUtils';
 import DateInput from '../../../../komponenter/Skjema/DateInput';
-import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { BehandlingÅrsak } from '../../../../typer/behandling/behandlingÅrsak';
 import { NyeOpplysningerMetadata } from '../../../../typer/behandling/nyeOpplysningerMetadata';
-import { byggTomRessurs, Ressurs, RessursStatus } from '../../../../typer/ressurs';
+import { RessursStatus } from '../../../../typer/ressurs';
 import { Toggle } from '../../../../utils/toggles';
 import { harVerdi } from '../../../../utils/utils';
 
 interface Props {
     fagsakId: string;
-    stønadstype: Stønadstype;
     lukkModal: () => void;
     hentBehandlinger: () => void;
 }
@@ -34,35 +31,18 @@ interface OpprettBehandlingRequest {
     fagsakId: string;
     årsak: BehandlingÅrsak;
     kravMottatt?: string;
-    valgteBarn: string[];
     nyeOpplysningerMetadata?: NyeOpplysningerMetadata;
-    forenkletBehandlingstype: OpprettNyBehandlingType;
+    forenkletBehandlingsyype: OpprettNyBehandlingType;
 }
 
-const utledSkalViseBarnTilRevurdering = (
-    stønadstype: Stønadstype,
-    årsak: BehandlingÅrsak | undefined
-): boolean =>
-    stønadstype === Stønadstype.BARNETILSYN &&
-    !!årsak &&
-    [
-        BehandlingÅrsak.SØKNAD,
-        BehandlingÅrsak.PAPIRSØKNAD,
-        BehandlingÅrsak.KORRIGERING_UTEN_BREV,
-    ].indexOf(årsak) > -1;
-
-const OpprettOrdinærBehandling: React.FC<Props> = ({
+const OpprettKjørelisteBehandling: React.FC<Props> = ({
     fagsakId,
-    stønadstype,
     lukkModal,
     hentBehandlinger,
 }) => {
     const { request } = useApp();
 
     const [årsak, settÅrsak] = useState<BehandlingÅrsak>();
-    const [barnTilRevurdering, setBarnTilRevurdering] =
-        useState<Ressurs<BarnTilRevurderingResponse>>(byggTomRessurs());
-    const [valgteBarn, settValgteBarn] = useState<string[]>([]);
 
     const [laster, settLaster] = useState<boolean>(false);
     const [feilmelding, settFeilmelding] = useState<Feil>();
@@ -103,9 +83,8 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
             fagsakId: fagsakId,
             årsak: årsak,
             kravMottatt: kravMottatt,
-            valgteBarn: valgteBarn,
             nyeOpplysningerMetadata: nyeOpplysninger,
-            forenkletBehandlingstype: OpprettNyBehandlingType.ORDINAER_BEHANDLING,
+            forenkletBehandlingsyype: OpprettNyBehandlingType.KJØRELISTE,
         }).then((response) => {
             if (response.status === RessursStatus.SUKSESS) {
                 hentBehandlinger();
@@ -132,9 +111,6 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
         settNyeOpplysninger(undefined);
     };
 
-    const skalViseBarnTilRevurdering = utledSkalViseBarnTilRevurdering(stønadstype, årsak);
-    const skalVentePåOkHentingAvBarn =
-        skalViseBarnTilRevurdering && barnTilRevurdering.status !== RessursStatus.SUKSESS;
     return (
         <VStack gap="space-16">
             <Select label={'Årsak'} onChange={endreÅrsak}>
@@ -171,25 +147,12 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
                     nullstillFeilForFelt={nullstillFeilForFelt}
                 />
             )}
-            {skalViseBarnTilRevurdering && (
-                <BarnTilRevurdering
-                    fagsakId={fagsakId}
-                    barnTilRevurdering={barnTilRevurdering}
-                    settBarnTilRevurdering={setBarnTilRevurdering}
-                    settValgteBarn={settValgteBarn}
-                />
-            )}
             <Feilmelding feil={feilmelding} />
             <HStack gap="space-16" justify={'end'}>
                 <Button variant="tertiary" onClick={lukkModal} size="small">
                     Avbryt
                 </Button>
-                <Button
-                    variant="primary"
-                    onClick={opprett}
-                    size="small"
-                    disabled={skalVentePåOkHentingAvBarn}
-                >
+                <Button variant="primary" onClick={opprett} size="small">
                     Lagre
                 </Button>
             </HStack>
@@ -197,4 +160,4 @@ const OpprettOrdinærBehandling: React.FC<Props> = ({
     );
 };
 
-export default OpprettOrdinærBehandling;
+export default OpprettKjørelisteBehandling;

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKjørelisteBehandling.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettKjørelisteBehandling.tsx
@@ -32,7 +32,7 @@ interface OpprettBehandlingRequest {
     årsak: BehandlingÅrsak;
     kravMottatt?: string;
     nyeOpplysningerMetadata?: NyeOpplysningerMetadata;
-    forenkletBehandlingsyype: OpprettNyBehandlingType;
+    forenkletBehandlingstype: OpprettNyBehandlingType;
 }
 
 const OpprettKjørelisteBehandling: React.FC<Props> = ({
@@ -84,7 +84,7 @@ const OpprettKjørelisteBehandling: React.FC<Props> = ({
             årsak: årsak,
             kravMottatt: kravMottatt,
             nyeOpplysningerMetadata: nyeOpplysninger,
-            forenkletBehandlingsyype: OpprettNyBehandlingType.KJØRELISTE,
+            forenkletBehandlingstype: OpprettNyBehandlingType.KJØRELISTE,
         }).then((response) => {
             if (response.status === RessursStatus.SUKSESS) {
                 hentBehandlinger();

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingModal.tsx
@@ -1,7 +1,11 @@
 import React, { FC, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
+
 import { Button, Select, VStack } from '@navikt/ds-react';
 
+import { kanOppretteManuellKjørelistebehandling } from './kjørelisteBehandlingUtils';
+import OpprettKjørelisteBehandling from './OpprettKjørelisteBehandling';
 import OpprettKlageBehandling from './OpprettKlageBehandling';
 import styles from './OpprettNyBehandlingModal.module.css';
 import {
@@ -11,21 +15,29 @@ import {
 import OpprettOrdinærBehandling from './OpprettOrdinærBehandling';
 import { useApp } from '../../../../context/AppContext';
 import { ModalWrapper } from '../../../../komponenter/Modal/ModalWrapper';
+import { BehandlingDetaljer } from '../../../../typer/behandling/behandlingoversikt';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
+import { Toggle } from '../../../../utils/toggles';
 
 interface Props {
     fagsakId: string;
     stønadstype: Stønadstype;
+    behandlinger: BehandlingDetaljer[];
     hentKlagebehandlinger: () => void;
     hentBehandlinger: () => void;
 }
 export const OpprettNyBehandlingModal: FC<Props> = ({
     fagsakId,
     stønadstype,
+    behandlinger,
     hentKlagebehandlinger,
     hentBehandlinger,
 }) => {
     const { erSaksbehandler } = useApp();
+    const kanBehandleManuellKjørelistebehandling = useFlag(
+        Toggle.KAN_OPPRETTE_MANUELL_KJØRELISTEBEHANDLING
+    );
+
     const [visModal, settVisModal] = useState(false);
     const [opprettNyBehandlingType, settOpprettNyBehandlingType] =
         useState<OpprettNyBehandlingType>();
@@ -38,6 +50,16 @@ export const OpprettNyBehandlingModal: FC<Props> = ({
     if (!erSaksbehandler) {
         return null;
     }
+
+    const kanOppretteManuellKjørelisteBehandling =
+        kanOppretteManuellKjørelistebehandling(behandlinger) &&
+        kanBehandleManuellKjørelistebehandling;
+
+    const tilgjengeligeBehandlingstyper = [
+        OpprettNyBehandlingType.ORDINAER_BEHANDLING,
+        ...(kanOppretteManuellKjørelisteBehandling ? [OpprettNyBehandlingType.KJØRELISTE] : []),
+        OpprettNyBehandlingType.KLAGE,
+    ];
 
     return (
         <div className={styles.container}>
@@ -61,28 +83,32 @@ export const OpprettNyBehandlingModal: FC<Props> = ({
                         }}
                     >
                         <option value={''}>Velg</option>
-                        {[
-                            OpprettNyBehandlingType.ORDINAER_BEHANDLING,
-                            OpprettNyBehandlingType.KLAGE,
-                        ].map((type) => (
+                        {tilgjengeligeBehandlingstyper.map((type) => (
                             <option key={type} value={type}>
                                 {opprettNyBehandlingTypeTilTekst[type]}
                             </option>
                         ))}
                     </Select>
-                    {opprettNyBehandlingType === OpprettNyBehandlingType.KLAGE && (
-                        <OpprettKlageBehandling
-                            fagsakId={fagsakId}
-                            lukkModal={lukkModal}
-                            hentKlagebehandlinger={hentKlagebehandlinger}
-                        />
-                    )}
                     {opprettNyBehandlingType === OpprettNyBehandlingType.ORDINAER_BEHANDLING && (
                         <OpprettOrdinærBehandling
                             fagsakId={fagsakId}
                             stønadstype={stønadstype}
                             lukkModal={lukkModal}
                             hentBehandlinger={hentBehandlinger}
+                        />
+                    )}
+                    {opprettNyBehandlingType === OpprettNyBehandlingType.KJØRELISTE && (
+                        <OpprettKjørelisteBehandling
+                            fagsakId={fagsakId}
+                            lukkModal={lukkModal}
+                            hentBehandlinger={hentBehandlinger}
+                        />
+                    )}
+                    {opprettNyBehandlingType === OpprettNyBehandlingType.KLAGE && (
+                        <OpprettKlageBehandling
+                            fagsakId={fagsakId}
+                            lukkModal={lukkModal}
+                            hentKlagebehandlinger={hentKlagebehandlinger}
                         />
                     )}
                 </VStack>

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingUtils.ts
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/OpprettNyBehandlingUtils.ts
@@ -4,12 +4,14 @@ export enum OpprettNyBehandlingType {
     ORDINAER_BEHANDLING = 'ORDINAER_BEHANDLING',
     KLAGE = 'KLAGE',
     TILBAKEKREVING = 'TILBAKEKREVING',
+    KJØRELISTE = 'KJØRELISTE',
 }
 
 export const opprettNyBehandlingTypeTilTekst: Record<OpprettNyBehandlingType, string> = {
     ORDINAER_BEHANDLING: 'Ordinær behandling',
     KLAGE: 'Klage',
     TILBAKEKREVING: 'Tilbakekreving',
+    KJØRELISTE: 'Kjørelistebehandling',
 };
 
 export const tomNyeOpplysningerMetadata: NyeOpplysningerMetadata = {

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/kjørelisteBehandlingUtils.ts
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/kjørelisteBehandlingUtils.ts
@@ -1,0 +1,31 @@
+import { BehandlingDetaljer } from '../../../../typer/behandling/behandlingoversikt';
+import { BehandlingStatus } from '../../../../typer/behandling/behandlingStatus';
+import { BehandlingType } from '../../../../typer/behandling/behandlingType';
+
+/**
+ * Sjekker om en behandling er en ferdigstilt kjørelistebehandling som kan brukes som grunnlag for en korrigering
+ */
+export const erFerdigstiltKjørelisteBehandling = (behandling: BehandlingDetaljer): boolean => {
+    return (
+        behandling.type === BehandlingType.KJØRELISTE &&
+        behandling.status === BehandlingStatus.FERDIGSTILT
+    );
+};
+
+/**
+ * Finner første ferdigstilt kjørelistebehandling i listen som kan brukes som grunnlag for korrigering
+ */
+export const finnFerdigstiltKjørelisteBehandling = (
+    behandlinger: BehandlingDetaljer[]
+): BehandlingDetaljer | undefined => {
+    return behandlinger.find(erFerdigstiltKjørelisteBehandling);
+};
+
+/**
+ * Sjekker om man kan opprette en korrigeringsbehandling basert på eksisterende kjørelistebehandling
+ */
+export const kanOppretteManuellKjørelistebehandling = (
+    behandlinger: BehandlingDetaljer[]
+): boolean => {
+    return !!finnFerdigstiltKjørelisteBehandling(behandlinger);
+};

--- a/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/kjørelisteBehandlingUtils.ts
+++ b/src/frontend/Sider/Personoversikt/Behandlingsoversikt/OpprettNyBehandling/kjørelisteBehandlingUtils.ts
@@ -2,9 +2,6 @@ import { BehandlingDetaljer } from '../../../../typer/behandling/behandlingovers
 import { BehandlingStatus } from '../../../../typer/behandling/behandlingStatus';
 import { BehandlingType } from '../../../../typer/behandling/behandlingType';
 
-/**
- * Sjekker om en behandling er en ferdigstilt kjørelistebehandling som kan brukes som grunnlag for en korrigering
- */
 export const erFerdigstiltKjørelisteBehandling = (behandling: BehandlingDetaljer): boolean => {
     return (
         behandling.type === BehandlingType.KJØRELISTE &&
@@ -12,20 +9,20 @@ export const erFerdigstiltKjørelisteBehandling = (behandling: BehandlingDetalje
     );
 };
 
-/**
- * Finner første ferdigstilt kjørelistebehandling i listen som kan brukes som grunnlag for korrigering
- */
 export const finnFerdigstiltKjørelisteBehandling = (
     behandlinger: BehandlingDetaljer[]
 ): BehandlingDetaljer | undefined => {
     return behandlinger.find(erFerdigstiltKjørelisteBehandling);
 };
 
-/**
- * Sjekker om man kan opprette en korrigeringsbehandling basert på eksisterende kjørelistebehandling
- */
 export const kanOppretteManuellKjørelistebehandling = (
     behandlinger: BehandlingDetaljer[]
 ): boolean => {
-    return !!finnFerdigstiltKjørelisteBehandling(behandlinger);
+    const ferdigstiltBehandling = finnFerdigstiltKjørelisteBehandling(behandlinger);
+
+    if (ferdigstiltBehandling === undefined) {
+        return false;
+    }
+
+    return erFerdigstiltKjørelisteBehandling(ferdigstiltBehandling);
 };

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -24,5 +24,5 @@ export enum Toggle {
     BRUK_DYNAMISK_KART = 'sak.frontend.bruk-dynamisk-kart',
     KAN_BEHANDLE_PRIVAT_BIL = 'sak.daglig-reise-privat-bil',
     KAN_OPPHØRE_DAGLIG_REISE_TSO = 'sak.frontend.kan-oppheve-daglig-reise-tso',
-    KAN_OPPRETTE_MANUELL_KJØRELISTEBEHANDLING = 'sak.frontend.kan-opprette-manuell-kjørelistebehandling',
+    KAN_OPPRETTE_MANUELL_KJØRELISTEBEHANDLING = 'sak.frontend.kan-opprette-manuell-kjorelistebehandling',
 }

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -24,4 +24,5 @@ export enum Toggle {
     BRUK_DYNAMISK_KART = 'sak.frontend.bruk-dynamisk-kart',
     KAN_BEHANDLE_PRIVAT_BIL = 'sak.daglig-reise-privat-bil',
     KAN_OPPHØRE_DAGLIG_REISE_TSO = 'sak.frontend.kan-oppheve-daglig-reise-tso',
+    KAN_OPPRETTE_MANUELL_KJØRELISTEBEHANDLING = 'sak.frontend.kan-opprette-manuell-kjørelistebehandling',
 }

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -8,6 +8,7 @@ import { Toggle } from './toggles';
  */
 const featureFlags: Partial<Record<Toggle, boolean>> = {
     [Toggle.KAN_BEHANDLE_PRIVAT_BIL]: true,
+    [Toggle.KAN_OPPRETTE_MANUELL_KJØRELISTEBEHANDLING]: true,
 };
 
 export const mockFlags: IToggle[] = Object.values(Toggle).map((toggle) => {

--- a/src/frontend/utils/unleashMock.ts
+++ b/src/frontend/utils/unleashMock.ts
@@ -8,7 +8,6 @@ import { Toggle } from './toggles';
  */
 const featureFlags: Partial<Record<Toggle, boolean>> = {
     [Toggle.KAN_BEHANDLE_PRIVAT_BIL]: true,
-    [Toggle.KAN_OPPRETTE_MANUELL_KJØRELISTEBEHANDLING]: true,
 };
 
 export const mockFlags: IToggle[] = Object.values(Toggle).map((toggle) => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Legger til muligheten for å opprette en manuell kjørelistebehandling dersom:
1. man har rammevedtak
2. man har en tidligere ferdigstilt kjøreliste
3. bryteren er på


<img width="1683" height="1085" alt="Screenshot 2026-05-13 at 14 33 36" src="https://github.com/user-attachments/assets/91583d45-09c8-44b0-96ca-73d0ced575c1" />


