### PR TITLE
Viser frem vedtaksperioder for privat bil sammen med offentlig transp…

### DIFF
--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DagligReise/VedtaksDetaljer.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DagligReise/VedtaksDetaljer.tsx
@@ -1,19 +1,40 @@
 import React, { FC } from 'react';
 
+import { BodyShort } from '@navikt/ds-react';
+
+import { VedtaksdetaljerPrivatBil } from './VedtaksdetaljerPrivatBil';
 import { DagligReiseBeregningstabell } from '../../../../komponenter/DagligReiseBeregningstabell';
+import { RammeForReiseMedPrivatBil } from '../../../../typer/vedtak/vedtakDagligReise';
 import { DetaljertBeregningsperioderDagligReise } from '../../../../typer/vedtak/vedtaksperiodeOppsummering';
 
 interface Props {
-    detaljertBeregningsperioder?: DetaljertBeregningsperioderDagligReise[];
+    detaljertBeregningsperioder?: DetaljertBeregningsperioderDagligReise[] | null;
+    rammevedtakPrivatBil?: RammeForReiseMedPrivatBil | null;
     className?: string;
 }
 
-export const Vedtaksdetaljer: FC<Props> = ({ detaljertBeregningsperioder, className }) => {
-    if (!detaljertBeregningsperioder) {
-        return <>Ingen beregningsdetaljer</>;
+export const Vedtaksdetaljer: FC<Props> = ({
+    detaljertBeregningsperioder,
+    rammevedtakPrivatBil,
+    className,
+}) => {
+    if (detaljertBeregningsperioder?.length) {
+        return (
+            <DagligReiseBeregningstabell
+                perioder={detaljertBeregningsperioder}
+                className={className}
+            />
+        );
     }
 
-    return (
-        <DagligReiseBeregningstabell perioder={detaljertBeregningsperioder} className={className} />
-    );
+    if (rammevedtakPrivatBil) {
+        return (
+            <VedtaksdetaljerPrivatBil
+                rammevedtakPrivatBil={rammevedtakPrivatBil}
+                className={className}
+            />
+        );
+    }
+
+    return <BodyShort size="small">Ingen beregningsdetaljer</BodyShort>;
 };

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DagligReise/VedtaksdetaljerPrivatBil.module.css
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DagligReise/VedtaksdetaljerPrivatBil.module.css
@@ -1,0 +1,3 @@
+.table {
+    margin-bottom: 1.75rem;
+}

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DagligReise/VedtaksdetaljerPrivatBil.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/DagligReise/VedtaksdetaljerPrivatBil.tsx
@@ -1,0 +1,99 @@
+import React, { FC } from 'react';
+
+import { BodyShort, Table, VStack } from '@navikt/ds-react';
+
+import styles from './VedtaksdetaljerPrivatBil.module.css';
+import { TableDataCellSmall, TableHeaderCellSmall } from '../../../../komponenter/TabellSmall';
+import {
+    RammeForReiseMedPrivatBil,
+    RammeForReiseMedPrivatBilDelperiode,
+} from '../../../../typer/vedtak/vedtakDagligReise';
+import { formaterIsoDato } from '../../../../utils/dato';
+import { kronerEllerStrek } from '../../../../utils/tekstformatering';
+
+type VisningsradPrivatBil = {
+    fom: string;
+    tom: string;
+    reisedagerPerUke: number;
+    kilometersats: number;
+    dagsatsUtenParkering: number;
+    bompengerPerDag: number | null;
+    fergekostnadPerDag: number | null;
+};
+
+interface Props {
+    rammevedtakPrivatBil: RammeForReiseMedPrivatBil;
+    className?: string;
+}
+
+function lagVisningsrader(
+    delperioder: RammeForReiseMedPrivatBilDelperiode[]
+): VisningsradPrivatBil[] {
+    return delperioder.flatMap((delperiode) =>
+        delperiode.satser.map((sats) => ({
+            fom: sats.fom,
+            tom: sats.tom,
+            reisedagerPerUke: delperiode.reisedagerPerUke,
+            kilometersats: sats.kilometersats,
+            dagsatsUtenParkering: sats.dagsatsUtenParkering,
+            bompengerPerDag: delperiode.bompengerPerDag ?? null,
+            fergekostnadPerDag: delperiode.fergekostnadPerDag ?? null,
+        }))
+    );
+}
+
+export const VedtaksdetaljerPrivatBil: FC<Props> = ({ rammevedtakPrivatBil, className }) => {
+    const visningsrader = lagVisningsrader(rammevedtakPrivatBil.delperioder);
+
+    return (
+        <VStack gap="space-8" className={className}>
+            <BodyShort size="small">
+                <strong>Reiseavstand en vei:</strong> {rammevedtakPrivatBil.reiseavstandEnVei} km
+            </BodyShort>
+
+            <Table size="small" className={styles.table}>
+                <Table.Header>
+                    <Table.Row>
+                        <TableHeaderCellSmall scope="col">Delperiode</TableHeaderCellSmall>
+                        <TableHeaderCellSmall scope="col">Reisedager pr. uke</TableHeaderCellSmall>
+                        <TableHeaderCellSmall scope="col">Kilometersats</TableHeaderCellSmall>
+                        <TableHeaderCellSmall scope="col">Bompenger pr. dag</TableHeaderCellSmall>
+                        <TableHeaderCellSmall scope="col">
+                            Fergekostnad pr. dag
+                        </TableHeaderCellSmall>
+                        <TableHeaderCellSmall scope="col">
+                            Dagsats uten parkering
+                        </TableHeaderCellSmall>
+                    </Table.Row>
+                </Table.Header>
+
+                <Table.Body>
+                    {visningsrader.length === 0 ? (
+                        <Table.Row>
+                            <Table.DataCell colSpan={6}>Ingen delperioder</Table.DataCell>
+                        </Table.Row>
+                    ) : (
+                        visningsrader.map((rad, index) => (
+                            <Table.Row key={`${rad.fom}-${rad.tom}-${index}`}>
+                                <TableDataCellSmall>
+                                    {formaterIsoDato(rad.fom)} - {formaterIsoDato(rad.tom)}
+                                </TableDataCellSmall>
+                                <TableDataCellSmall>{rad.reisedagerPerUke}</TableDataCellSmall>
+                                <TableDataCellSmall>{rad.kilometersats} kr</TableDataCellSmall>
+                                <TableDataCellSmall>
+                                    {kronerEllerStrek(rad.bompengerPerDag ?? undefined)}
+                                </TableDataCellSmall>
+                                <TableDataCellSmall>
+                                    {kronerEllerStrek(rad.fergekostnadPerDag ?? undefined)}
+                                </TableDataCellSmall>
+                                <TableDataCellSmall>
+                                    {rad.dagsatsUtenParkering} kr
+                                </TableDataCellSmall>
+                            </Table.Row>
+                        ))
+                    )}
+                </Table.Body>
+            </Table>
+        </VStack>
+    );
+};

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktDagligReise.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktDagligReise.tsx
@@ -33,30 +33,42 @@ export const VedtaksperioderOversiktDagligReise: React.FC<Props> = ({
             <Table.Body>
                 {vedtaksperioder.map((periode, index) => {
                     const beregningsperioder = periode.detaljertBeregningsperioder ?? [];
-
-                    const fom = beregningsperioder[beregningsperioder.length - 1]?.fom;
-                    const tom = beregningsperioder[0]?.tom;
+                    const periodeFom =
+                        beregningsperioder[beregningsperioder.length - 1]?.fom ??
+                        periode.rammevedtakPrivatBil?.fom;
+                    const periodeTom =
+                        beregningsperioder[0]?.tom ?? periode.rammevedtakPrivatBil?.tom;
+                    const reisedagerPerUke =
+                        beregningsperioder[0]?.antallReisedagerPerUke ??
+                        periode.rammevedtakPrivatBil?.delperioder[0]?.reisedagerPerUke ??
+                        '-';
+                    const tiltaksadresse =
+                        periode.adresse ?? periode.rammevedtakPrivatBil?.aktivitetsadresse ?? '-';
+                    const rowKey =
+                        periode.rammevedtakPrivatBil?.reiseId ??
+                        `${periodeFom}-${periodeTom}-${index}`;
 
                     return (
                         <Table.ExpandableRow
-                            key={index}
+                            key={rowKey}
                             content={
                                 <Vedtaksdetaljer
                                     detaljertBeregningsperioder={beregningsperioder}
+                                    rammevedtakPrivatBil={periode.rammevedtakPrivatBil}
                                     className={styles.expandedContent}
                                 />
                             }
                             togglePlacement="right"
                         >
-                            <Table.DataCell>{formaterNullablePeriode(fom, tom)}</Table.DataCell>
+                            <Table.DataCell>
+                                {formaterNullablePeriode(periodeFom, periodeTom)}
+                            </Table.DataCell>
 
                             <Table.DataCell>
                                 {typeDagligReiseTilTekst[periode.typeDagligReise]}
                             </Table.DataCell>
-                            <Table.DataCell>{periode.adresse ?? '-'}</Table.DataCell>
-                            <Table.DataCell>
-                                {[beregningsperioder[0].antallReisedagerPerUke]}
-                            </Table.DataCell>
+                            <Table.DataCell>{tiltaksadresse}</Table.DataCell>
+                            <Table.DataCell>{reisedagerPerUke}</Table.DataCell>
                         </Table.ExpandableRow>
                     );
                 })}

--- a/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktDagligReise.tsx
+++ b/src/frontend/Sider/Personoversikt/Vedtaksperioderoversikt/VedtaksperioderOversiktDagligReise.tsx
@@ -5,6 +5,7 @@ import { Table } from '@navikt/ds-react';
 import { Vedtaksdetaljer } from './DagligReise/VedtaksDetaljer';
 import { BorderTable } from './VedtaksperioderBorderTable';
 import styles from './VedtaksperioderOversiktDagligReise.module.css';
+import { RammeForReiseMedPrivatBilDelperiode } from '../../../typer/vedtak/vedtakDagligReise';
 import { DetaljertVedtaksperiodeDagligReise } from '../../../typer/vedtak/vedtaksperiodeOppsummering';
 import { formaterNullablePeriode } from '../../../utils/dato';
 import { typeDagligReiseTilTekst } from '../../Behandling/Stønadsvilkår/DagligReise/typer/vilkårDagligReise';
@@ -40,8 +41,9 @@ export const VedtaksperioderOversiktDagligReise: React.FC<Props> = ({
                         beregningsperioder[0]?.tom ?? periode.rammevedtakPrivatBil?.tom;
                     const reisedagerPerUke =
                         beregningsperioder[0]?.antallReisedagerPerUke ??
-                        periode.rammevedtakPrivatBil?.delperioder[0]?.reisedagerPerUke ??
-                        '-';
+                        hentReisedagerPerUkeFraDelperioder(
+                            periode.rammevedtakPrivatBil?.delperioder
+                        );
                     const tiltaksadresse =
                         periode.adresse ?? periode.rammevedtakPrivatBil?.aktivitetsadresse ?? '-';
                     const rowKey =
@@ -76,3 +78,15 @@ export const VedtaksperioderOversiktDagligReise: React.FC<Props> = ({
         </BorderTable>
     );
 };
+
+function hentReisedagerPerUkeFraDelperioder(
+    delperioder: RammeForReiseMedPrivatBilDelperiode[] | undefined
+): number | string {
+    if (delperioder === undefined) {
+        return '-';
+    }
+    if (delperioder.length > 1) {
+        return 'Varierende';
+    }
+    return delperioder[0].reisedagerPerUke;
+}

--- a/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
+++ b/src/frontend/typer/vedtak/vedtaksperiodeOppsummering.ts
@@ -1,3 +1,4 @@
+import { RammeForReiseMedPrivatBil } from './vedtakDagligReise';
 import { FaktiskMålgruppe } from '../../Sider/Behandling/Felles/faktiskMålgruppe';
 import { AktivitetType } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitet';
 import { Studienivå } from '../../Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetLæremidler';
@@ -60,8 +61,9 @@ export type DetaljertBeregningsperioderDagligReise = {
 export type DetaljertVedtaksperiodeDagligReise = {
     typeDagligReise: TypeDagligReise;
     stønadstype: Stønadstype;
-    detaljertBeregningsperioder: DetaljertBeregningsperioderDagligReise[];
-    adresse?: string;
+    detaljertBeregningsperioder: DetaljertBeregningsperioderDagligReise[] | null;
+    adresse: string | null;
+    rammevedtakPrivatBil: RammeForReiseMedPrivatBil | null;
 };
 
 export interface UtgiftBoutgift {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Back-end: https://github.com/navikt/tilleggsstonader-sak/pull/1214

To delperioder med ulike reisedager i uka:
<img width="1125" height="392" alt="Screenshot 2026-05-18 at 14 07 53" src="https://github.com/user-attachments/assets/aae2c54d-c8d6-45fe-96ac-c70e6db02b9f" />
Note: Spurt om hva vi gjør med "reisedager i uka" når det er delperiode med ulike reisedager - frem til nå viser jeg bare den første - kom gjerne med innspill :)) (har vurdert komma, stjerne, strek etc)

Både privat bil og offentlig transport:
<img width="1112" height="522" alt="Screenshot 2026-05-18 at 14 08 00" src="https://github.com/user-attachments/assets/61dc8d1d-5768-4f1a-8ab5-d8e345671508" />

Ønske fra design dersom det er flere delperioder:
<img width="1128" height="417" alt="Screenshot 2026-05-19 at 14 16 19" src="https://github.com/user-attachments/assets/461b0567-ce00-4605-a4c9-5cc861a66047" />

