### PR TITLE
Rename typeAktivitet til tiltaksvariant i frontend

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKort.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/AktivitetKortLesevisning/AktivitetKort.tsx
@@ -59,10 +59,10 @@ export const AktivitetKort: React.FC<{
                 </Celle>
                 <Celle $width={180}>
                     <BodyShort size="small">{vilkårperiodeTypeTilTekst[aktivitet.type]}</BodyShort>
-                    {'typeAktivitet' in aktivitet && (
-                        <BodyShort size="small">{aktivitet.typeAktivitet?.beskrivelse}</BodyShort>
+                    {'tiltaksvariant' in aktivitet && (
+                        <BodyShort size="small">{aktivitet.tiltaksvariant?.beskrivelse}</BodyShort>
                     )}
-                    {!('typeAktivitet' in aktivitet) && aktivitetFraRegister?.typeNavn && (
+                    {!('tiltaksvariant' in aktivitet) && aktivitetFraRegister?.typeNavn && (
                         <BodyShort size="small">{aktivitetFraRegister?.typeNavn}</BodyShort>
                     )}
                     {aktivitetFraRegister?.arrangør && (

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitet.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitet.tsx
@@ -7,7 +7,7 @@ import { EndreAktivitetDagligReiseTsr } from './EndreAktivitetDagligReiseTsr';
 import { EndreAktivitetLæremidler } from './EndreAktivitetLæremidler';
 import { EndreAktivitetReiseTilSamlingTso } from './EndreAktivitetReiseTilSamlingTso';
 import { useBehandling } from '../../../../context/BehandlingContext';
-import { useHentTypeAktivitetValg } from '../../../../hooks/useHentTypeAktivitetValg';
+import { useHentTiltaksvariantValg } from '../../../../hooks/useHentTiltaksvariantValg';
 import DataViewer from '../../../../komponenter/DataViewer';
 import { Stønadstype } from '../../../../typer/behandling/behandlingTema';
 import { Registeraktivitet } from '../../../../typer/registeraktivitet';
@@ -25,7 +25,7 @@ export const EndreAktivitet: React.FC<{
     avbrytRedigering: () => void;
 }> = ({ aktivitet, aktivitetFraRegister, avbrytRedigering }) => {
     const { behandling } = useBehandling();
-    const { typeAktivitetValg } = useHentTypeAktivitetValg();
+    const { tiltaksvariantValg } = useHentTiltaksvariantValg();
 
     switch (behandling.stønadstype) {
         case Stønadstype.BARNETILSYN:
@@ -62,13 +62,13 @@ export const EndreAktivitet: React.FC<{
             );
         case Stønadstype.DAGLIG_REISE_TSR:
             return (
-                <DataViewer response={{ typeAktivitetValg }} type={'typeAktivitetValg'}>
-                    {({ typeAktivitetValg }) => (
+                <DataViewer response={{ tiltaksvariantValg }} type={'tiltaksvariantValg'}>
+                    {({ tiltaksvariantValg }) => (
                         <EndreAktivitetDagligReiseTsr
                             aktivitet={aktivitet as AktivitetDagligReiseTsr}
                             aktivitetFraRegister={aktivitetFraRegister}
                             avbrytRedigering={avbrytRedigering}
-                            typeAktivitetValg={typeAktivitetValg}
+                            tiltaksvariantValg={tiltaksvariantValg}
                         />
                     )}
                 </DataViewer>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetDagligReiseTsr.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/EndreAktivitetDagligReiseTsr.tsx
@@ -8,7 +8,7 @@ import styles from './EndreAktivitetDagligReiseTsr.module.css';
 import { valgbareAktivitetTyper } from './utilsAktivitet';
 import {
     finnBegrunnelseGrunnerAktivitet,
-    finnTypeAktivitetForKode,
+    finnTiltaksvariantForKode,
     mapEksisterendeAktivitet,
     mapFaktaOgSvarTilRequest,
     nyAktivitet,
@@ -41,7 +41,7 @@ import SlettVilkårperiode from '../Vilkårperioder/SlettVilkårperiodeModal';
 
 export interface EndreAktivitetFormDagligReiseTsr extends Periode {
     type: AktivitetType | '';
-    typeAktivitet?: Kodeverk;
+    tiltaksvariant?: Kodeverk;
     svarHarUtgifter: SvarJaNei | undefined;
     aktivitetsdager: number | undefined;
     begrunnelse?: string;
@@ -49,12 +49,12 @@ export interface EndreAktivitetFormDagligReiseTsr extends Periode {
 }
 
 const initaliserForm = (
-    typeAktivitetValg: Kodeverk[],
+    tiltaksvariantValg: Kodeverk[],
     eksisterendeAktivitet?: AktivitetDagligReiseTsr,
     aktivitetFraRegister?: Registeraktivitet
 ): EndreAktivitetFormDagligReiseTsr => {
     return eksisterendeAktivitet === undefined
-        ? nyAktivitet(aktivitetFraRegister, typeAktivitetValg)
+        ? nyAktivitet(aktivitetFraRegister, tiltaksvariantValg)
         : mapEksisterendeAktivitet(eksisterendeAktivitet);
 };
 
@@ -62,14 +62,14 @@ export const EndreAktivitetDagligReiseTsr: React.FC<{
     aktivitet?: AktivitetDagligReiseTsr;
     aktivitetFraRegister?: Registeraktivitet;
     avbrytRedigering: () => void;
-    typeAktivitetValg: Kodeverk[];
-}> = ({ aktivitet, avbrytRedigering, aktivitetFraRegister, typeAktivitetValg }) => {
+    tiltaksvariantValg: Kodeverk[];
+}> = ({ aktivitet, avbrytRedigering, aktivitetFraRegister, tiltaksvariantValg }) => {
     const { behandling, behandlingFakta } = useBehandling();
     const { oppdaterAktivitet, leggTilAktivitet } = useInngangsvilkår();
     const { lagreVilkårperiode } = useLagreVilkårperiode();
 
     const [form, settForm] = useState<EndreAktivitetFormDagligReiseTsr>(
-        initaliserForm(typeAktivitetValg, aktivitet, aktivitetFraRegister)
+        initaliserForm(tiltaksvariantValg, aktivitet, aktivitetFraRegister)
     );
 
     const [laster, settLaster] = useState<boolean>(false);
@@ -141,9 +141,9 @@ export const EndreAktivitetDagligReiseTsr: React.FC<{
         );
     };
 
-    const oppdaterTypeAktivitet = (typeAktivitetString: string) => {
-        const typeAktivitet = finnTypeAktivitetForKode(typeAktivitetString, typeAktivitetValg);
-        settForm((prevState) => ({ ...prevState, ['typeAktivitet']: typeAktivitet }));
+    const oppdaterTiltaksvariant = (tiltaksvariantString: string) => {
+        const tiltaksvariant = finnTiltaksvariantForKode(tiltaksvariantString, tiltaksvariantValg);
+        settForm((prevState) => ({ ...prevState, ['tiltaksvariant']: tiltaksvariant }));
     };
 
     const delvilkårSomKreverBegrunnelse = finnBegrunnelseGrunnerAktivitet(
@@ -153,11 +153,11 @@ export const EndreAktivitetDagligReiseTsr: React.FC<{
 
     const aktivitetErBruktFraSystem = form.kildeId !== undefined;
 
-    const fantIkkeTypeAktivitet = aktivitetFraRegister && form?.typeAktivitet === undefined;
+    const fantIkkeTiltaksvariant = aktivitetFraRegister && form?.tiltaksvariant === undefined;
 
     return (
         <ResultatOgStatusKort periode={aktivitet} redigeres>
-            {fantIkkeTypeAktivitet && (
+            {fantIkkeTiltaksvariant && (
                 <Alert variant={'error'}>
                     {`Klarte ikke å opprette aktivitet med tiltaksvariant "${aktivitetFraRegister.typeNavn}". Ta kontakt med utviklerteamet.`}
                 </Alert>
@@ -168,11 +168,11 @@ export const EndreAktivitetDagligReiseTsr: React.FC<{
                         form={form}
                         oppdaterTypeIForm={oppdaterType}
                         oppdaterPeriode={oppdaterForm}
-                        oppdaterTypeAktivitet={oppdaterTypeAktivitet}
+                        oppdaterTiltaksvariant={oppdaterTiltaksvariant}
                         typeOptions={valgbareAktivitetTyper(Stønadstype.DAGLIG_REISE_TSR)}
-                        typeAktivitetOptions={kodeverkTilOptions(typeAktivitetValg)}
+                        tiltaksvariantOptions={kodeverkTilOptions(tiltaksvariantValg)}
                         formFeil={vilkårsperiodeFeil}
-                        kanEndreTypeAktivitet={
+                        kanEndreTiltaksvariant={
                             aktivitet === undefined && !aktivitetErBruktFraSystem
                         }
                         kanEndreType={aktivitet === undefined && !aktivitetErBruktFraSystem}
@@ -211,7 +211,7 @@ export const EndreAktivitetDagligReiseTsr: React.FC<{
                 feil={vilkårsperiodeFeil?.begrunnelse}
             />
             <HStack gap="space-16">
-                <Button size="xsmall" onClick={lagre} disabled={fantIkkeTypeAktivitet}>
+                <Button size="xsmall" onClick={lagre} disabled={fantIkkeTiltaksvariant}>
                     Lagre
                 </Button>
                 <Button onClick={avbrytRedigering} variant="secondary" size="xsmall">

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsDagligReiseTsr.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/utilsDagligReiseTsr.ts
@@ -15,10 +15,10 @@ import { BegrunnelseGrunner } from '../Vilkårperioder/Begrunnelse/utils';
 
 export const nyAktivitet = (
     aktivitetFraRegister: Registeraktivitet | undefined,
-    typeAktivitetValg: Kodeverk[]
+    tiltaksvariantValg: Kodeverk[]
 ): EndreAktivitetFormDagligReiseTsr =>
     aktivitetFraRegister
-        ? nyAktivitetFraRegister(aktivitetFraRegister, typeAktivitetValg)
+        ? nyAktivitetFraRegister(aktivitetFraRegister, tiltaksvariantValg)
         : nyTomAktivitet();
 
 export const mapEksisterendeAktivitet = (
@@ -31,13 +31,13 @@ export const mapEksisterendeAktivitet = (
 
 function nyAktivitetFraRegister(
     aktivitetFraRegister: Registeraktivitet,
-    typeAktivitetValg: Kodeverk[]
+    tiltaksvariantValg: Kodeverk[]
 ): EndreAktivitetFormDagligReiseTsr {
     return {
         type: aktivitetFraRegister.erUtdanning ? AktivitetType.UTDANNING : AktivitetType.TILTAK,
-        typeAktivitet: finnTypeAktivitetForRegisterAktivitet(
+        tiltaksvariant: finnTiltaksvariantForRegisterAktivitet(
             aktivitetFraRegister,
-            typeAktivitetValg
+            tiltaksvariantValg
         ),
         svarHarUtgifter: undefined,
         aktivitetsdager: aktivitetFraRegister.antallDagerPerUke,
@@ -47,28 +47,28 @@ function nyAktivitetFraRegister(
     };
 }
 
-function finnTypeAktivitetForRegisterAktivitet(
+function finnTiltaksvariantForRegisterAktivitet(
     registerAktivitet: Registeraktivitet,
-    typeAktivitetValg: Kodeverk[]
+    tiltaksvariantValg: Kodeverk[]
 ) {
-    return typeAktivitetValg.find(
-        (typeAktivitetValg) => typeAktivitetValg.beskrivelse === registerAktivitet.typeNavn
+    return tiltaksvariantValg.find(
+        (tiltaksvariantValg) => tiltaksvariantValg.beskrivelse === registerAktivitet.typeNavn
     );
 }
 
-export function finnTypeAktivitetForKode(
+export function finnTiltaksvariantForKode(
     registerAktivitetKode: string,
-    typeAktivitetValg: Kodeverk[]
+    tiltaksvariantValg: Kodeverk[]
 ) {
-    return typeAktivitetValg.find(
-        (typeAktivitetValg) => typeAktivitetValg.kode === registerAktivitetKode
+    return tiltaksvariantValg.find(
+        (tiltaksvariantValg) => tiltaksvariantValg.kode === registerAktivitetKode
     );
 }
 
 function nyTomAktivitet(): EndreAktivitetFormDagligReiseTsr {
     return {
         type: '',
-        typeAktivitet: undefined,
+        tiltaksvariant: undefined,
         svarHarUtgifter: undefined,
         aktivitetsdager: undefined,
         fom: '',

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetDagligReiseTsr.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Aktivitet/valideringAktivitetDagligReiseTsr.tsx
@@ -7,7 +7,7 @@ import { AktivitetType } from '../typer/vilkårperiode/aktivitet';
 
 export interface AktivitetValidering extends Periode {
     type: AktivitetType | '';
-    typeAktivitet?: string;
+    tiltaksvariant?: string;
     aktivitetsdager: number | undefined;
     begrunnelse?: string;
 }
@@ -19,7 +19,7 @@ export const validerAktivitet = (
         fom: undefined,
         tom: undefined,
         type: undefined,
-        typeAktivitet: undefined,
+        tiltaksvariant: undefined,
         begrunnelse: undefined,
         aktivitetsdager: undefined,
     };
@@ -30,9 +30,9 @@ export const validerAktivitet = (
 
     if (
         endretAktivitet.type !== AktivitetType.INGEN_AKTIVITET &&
-        endretAktivitet.typeAktivitet === undefined
+        endretAktivitet.tiltaksvariant === undefined
     ) {
-        return { ...feil, typeAktivitet: 'Må velges' };
+        return { ...feil, tiltaksvariant: 'Må velges' };
     }
 
     const periodeValidering = validerPeriode(endretAktivitet);

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Vilkårperioder/EndreTypeOgDatoer.tsx
@@ -15,24 +15,24 @@ type MålgruppeEllerAktivitet = MålgruppeType | AktivitetType;
 
 interface TypeOgDatoFelter extends Periode {
     type: MålgruppeType | AktivitetType | '';
-    typeAktivitet?: Kodeverk;
+    tiltaksvariant?: Kodeverk;
 }
 
 interface TypeOgDatoFelterFeil extends Periode {
     type: MålgruppeType | AktivitetType | '';
-    typeAktivitet?: string;
+    tiltaksvariant?: string;
 }
 
 interface Props<T extends MålgruppeEllerAktivitet> {
     form: TypeOgDatoFelter;
     oppdaterTypeIForm: (type: T) => void;
     oppdaterPeriode: (key: keyof Periode, nyVerdi: string) => void;
-    oppdaterTypeAktivitet?: (typeAktivitet: string) => void;
+    oppdaterTiltaksvariant?: (tiltaksvariant: string) => void;
     typeOptions: SelectOption[];
-    typeAktivitetOptions?: SelectOption[];
+    tiltaksvariantOptions?: SelectOption[];
     formFeil?: FormErrors<TypeOgDatoFelterFeil>;
     kanEndreType: boolean;
-    kanEndreTypeAktivitet?: boolean;
+    kanEndreTiltaksvariant?: boolean;
     erStøttetType?: boolean;
 }
 
@@ -40,12 +40,12 @@ export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
     form,
     oppdaterTypeIForm,
     oppdaterPeriode,
-    oppdaterTypeAktivitet,
+    oppdaterTiltaksvariant,
     typeOptions,
-    typeAktivitetOptions,
+    tiltaksvariantOptions,
     formFeil,
     kanEndreType,
-    kanEndreTypeAktivitet,
+    kanEndreTiltaksvariant,
     erStøttetType = true,
 }: Props<T>) => {
     const { keyDato: fomKeyDato, oppdaterDatoKey: oppdaterFomDatoKey } =
@@ -73,17 +73,17 @@ export const EndreTypeOgDatoer = <T extends MålgruppeEllerAktivitet>({
                     error={formFeil?.type}
                 />
             </FeilmeldingMaksBredde>
-            {typeAktivitetOptions && oppdaterTypeAktivitet && (
+            {tiltaksvariantOptions && oppdaterTiltaksvariant && (
                 <FeilmeldingMaksBredde>
                     <SelectMedOptions
                         className={styles.wideBoi}
                         label={'Variant'}
-                        readOnly={!kanEndreTypeAktivitet}
-                        value={form.typeAktivitet?.kode}
-                        valg={typeAktivitetOptions}
-                        onChange={(e) => oppdaterTypeAktivitet(e.target.value)}
+                        readOnly={!kanEndreTiltaksvariant}
+                        value={form.tiltaksvariant?.kode}
+                        valg={tiltaksvariantOptions}
+                        onChange={(e) => oppdaterTiltaksvariant(e.target.value)}
                         size="small"
-                        error={formFeil?.typeAktivitet}
+                        error={formFeil?.tiltaksvariant}
                     />
                 </FeilmeldingMaksBredde>
             )}

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr.ts
@@ -3,7 +3,7 @@ import { Kodeverk } from '../../../../../typer/kodeverk';
 
 export interface AktivitetDagligReiseTsr extends VilkårPeriodeAktivitet {
     kildeId?: string;
-    typeAktivitet?: Kodeverk;
+    tiltaksvariant?: Kodeverk;
     faktaOgVurderinger: AktivitetDagligReiseTsrFaktaOgVurderinger;
 }
 

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaDagligReise.tsx
@@ -37,15 +37,15 @@ export const EndreFaktaDagligReise: React.FC<{
     reiseTom,
     gjelderTsr,
 }) => {
-    const typeAktiviteter = oppfylteAktiviteter
+    const tiltaksvarianter = oppfylteAktiviteter
         .filter(
             (aktivitet): aktivitet is AktivitetDagligReiseTsr =>
                 aktivitet.faktaOgVurderinger['@type'] === 'AKTIVITET_DAGLIG_REISE_TSR'
         )
-        .map((aktivitet) => aktivitet.typeAktivitet)
-        .filter((typeAktivitet) => typeAktivitet != null);
+        .map((aktivitet) => aktivitet.tiltaksvariant)
+        .filter((tiltaksvariant) => tiltaksvariant != null);
 
-    const tilgjengeligeTypeAktiviteter = Array.from(new Set(typeAktiviteter)).sort((a, b) =>
+    const tilgjengeligeTiltaksvarianter = Array.from(new Set(tiltaksvarianter)).sort((a, b) =>
         a.kode.localeCompare(b.kode)
     );
 
@@ -58,7 +58,7 @@ export const EndreFaktaDagligReise: React.FC<{
                     settFakta={settFakta}
                     feilmeldinger={feilmeldinger.fakta as FeilmeldingerFaktaOffentligTransport}
                     gjelderTsr={gjelderTsr}
-                    tilgjengeligeTypeAktiviteter={tilgjengeligeTypeAktiviteter}
+                    tilgjengeligeTiltaksvarianter={tilgjengeligeTiltaksvarianter}
                 />
             );
         case 'DAGLIG_REISE_PRIVAT_BIL':

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaOffentligTransport.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaOffentligTransport.tsx
@@ -17,7 +17,7 @@ interface Props {
     settFakta: React.Dispatch<React.SetStateAction<FaktaDagligReise>>;
     nullstillFeilOgUlagretkomponent: () => void;
     gjelderTsr: boolean;
-    tilgjengeligeTypeAktiviteter: Kodeverk[];
+    tilgjengeligeTiltaksvarianter: Kodeverk[];
 }
 
 export const EndreFaktaOffentligTransport: React.FC<Props> = ({
@@ -26,7 +26,7 @@ export const EndreFaktaOffentligTransport: React.FC<Props> = ({
     nullstillFeilOgUlagretkomponent,
     feilmeldinger,
     gjelderTsr,
-    tilgjengeligeTypeAktiviteter,
+    tilgjengeligeTiltaksvarianter,
 }) => {
     const oppdaterFakta = (key: keyof FaktaOffentligTransport, verdi: number | undefined) => {
         settFakta((prevState) => ({
@@ -37,10 +37,10 @@ export const EndreFaktaOffentligTransport: React.FC<Props> = ({
         nullstillFeilOgUlagretkomponent();
     };
 
-    const oppdaterTypeAktivitet = (kode: string) => {
+    const oppdaterTiltaksvariant = (kode: string) => {
         settFakta((prevState) => ({
             ...(prevState.type === 'OFFENTLIG_TRANSPORT' ? prevState : tomtOffentligTransport),
-            typeAktivitet: kode || undefined,
+            tiltaksvariant: kode || undefined,
         }));
 
         nullstillFeilOgUlagretkomponent();
@@ -65,11 +65,11 @@ export const EndreFaktaOffentligTransport: React.FC<Props> = ({
                             size="small"
                             className={styles.wideSelect}
                             error={feilmeldinger?.aktivitet}
-                            value={fakta.typeAktivitet || ''}
-                            onChange={(e) => oppdaterTypeAktivitet(e.target.value)}
+                            value={fakta.tiltaksvariant || ''}
+                            onChange={(e) => oppdaterTiltaksvariant(e.target.value)}
                         >
                             <option value="">Velg aktivitet</option>
-                            {tilgjengeligeTypeAktiviteter.map((valg) => (
+                            {tilgjengeligeTiltaksvarianter.map((valg) => (
                                 <option key={valg.kode} value={valg.kode}>
                                     {valg.beskrivelse}
                                 </option>

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/utils.ts
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/utils.ts
@@ -114,7 +114,7 @@ export const tomtOffentligTransport: FaktaOffentligTransport = {
     prisEnkelbillett: undefined,
     prisSyvdagersbillett: undefined,
     prisTrettidagersbillett: undefined,
-    typeAktivitet: undefined,
+    tiltaksvariant: undefined,
 };
 
 export const defaultPrivatBilPeriode = {

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/validering.ts
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/validering.ts
@@ -110,7 +110,7 @@ const validerFaktaOffentligTransport = (
         return { felles: 'Mangler reisedager per uke og minst én billettpris' };
     }
 
-    if (gjelderTsr && !fakta.typeAktivitet) {
+    if (gjelderTsr && !fakta.tiltaksvariant) {
         return { aktivitet: 'Du må velge en tiltaksvariant' };
     }
 

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/typer/faktaDagligReise.ts
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/typer/faktaDagligReise.ts
@@ -11,7 +11,7 @@ export interface FaktaOffentligTransport extends FaktaDagligReise {
     prisEnkelbillett: number | undefined;
     prisSyvdagersbillett: number | undefined;
     prisTrettidagersbillett: number | undefined;
-    typeAktivitet?: string;
+    tiltaksvariant?: string;
 }
 
 export interface FaktaDelperiodePrivatBil {

--- a/src/frontend/hooks/useHentTiltaksvariantValg.ts
+++ b/src/frontend/hooks/useHentTiltaksvariantValg.ts
@@ -5,24 +5,24 @@ import { Kodeverk } from '../typer/kodeverk';
 import { byggHenterRessurs, byggTomRessurs, Ressurs } from '../typer/ressurs';
 
 interface Response {
-    typeAktivitetValg: Ressurs<Kodeverk[]>;
+    tiltaksvariantValg: Ressurs<Kodeverk[]>;
 }
 
-export const useHentTypeAktivitetValg = (): Response => {
+export const useHentTiltaksvariantValg = (): Response => {
     const { request } = useApp();
 
-    const [typeAktivitetValg, settTypeAktivitetValg] =
+    const [tiltaksvariantValg, settTiltaksvariantValg] =
         useState<Ressurs<Kodeverk[]>>(byggTomRessurs());
 
     useEffect(() => {
-        settTypeAktivitetValg(byggHenterRessurs());
+        settTiltaksvariantValg(byggHenterRessurs());
 
-        request<Kodeverk[], null>(`/api/sak/vilkarperiode/aktivitet/type-aktivitet`).then(
-            settTypeAktivitetValg
+        request<Kodeverk[], null>(`/api/sak/vilkarperiode/aktivitet/tiltaksvarianter`).then(
+            settTiltaksvariantValg
         );
     }, [request]);
 
     return {
-        typeAktivitetValg,
+        tiltaksvariantValg,
     };
 };

--- a/src/frontend/hooks/useLagreVilkårperiode.ts
+++ b/src/frontend/hooks/useLagreVilkårperiode.ts
@@ -22,7 +22,7 @@ import { Periode } from '../utils/periode';
 export interface LagreVilkårperiode extends Periode {
     behandlingId: string;
     type: AktivitetType | MålgruppeType | '';
-    typeAktivitet: string | undefined;
+    tiltaksvariant: string | undefined;
     faktaOgSvar: FaktaOgSvar;
     begrunnelse?: string;
     kildeId?: string;
@@ -86,7 +86,7 @@ export const useLagreVilkårperiode = () => {
         tom: form.tom,
         behandlingId: behandlingId,
         type: form.type,
-        typeAktivitet: 'typeAktivitet' in form ? form.typeAktivitet?.kode : undefined,
+        tiltaksvariant: 'tiltaksvariant' in form ? form.tiltaksvariant?.kode : undefined,
         faktaOgSvar: faktaOgSvar,
         begrunnelse: form.begrunnelse,
         kildeId: 'kildeId' in form ? form.kildeId : undefined,


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Har lenge vært forvirrende å ha aktivitetType og typeAktivitet på vilkårsperioder.

Omdøper feltet fra 'typeAktivitet' til 'tiltaksvariant' i:

- Vilkårperiode-typer og aktivitet-komponenter (TSR)
- OT vilkår-fakta typer og EndreFaktaOffentligTransport
- useLagreVilkårperiode hook
- Relaterte utils og valideringsfiler

Backend: https://github.com/navikt/tilleggsstonader-sak/pull/1234