### PR TITLE
🐛 Tillat desimaltall for bompenger og fergjekostnader.

### DIFF
--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaPrivatBil.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaPrivatBil.tsx
@@ -231,7 +231,7 @@ export const EndreFaktaPrivatBil: React.FC<Props> = ({
                                         oppdaterPeriode(
                                             index,
                                             'bompengerPerDag',
-                                            tilHeltall(fjernSpaces(e.target.value))
+                                            tilTallverdi(fjernSpaces(e.target.value))
                                         );
                                     }}
                                 />
@@ -250,7 +250,7 @@ export const EndreFaktaPrivatBil: React.FC<Props> = ({
                                         oppdaterPeriode(
                                             index,
                                             'fergekostnadPerDag',
-                                            tilHeltall(fjernSpaces(e.target.value))
+                                            tilTallverdi(fjernSpaces(e.target.value))
                                         );
                                     }}
                                 />

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/innvilgeVedtak/Beregningsresultat/Rammevedtak.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/innvilgeVedtak/Beregningsresultat/Rammevedtak.tsx
@@ -15,6 +15,7 @@ import {
     RammevedtakPrivatBil,
 } from '../../../../../../typer/vedtak/vedtakDagligReise';
 import { formaterIsoDato } from '../../../../../../utils/dato';
+import { formaterTallMedTusenSkille } from '../../../../../../utils/fomatering';
 
 // Hjelpefunksjon for å flate ut delperioder og satser til visningsrader
 interface VisningsradPrivatBil {
@@ -118,16 +119,18 @@ export const BeregningsresultatRammevedtakPrivatBil: FC<Props> = ({ rammevedtak 
                                                 {rad.reisedagerPerUke}
                                             </TableDataCellSmall>
                                             <TableDataCellSmall>
-                                                {rad.kilometersats}
+                                                {formaterTallMedTusenSkille(rad.kilometersats)}
                                             </TableDataCellSmall>
                                             <TableDataCellSmall>
-                                                {rad.dagsatsUtenParkering}
+                                                {formaterTallMedTusenSkille(
+                                                    rad.dagsatsUtenParkering
+                                                )}
                                             </TableDataCellSmall>
                                             <TableDataCellSmall>
-                                                {rad.bompengerPerDag}
+                                                {formaterTallMedTusenSkille(rad.bompengerPerDag)}
                                             </TableDataCellSmall>
                                             <TableDataCellSmall>
-                                                {rad.fergekostnadPerDag}
+                                                {formaterTallMedTusenSkille(rad.fergekostnadPerDag)}
                                             </TableDataCellSmall>
                                         </Table.Row>
                                     ))}

--- a/src/frontend/komponenter/Brev/vedtakstabell/rammevedtak/lagRammevedtakstabellMedDelperioder.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/rammevedtak/lagRammevedtakstabellMedDelperioder.ts
@@ -1,9 +1,10 @@
-import { formaterKrVerdi } from './rammevedtakstabellUtils';
+import { formaterKrVerdiVedBekreftetSats } from './rammevedtakstabellUtils';
 import {
     RammeForReiseMedPrivatBil,
     RammeForReiseMedPrivatBilDelperiode,
 } from '../../../../typer/vedtak/vedtakDagligReise';
 import { formaterIsoPeriodeMedTankestrek } from '../../../../utils/dato';
