### PR TITLE
✨Legg til tag som viser status på avklarte dager ved en revudrering

### DIFF
--- a/src/frontend/Sider/Behandling/Kjøreliste/KjørelisteFane.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/KjørelisteFane.tsx
@@ -3,22 +3,25 @@ import React, { FC } from 'react';
 import { VStack } from '@navikt/ds-react';
 
 import { ReiseKort } from './ReiseKort';
+import { KjørelisteProvider } from '../../../context/KjørelisteContext';
 import { useReisevurderingPrivatBil } from '../../../hooks/useReisevurderingPrivatBil';
 import { useVedtak } from '../../../hooks/useVedtak';
 import DataViewer from '../../../komponenter/DataViewer';
 import { StegKnapp } from '../../../komponenter/Stegflyt/StegKnapp';
 import { Steg } from '../../../typer/behandling/steg';
 import { ReisevurderingPrivatBil } from '../../../typer/kjøreliste';
-import { InnvilgelseDagligReise } from '../../../typer/vedtak/vedtakDagligReise';
+import { VedtakDagligReise } from '../../../typer/vedtak/vedtakDagligReise';
 
 export const KjørelisteFane: FC = () => {
-    const { vedtak } = useVedtak<InnvilgelseDagligReise>();
+    const { vedtak } = useVedtak<VedtakDagligReise>();
     const { reisevurderingerResponse } = useReisevurderingPrivatBil();
 
     return (
         <DataViewer response={{ vedtak, reisevurderingerResponse }} type={'reisedata'}>
-            {({ reisevurderingerResponse }) => (
-                <FaneInnhold reisevurderingerResponse={reisevurderingerResponse} />
+            {({ vedtak, reisevurderingerResponse }) => (
+                <KjørelisteProvider vedtak={vedtak}>
+                    <FaneInnhold reisevurderingerResponse={reisevurderingerResponse} />
+                </KjørelisteProvider>
             )}
         </DataViewer>
     );

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/AvklartDagLesevisning.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/AvklartDagLesevisning.tsx
@@ -11,24 +11,21 @@ export const AvklartDagLesevisning: FC<{
     avklartDag: AvklartDag | undefined;
 }> = ({ avklartDag }) => {
     const erSlettet = avklartDag?.avklartKjørtDagStatus === AvklartKjørtDagStatus.SLETTET;
-    const skalHaSlettetStyling = (harVerdi: boolean) =>
+    const finnClassname = (harVerdi: boolean) =>
         erSlettet && harVerdi ? styles.slettet : undefined;
 
     return (
         <div className={styles.høyreGrid}>
-            <HStack gap="space-4" className={skalHaSlettetStyling(avklartDag !== undefined)}>
+            <HStack gap="space-4" className={finnClassname(avklartDag !== undefined)}>
                 <BodyShort size="small">
                     {avklartDag &&
                         godkjentGjennomførtKjøringTilTekst[avklartDag.godkjentGjennomførtKjøring]}
                 </BodyShort>
             </HStack>
-            <BodyShort
-                size="small"
-                className={skalHaSlettetStyling(!!avklartDag?.parkeringsutgift)}
-            >
+            <BodyShort size="small" className={finnClassname(!!avklartDag?.parkeringsutgift)}>
                 {kronerEllerStrek(avklartDag?.parkeringsutgift)}
             </BodyShort>
-            <BodyShort size="small" className={skalHaSlettetStyling(!!avklartDag?.begrunnelse)}>
+            <BodyShort size="small" className={finnClassname(!!avklartDag?.begrunnelse)}>
                 {avklartDag?.begrunnelse || '-'}
             </BodyShort>
             <AvklartKjørtDagStatusTag avklartKjørtDagStatus={avklartDag?.avklartKjørtDagStatus} />

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/AvklartDagLesevisning.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/AvklartDagLesevisning.tsx
@@ -24,14 +24,11 @@ export const AvklartDagLesevisning: FC<{
             </HStack>
             <BodyShort
                 size="small"
-                className={skalHaSlettetStyling(avklartDag?.parkeringsutgift !== undefined)}
+                className={skalHaSlettetStyling(!!avklartDag?.parkeringsutgift)}
             >
                 {kronerEllerStrek(avklartDag?.parkeringsutgift)}
             </BodyShort>
-            <BodyShort
-                size="small"
-                className={skalHaSlettetStyling(avklartDag?.begrunnelse != undefined)}
-            >
+            <BodyShort size="small" className={skalHaSlettetStyling(!!avklartDag?.begrunnelse)}>
                 {avklartDag?.begrunnelse || '-'}
             </BodyShort>
             <AvklartKjørtDagStatusTag avklartKjørtDagStatus={avklartDag?.avklartKjørtDagStatus} />

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/AvklartDagLesevisning.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/AvklartDagLesevisning.tsx
@@ -1,8 +1,8 @@
 import React, { FC } from 'react';
 
-import { BodyShort, HStack } from '@navikt/ds-react';
+import { BodyShort, HStack, Tag } from '@navikt/ds-react';
 
-import { AvklartDag } from '../../../../../typer/kjøreliste';
+import { AvklartDag, AvklartKjørtDagStatus } from '../../../../../typer/kjøreliste';
 import { kronerEllerStrek } from '../../../../../utils/tekstformatering';
 import { godkjentGjennomførtKjøringTilTekst } from '../../utils';
 import styles from '../UkeInnhold.module.css';
@@ -10,16 +10,60 @@ import styles from '../UkeInnhold.module.css';
 export const AvklartDagLesevisning: FC<{
     avklartDag: AvklartDag | undefined;
 }> = ({ avklartDag }) => {
+    const erSlettet = avklartDag?.avklartKjørtDagStatus === AvklartKjørtDagStatus.SLETTET;
+    const skalHaSlettetStyling = (harVerdi: boolean) =>
+        erSlettet && harVerdi ? styles.slettet : undefined;
+
     return (
         <div className={styles.høyreGrid}>
-            <HStack gap="space-4">
+            <HStack gap="space-4" className={skalHaSlettetStyling(avklartDag !== undefined)}>
                 <BodyShort size="small">
                     {avklartDag &&
                         godkjentGjennomførtKjøringTilTekst[avklartDag.godkjentGjennomførtKjøring]}
                 </BodyShort>
             </HStack>
-            <BodyShort size="small">{kronerEllerStrek(avklartDag?.parkeringsutgift)}</BodyShort>
-            <BodyShort size="small">{avklartDag?.begrunnelse || '-'}</BodyShort>
+            <BodyShort
+                size="small"
+                className={skalHaSlettetStyling(avklartDag?.parkeringsutgift !== undefined)}
+            >
+                {kronerEllerStrek(avklartDag?.parkeringsutgift)}
+            </BodyShort>
+            <BodyShort
+                size="small"
+                className={skalHaSlettetStyling(avklartDag?.begrunnelse != undefined)}
+            >
+                {avklartDag?.begrunnelse || '-'}
+            </BodyShort>
+            <AvklartKjørtDagStatusTag avklartKjørtDagStatus={avklartDag?.avklartKjørtDagStatus} />
         </div>
     );
+};
+
+const AvklartKjørtDagStatusTag: FC<{
+    avklartKjørtDagStatus: AvklartKjørtDagStatus | undefined;
+}> = ({ avklartKjørtDagStatus }) => {
+    switch (avklartKjørtDagStatus) {
+        case AvklartKjørtDagStatus.NY:
+            return (
+                <Tag size="small" data-color="success">
+                    Ny
+                </Tag>
+            );
+        case AvklartKjørtDagStatus.ENDRET:
+            return (
+                <Tag size="small" data-color="warning">
+                    Endret
+                </Tag>
+            );
+        case AvklartKjørtDagStatus.UENDRET:
+            return <BodyShort size="small">Uendret</BodyShort>;
+        case AvklartKjørtDagStatus.SLETTET:
+            return (
+                <Tag size="small" data-color="danger">
+                    Slettet
+                </Tag>
+            );
+        default:
+            return null;
+    }
 };

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.module.css
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.module.css
@@ -47,7 +47,7 @@
 
 .høyre-grid {
     padding-right: 1rem;
-    grid-template-columns: var(--kolonne-5) var(--kolonne-6) var(--kolonne-7);
+    grid-template-columns: var(--kolonne-5) var(--kolonne-6) auto max-content;
 }
 
 .høyre-grid-redigering {
@@ -57,4 +57,8 @@
 
 .maks-høyde {
     max-height: 2rem;
+}
+
+.slettet {
+    text-decoration: line-through;
 }

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -3,6 +3,8 @@ import React, { FC, useState } from 'react';
 import { PencilIcon } from '@navikt/aksel-icons';
 import { Button, HStack, InlineMessage, Label, VStack } from '@navikt/ds-react';
 
+import { AvklartDagLesevisning } from './Dag/AvklartDagLesevisning';
+import { KjørelisteDagInfo } from './Dag/KjørelisteDagInfo';
 import { RedigerAvklartDag } from './Dag/RedigerAvklartDag';
 import styles from './UkeInnhold.module.css';
 import {
@@ -11,20 +13,27 @@ import {
 } from './valideringAvklarteDager';
 import { useApp } from '../../../../context/AppContext';
 import { useBehandling } from '../../../../context/BehandlingContext';
+import { useKjørelisteContext } from '../../../../context/KjørelisteContext';
 import { useSteg } from '../../../../context/StegContext';
 import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
-import { RedigerbarAvklartDag, UkeVurdering } from '../../../../typer/kjøreliste';
+import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
+import { Feil, feiletRessursTilFeilmelding } from '../../../../komponenter/Feil/feilmeldingUtils';
+import {
+    AvklartKjørtDagStatus,
+    AvklartKjørtUkeStatus,
+    RedigerbarAvklartDag,
+    UkeVurdering,
+} from '../../../../typer/kjøreliste';
 import { RessursStatus } from '../../../../typer/ressurs';
+import {
+    RammeForReiseMedPrivatBilDelperiode,
+    vedtakErOpphør,
+} from '../../../../typer/vedtak/vedtakDagligReise';
 import {
     mapTilRedigerbareAvklarteDager,
     tomRedigerbarAvklartDag,
     typeAvvikTilTekst,
 } from '../utils';
-import { AvklartDagLesevisning } from './Dag/AvklartDagLesevisning';
-import { KjørelisteDagInfo } from './Dag/KjørelisteDagInfo';
-import { Feilmelding } from '../../../../komponenter/Feil/Feilmelding';
-import { Feil, feiletRessursTilFeilmelding } from '../../../../komponenter/Feil/feilmeldingUtils';
-import { RammeForReiseMedPrivatBilDelperiode } from '../../../../typer/vedtak/vedtakDagligReise';
 
 export const UkeInnhold: FC<{
     uke: UkeVurdering;
@@ -34,6 +43,7 @@ export const UkeInnhold: FC<{
     const { request } = useApp();
     const { behandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
+    const { vedtak } = useKjørelisteContext();
 
     const [redigerer, settRedigerer] = React.useState(false);
     const [redigerbareDager, settRedigerbareDager] = useState<RedigerbarAvklartDag[]>([]);
@@ -71,10 +81,15 @@ export const UkeInnhold: FC<{
             return;
         }
 
+        const redigerbareDagerSomSkalLagre = redigerbareDager.filter((dag) => {
+            const originalDag = uke.dager.find((d) => d.dato === dag.dato);
+            return originalDag?.avklartDag?.avklartKjørtDagStatus !== AvklartKjørtDagStatus.SLETTET;
+        });
+
         request<UkeVurdering, RedigerbarAvklartDag[]>(
             `/api/sak/kjoreliste/${behandling.id}/${uke.avklartUkeId}`,
             'PUT',
-            redigerbareDager
+            redigerbareDagerSomSkalLagre
         ).then((res) => {
             if (res.status === RessursStatus.SUKSESS) {
                 oppdaterUke(res.data);
@@ -99,7 +114,12 @@ export const UkeInnhold: FC<{
     };
 
     // TODO: Må oppdateres når vi håndterer redigering uten at uke er innsendt
-    const kanRedigereUke = erStegRedigerbart && !!uke.kjørelisteInnsendtDato && !!uke.avklartUkeId;
+    const kanRedigereUke =
+        erStegRedigerbart &&
+        !!uke.kjørelisteInnsendtDato &&
+        !!uke.avklartUkeId &&
+        uke.avklartKjørtUkeStatus !== AvklartKjørtUkeStatus.SLETTET &&
+        !vedtakErOpphør(vedtak);
 
     return (
         <VStack gap="space-16">

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -81,7 +81,7 @@ export const UkeInnhold: FC<{
             return;
         }
 
-        const redigerbareDagerSomSkalLagre = redigerbareDager.filter((dag) => {
+        const redigerbareDagerSomSkalLagres = redigerbareDager.filter((dag) => {
             const originalDag = uke.dager.find((d) => d.dato === dag.dato);
             return originalDag?.avklartDag?.avklartKjørtDagStatus !== AvklartKjørtDagStatus.SLETTET;
         });
@@ -89,7 +89,7 @@ export const UkeInnhold: FC<{
         request<UkeVurdering, RedigerbarAvklartDag[]>(
             `/api/sak/kjoreliste/${behandling.id}/${uke.avklartUkeId}`,
             'PUT',
-            redigerbareDagerSomSkalLagre
+            redigerbareDagerSomSkalLagres
         ).then((res) => {
             if (res.status === RessursStatus.SUKSESS) {
                 oppdaterUke(res.data);

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -118,6 +118,7 @@ export const UkeInnhold: FC<{
                         <Label size="small">Status</Label>
                         <Label size="small">Godkjent Park. (Kr)</Label>
                         <Label size="small">Begrunnelse</Label>
+                        {!redigerer && <div />}
                     </div>
                 </div>
                 <div className={styles.wrapper}>

--- a/src/frontend/context/KjørelisteContext.ts
+++ b/src/frontend/context/KjørelisteContext.ts
@@ -1,0 +1,11 @@
+import constate from 'constate';
+
+import { VedtakDagligReise } from '../typer/vedtak/vedtakDagligReise';
+
+interface KjørelisteContextType {
+    vedtak: VedtakDagligReise;
+}
+
+export const [KjørelisteProvider, useKjørelisteContext] = constate(
+    ({ vedtak }: KjørelisteContextType) => ({ vedtak })
+);

--- a/src/frontend/typer/kjøreliste.ts
+++ b/src/frontend/typer/kjøreliste.ts
@@ -43,6 +43,7 @@ export interface AvklartDag {
     godkjentGjennomførtKjøring: GodkjentGjennomførtKjøring;
     begrunnelse?: string; // må fylles ut om avvik?
     parkeringsutgift?: number;
+    avklartKjørtDagStatus?: AvklartKjørtDagStatus;
 }
 
 export enum GodkjentGjennomførtKjøring {
@@ -62,6 +63,13 @@ export enum AvklartKjørtUkeStatus {
     NY = 'NY', // Uke finnes ikke i forrige behandling
     ENDRET = 'ENDRET', // Uke finnes i forrige behandling, men er endret av saksbehandler (inkl. tømt innhold → gir 0 kr)
     UENDRET = 'UENDRET', // Uke er kopiert uendret fra forrige behandling
+    SLETTET = 'SLETTET',
+}
+
+export enum AvklartKjørtDagStatus {
+    NY = 'NY',
+    ENDRET = 'ENDRET',
+    UENDRET = 'UENDRET',
     SLETTET = 'SLETTET',
 }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
For at det skal bli enklere å se status på en dag ved revudering og opphør vises en tag med status på dagen. Ved sletting settes det en strek gjennom dataen SB har lagt inn.

Fjerner også muligheten til å redigere kjørelisteuker hvis for opphør.

<img width="1438" height="970" alt="image" src="https://github.com/user-attachments/assets/148cb90d-6995-4820-85cd-6541e870acdb" />
