### PR TITLE
Støtt overskridelse av reisedager i kjørelistevalidering

### DIFF
--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -1,5 +1,7 @@
 import React, { FC, useState } from 'react';
 
+import { useFlag } from '@unleash/proxy-client-react';
+
 import { PencilIcon } from '@navikt/aksel-icons';
 import { Button, HStack, InlineMessage, Label, VStack } from '@navikt/ds-react';
 
@@ -29,6 +31,7 @@ import {
     RammeForReiseMedPrivatBilDelperiode,
     vedtakErOpphør,
 } from '../../../../typer/vedtak/vedtakDagligReise';
+import { Toggle } from '../../../../utils/toggles';
 import {
     mapTilRedigerbareAvklarteDager,
     tomRedigerbarAvklartDag,
@@ -44,6 +47,9 @@ export const UkeInnhold: FC<{
     const { behandling } = useBehandling();
     const { erStegRedigerbart } = useSteg();
     const { vedtak } = useKjørelisteContext();
+    const kanOverskrideAntallDagerIRammevedtak = useFlag(
+        Toggle.KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK
+    );
 
     const [redigerer, settRedigerer] = React.useState(false);
     const [redigerbareDager, settRedigerbareDager] = useState<RedigerbarAvklartDag[]>([]);
@@ -65,7 +71,11 @@ export const UkeInnhold: FC<{
         settValideringsfeilForDager(feil);
 
         const erAntallGodkjenteDagerInnenforRammevedtak =
-            validerAntallReisedagerInnenforRammevedtak(redigerbareDager, delperiodeForUke);
+            validerAntallReisedagerInnenforRammevedtak(
+                redigerbareDager,
+                delperiodeForUke,
+                kanOverskrideAntallDagerIRammevedtak
+            );
 
         settValideringsfeilForUke(
             erAntallGodkjenteDagerInnenforRammevedtak

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/valideringAvklarteDager.ts
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/valideringAvklarteDager.ts
@@ -61,8 +61,13 @@ export const validerAvklarteDager = (
 
 export const validerAntallReisedagerInnenforRammevedtak = (
     avklarteDager: RedigerbarAvklartDag[],
-    delperiodeForUke: RammeForReiseMedPrivatBilDelperiode
+    delperiodeForUke: RammeForReiseMedPrivatBilDelperiode,
+    tillatOverskridelseRammevedtak: boolean = false
 ): boolean => {
+    if (tillatOverskridelseRammevedtak) {
+        return true;
+    }
+
     const antallDagerMedKjøring = avklarteDager.filter(
         (dag) => dag.godkjentGjennomførtKjøring === GodkjentGjennomførtKjøring.JA
     ).length;

--- a/src/frontend/utils/toggles.ts
+++ b/src/frontend/utils/toggles.ts
@@ -23,6 +23,7 @@ export enum Toggle {
      */
     BRUK_DYNAMISK_KART = 'sak.frontend.bruk-dynamisk-kart',
     KAN_BEHANDLE_PRIVAT_BIL = 'sak.daglig-reise-privat-bil',
+    KAN_OVERSKRIDE_ANTALL_DAGER_I_RAMMEVEDTAK = 'sak.kan-overskride-antall-dager-i-rammevedtak',
     KAN_OPPHØRE_DAGLIG_REISE_TSO = 'sak.frontend.kan-oppheve-daglig-reise-tso',
     KAN_OPPRETTE_MANUELL_KJØRELISTEBEHANDLING = 'sak.frontend.kan-opprette-manuell-kjorelistebehandling',
     KAN_BEHANDLE_REISE_TIL_SAMLING = 'sak.reise-til-samling-tso',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Kobler frontend-validering til toggle sak.kan-overskride-antall-dager-i-rammevedtak, slik at uke kan lagres med flere godkjente dager enn rammevedtaket når togglen er aktiv.

Backend:
https://github.com/navikt/tilleggsstonader-sak/pull/1272