### PR TITLE
✨ Legg til ny status 'GAMMEL_MANGLER_DATA' og oppdater valideringslog…

### DIFF
--- a/src/frontend/Sider/Klage/Steg/Formkrav/typer.ts
+++ b/src/frontend/Sider/Klage/Steg/Formkrav/typer.ts
@@ -5,6 +5,7 @@ export enum VilkårStatus {
     OPPFYLT = 'OPPFYLT',
     IKKE_OPPFYLT = 'IKKE_OPPFYLT',
     IKKE_SATT = 'IKKE_SATT',
+    GAMMEL_MANGLER_DATA = 'GAMMEL_MANGLER_DATA',
 }
 
 export enum FormkravFristUnntak {
@@ -25,6 +26,7 @@ export const vilkårStatusTilTekst: Record<VilkårStatus, string> = {
     OPPFYLT: 'Oppfylt',
     IKKE_OPPFYLT: 'Ikke oppfylt',
     IKKE_SATT: 'Ikke satt',
+    GAMMEL_MANGLER_DATA: 'Gammel - mangler data',
 };
 
 export interface IFormalkrav {

--- a/src/frontend/Sider/Klage/Steg/Formkrav/validerFormkravUtils.ts
+++ b/src/frontend/Sider/Klage/Steg/Formkrav/validerFormkravUtils.ts
@@ -3,6 +3,9 @@ import { utledRadioKnapper } from './utils';
 import { harVerdi } from '../../../../utils/utils';
 import { PåklagetVedtakstype } from '../../typer/klagebehandling/påklagetVedtakstype';
 
+const erOppfyltEllerGammel = (status: VilkårStatus) =>
+    status === VilkårStatus.OPPFYLT || status === VilkårStatus.GAMMEL_MANGLER_DATA;
+
 export const alleVurderingerErStatus = (
     formkravVurdering: IFormkravVilkår,
     status: VilkårStatus
@@ -24,8 +27,14 @@ export const påKlagetVedtakValgt = (vurderinger: IFormkravVilkår) => {
 };
 
 export const alleVilkårOppfylt = (vurderinger: IFormkravVilkår) => {
+    const { klagePart, klagersRettsligInteresse, klageKonkret, klagefristOverholdt, klageSignert } =
+        vurderinger;
     return (
-        alleVurderingerErStatus(vurderinger, VilkårStatus.OPPFYLT) ||
+        (erOppfyltEllerGammel(klagePart) &&
+            erOppfyltEllerGammel(klagersRettsligInteresse) &&
+            erOppfyltEllerGammel(klageKonkret) &&
+            erOppfyltEllerGammel(klageSignert) &&
+            erOppfyltEllerGammel(klagefristOverholdt)) ||
         (alleVurderingerOppfyltUntattKlagefrist(vurderinger) &&
             klagefristUnntakErValgtOgOppfylt(vurderinger.klagefristOverholdtUnntak))
     );
@@ -35,10 +44,10 @@ export const alleVurderingerOppfyltUntattKlagefrist = (formkrav: IFormkravVilkå
     const { klagePart, klagersRettsligInteresse, klageKonkret, klagefristOverholdt, klageSignert } =
         formkrav;
     return (
-        klagePart === VilkårStatus.OPPFYLT &&
-        klagersRettsligInteresse === VilkårStatus.OPPFYLT &&
-        klageKonkret === VilkårStatus.OPPFYLT &&
-        klageSignert === VilkårStatus.OPPFYLT &&
+        erOppfyltEllerGammel(klagePart) &&
+        erOppfyltEllerGammel(klagersRettsligInteresse) &&
+        erOppfyltEllerGammel(klageKonkret) &&
+        erOppfyltEllerGammel(klageSignert) &&
         klagefristOverholdt === VilkårStatus.IKKE_OPPFYLT
     );
 };


### PR DESCRIPTION
…ikk for kravvurderinger

### Hvorfor er denne endringen nødvendig? ✨

legge til GAMMEL_MANGLER_DATA som blir satt på alle gamle klager før klagers rettslig interesse ble lagt til så man kan gå inn på lesevisning på gamle ferdige klagebehandlinger