+import { formaterTallMedTusenSkille } from '../../../../utils/fomatering';
 
 export function lagRammevedtakstabellMedDelperioder(reise: RammeForReiseMedPrivatBil): string {
     return `
@@ -72,12 +73,15 @@ function lagRadData(delperiode: RammeForReiseMedPrivatBilDelperiode) {
     return delperiode.satser.map((sats) => ({
         periode: formaterIsoPeriodeMedTankestrek({ fom: sats.fom, tom: sats.tom }),
         reisedagerPerUke: delperiode.reisedagerPerUke,
-        kilometersats: formaterKrVerdi(sats.kilometersats, sats.satsBekreftetVedVedtakstidspunkt),
-        dagsatsUtenParkering: formaterKrVerdi(
+        kilometersats: formaterKrVerdiVedBekreftetSats(
+            sats.kilometersats,
+            sats.satsBekreftetVedVedtakstidspunkt
+        ),
+        dagsatsUtenParkering: formaterKrVerdiVedBekreftetSats(
             sats.dagsatsUtenParkering,
             sats.satsBekreftetVedVedtakstidspunkt
         ),
-        bompengerPerDag: delperiode.bompengerPerDag,
-        fergekostnadPerDag: delperiode.fergekostnadPerDag,
+        bompengerPerDag: formaterTallMedTusenSkille(delperiode.bompengerPerDag),
+        fergekostnadPerDag: formaterTallMedTusenSkille(delperiode.fergekostnadPerDag),
     }));
 }

--- a/src/frontend/komponenter/Brev/vedtakstabell/rammevedtak/lagRammevedtakstabellUtenDelperioder.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/rammevedtak/lagRammevedtakstabellUtenDelperioder.ts
@@ -1,6 +1,7 @@
-import { formaterKrVerdi } from './rammevedtakstabellUtils';
+import { formaterKrVerdiVedBekreftetSats } from './rammevedtakstabellUtils';
 import { RammeForReiseMedPrivatBil } from '../../../../typer/vedtak/vedtakDagligReise';
 import { formaterIsoPeriodeMedTankestrek } from '../../../../utils/dato';
+import { formaterTallMedTusenSkille } from '../../../../utils/fomatering';
 
 export function lagRammevedtakstabellUtenDelperioder(reise: RammeForReiseMedPrivatBil): string {
     const rader = lagRadData(reise);
@@ -49,15 +50,15 @@ function lagRadData(reise: RammeForReiseMedPrivatBil) {
                 fom: sats.fom,
                 tom: sats.tom,
             }),
-            reiseavstand: reise.reiseavstandEnVei,
+            reiseavstand: formaterTallMedTusenSkille(reise.reiseavstandEnVei),
             reisedagerPerUke: delperiode.reisedagerPerUke,
-            kilometersats: formaterKrVerdi(
+            kilometersats: formaterKrVerdiVedBekreftetSats(
                 sats.kilometersats,
                 sats.satsBekreftetVedVedtakstidspunkt
             ),
-            bompengerPerDag: delperiode.bompengerPerDag,
-            fergekostnadPerDag: delperiode.fergekostnadPerDag,
-            dagsatsUtenParkering: formaterKrVerdi(
+            bompengerPerDag: formaterTallMedTusenSkille(delperiode.bompengerPerDag),
+            fergekostnadPerDag: formaterTallMedTusenSkille(delperiode.fergekostnadPerDag),
+            dagsatsUtenParkering: formaterKrVerdiVedBekreftetSats(
                 sats.dagsatsUtenParkering,
                 sats.satsBekreftetVedVedtakstidspunkt
             ),

--- a/src/frontend/komponenter/Brev/vedtakstabell/rammevedtak/rammevedtakstabellUtils.ts
+++ b/src/frontend/komponenter/Brev/vedtakstabell/rammevedtak/rammevedtakstabellUtils.ts
@@ -1,3 +1,7 @@
-export function formaterKrVerdi(verdi: string | number, bekreftet: boolean): string {
-    return bekreftet ? `${verdi} kr` : `${verdi} kr*`;
+import { formaterTallMedTusenSkille } from '../../../../utils/fomatering';
+
+export function formaterKrVerdiVedBekreftetSats(verdi: number, bekreftet: boolean): string {
+    return bekreftet
+        ? `${formaterTallMedTusenSkille(verdi)} kr`
+        : `${formaterTallMedTusenSkille(verdi)} kr*`;
 }

--- a/src/frontend/utils/fomatering.ts
+++ b/src/frontend/utils/fomatering.ts
@@ -2,8 +2,14 @@ import { harTallverdi } from './tall';
 
 export const TANKESTREKK = `–`;
 
-export const tallMedTusenSkille = (verdi?: number): string | undefined =>
-    harTallverdi(verdi) ? Number(verdi).toLocaleString('no-NO', { currency: 'NOK' }) : undefined;
+export const tallMedTusenSkille = (verdi?: number): string | undefined => {
+    if (!harTallverdi(verdi)) return undefined;
+    const erDesimaltall = !Number.isInteger(verdi);
+    return Number(verdi).toLocaleString('no-NO', {
+        currency: 'NOK',
+        ...(erDesimaltall && { minimumFractionDigits: 2 }),
+    });
+};
 
 export const formaterTallMedTusenSkille = (verdi?: number): string =>
     tallMedTusenSkille(verdi) || '';


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Nå tillater vi kun heltal som bompenger og fergekostander. Dette har ført til en feil saksbehandler tror hen har skrevet inn desimaltall, men så ble ikke komma med og tallet med mye større en saksbehandler hadde forventet. Denne endringen gjør om bompenger og ferge kan være desimaltall.