### PR TITLE
Legger til støtte for visning av bompenger på rute

### DIFF
--- a/src/frontend/Sider/Reiseavstand/Reiseavstand.tsx
+++ b/src/frontend/Sider/Reiseavstand/Reiseavstand.tsx
@@ -34,6 +34,10 @@ export const Reiseavstand: React.FC<{ reisedata: Reisedata }> = ({ reisedata }) 
                     <BodyShort>Ingen ferje</BodyShort>
                 )}
             </VStack>
+            <VStack className={styles.kort}>
+                <Label>Bompenger</Label>
+                <BodyShort>{reisedata.reiserute.harBomvei ? 'Ja' : 'Nei'}</BodyShort>
+            </VStack>
         </HGrid>
     );
 };

--- a/src/frontend/Sider/Reiseavstand/Typer/Reisedata.ts
+++ b/src/frontend/Sider/Reiseavstand/Typer/Reisedata.ts
@@ -12,6 +12,7 @@ export interface Reiserute {
     sluttLokasjon: Lokasjon;
     startAdresse: string;
     sluttAdresse: string;
+    harBomvei: boolean;
 }
 
 export interface Strekninger {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Viser frem om `reiserute.harBomvei ? 'Ja' : 'Nei'`

<img width="1628" height="951" alt="Screenshot 2026-06-08 at 13 52 24" src="https://github.com/user-attachments/assets/3906f744-ffac-49dc-aefc-e3e1e3c4745e" />
