### PR TITLE
Hindre revurdering hvis kjorelistebehandling pa vent

### DIFF
--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -13,6 +13,7 @@ import {
     isFanePath,
     stegTilFaneForBehandling,
 } from './faner';
+import { KjørelisteBehandlingPåVentAlert } from './Felles/KjørelisteBehandlingPåVentAlert';
 import { TidligereVedtaksperioder } from './Vilkårvurdering/TidligereVedtaksperioder';
 import { useApp } from '../../context/AppContext';
 import { useBehandling } from '../../context/BehandlingContext';
@@ -21,13 +22,18 @@ import { useNavigateUtenSjekkForUlagredeKomponenter } from '../../hooks/useNavig
 import DataViewer from '../../komponenter/DataViewer';
 import { SettPåVentSak } from '../../komponenter/SettPåVent/SettPåVentContainer';
 import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
+import { Stønadstype } from '../../typer/behandling/behandlingTema';
+import { BehandlingType } from '../../typer/behandling/behandlingType';
 import { RessursStatus } from '../../typer/ressurs';
 import { Toast } from '../../typer/toast';
+
+const erDagligReise = (stønadstype: Stønadstype) =>
+    stønadstype === Stønadstype.DAGLIG_REISE_TSO || stønadstype === Stønadstype.DAGLIG_REISE_TSR;
 
 const BehandlingTabsInnhold = () => {
     const navigate = useNavigate();
     const navigateUtenSjekk = useNavigateUtenSjekkForUlagredeKomponenter();
-    const { settToast } = useApp();
+    const { settToast, request } = useApp();
     const {
         behandling,
         behandlingFakta,
@@ -40,6 +46,7 @@ const BehandlingTabsInnhold = () => {
 
     const path = useLocation().pathname.split('/')[3];
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
+    const [harKjørelisteBehandlingPåVent, settHarKjørelisteBehandlingPåVent] = useState(false);
 
     const harRammevedtak =
         rammevedtakRessurs.status === RessursStatus.SUKSESS &&
@@ -61,6 +68,21 @@ const BehandlingTabsInnhold = () => {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [behandling.steg, harRammevedtak]);
+
+    useEffect(() => {
+        if (
+            behandling.type === BehandlingType.REVURDERING &&
+            erDagligReise(behandling.stønadstype)
+        ) {
+            request<boolean, null>(`/api/sak/behandling/${behandling.id}/kjoreliste-pa-vent`).then(
+                (res) => {
+                    if (res.status === 'SUKSESS') {
+                        settHarKjørelisteBehandlingPåVent(res.data);
+                    }
+                }
+            );
+        }
+    }, [behandling.id, behandling.type, behandling.stønadstype, request]);
 
     const håndterFaneBytte = (nyFane: FanePath) => {
         if (!faneErLåst(behandling, nyFane)) {
@@ -120,6 +142,7 @@ const BehandlingTabsInnhold = () => {
                                 Mulighet for å saksbehandle er skrudd av
                             </Alert>
                         )}
+                        {harKjørelisteBehandlingPåVent && <KjørelisteBehandlingPåVentAlert />}
                         <SettPåVentSak
                             statusPåVentRedigering={statusPåVentRedigering}
                             settStatusPåVentRedigering={settStatusPåVentRedigering}

--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -46,7 +46,7 @@ const BehandlingTabsInnhold = () => {
 
     const path = useLocation().pathname.split('/')[3];
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
-    const [harKjørelisteBehandlingPåVent, settHarKjørelisteBehandlingPåVent] = useState(false);
+    const [harÅpenKjørelisteBehandling, settHarÅpenKjørelisteBehandling] = useState(false);
 
     const harRammevedtak =
         rammevedtakRessurs.status === RessursStatus.SUKSESS &&
@@ -74,13 +74,13 @@ const BehandlingTabsInnhold = () => {
             behandling.type === BehandlingType.REVURDERING &&
             erDagligReise(behandling.stønadstype)
         ) {
-            request<boolean, null>(`/api/sak/behandling/${behandling.id}/kjoreliste-pa-vent`).then(
-                (res) => {
-                    if (res.status === 'SUKSESS') {
-                        settHarKjørelisteBehandlingPåVent(res.data);
-                    }
+            request<boolean, null>(
+                `/api/sak/behandling/${behandling.id}/apen-kjorelistebehandling`
+            ).then((res) => {
+                if (res.status === 'SUKSESS') {
+                    settHarÅpenKjørelisteBehandling(res.data);
                 }
-            );
+            });
         }
     }, [behandling.id, behandling.type, behandling.stønadstype, request]);
 
@@ -142,7 +142,7 @@ const BehandlingTabsInnhold = () => {
                                 Mulighet for å saksbehandle er skrudd av
                             </Alert>
                         )}
-                        {harKjørelisteBehandlingPåVent && <KjørelisteBehandlingPåVentAlert />}
+                        {harÅpenKjørelisteBehandling && <KjørelisteBehandlingPåVentAlert />}
                         <SettPåVentSak
                             statusPåVentRedigering={statusPåVentRedigering}
                             settStatusPåVentRedigering={settStatusPåVentRedigering}

--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -22,6 +22,7 @@ import { useNavigateUtenSjekkForUlagredeKomponenter } from '../../hooks/useNavig
 import DataViewer from '../../komponenter/DataViewer';
 import { SettPåVentSak } from '../../komponenter/SettPåVent/SettPåVentContainer';
 import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
+import { BehandlingType } from '../../typer/behandling/behandlingType';
 import { RessursStatus } from '../../typer/ressurs';
 import { Toast } from '../../typer/toast';
 
@@ -121,9 +122,10 @@ const BehandlingTabsInnhold = () => {
                                 Mulighet for å saksbehandle er skrudd av
                             </Alert>
                         )}
-                        {behandling.harÅpenKjørelistebehandling && (
-                            <KjørelisteBehandlingPåVentAlert />
-                        )}
+                        {behandling.type === BehandlingType.REVURDERING &&
+                            behandling.harÅpenKjørelistebehandling && (
+                                <KjørelisteBehandlingPåVentAlert />
+                            )}
                         <SettPåVentSak
                             statusPåVentRedigering={statusPåVentRedigering}
                             settStatusPåVentRedigering={settStatusPåVentRedigering}

--- a/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
+++ b/src/frontend/Sider/Behandling/BehandlingTabsInnhold.tsx
@@ -22,18 +22,13 @@ import { useNavigateUtenSjekkForUlagredeKomponenter } from '../../hooks/useNavig
 import DataViewer from '../../komponenter/DataViewer';
 import { SettPåVentSak } from '../../komponenter/SettPåVent/SettPåVentContainer';
 import { Sticky } from '../../komponenter/Visningskomponenter/Sticky';
-import { Stønadstype } from '../../typer/behandling/behandlingTema';
-import { BehandlingType } from '../../typer/behandling/behandlingType';
 import { RessursStatus } from '../../typer/ressurs';
 import { Toast } from '../../typer/toast';
-
-const erDagligReise = (stønadstype: Stønadstype) =>
-    stønadstype === Stønadstype.DAGLIG_REISE_TSO || stønadstype === Stønadstype.DAGLIG_REISE_TSR;
 
 const BehandlingTabsInnhold = () => {
     const navigate = useNavigate();
     const navigateUtenSjekk = useNavigateUtenSjekkForUlagredeKomponenter();
-    const { settToast, request } = useApp();
+    const { settToast } = useApp();
     const {
         behandling,
         behandlingFakta,
@@ -46,7 +41,6 @@ const BehandlingTabsInnhold = () => {
 
     const path = useLocation().pathname.split('/')[3];
     const [statusPåVentRedigering, settStatusPåVentRedigering] = useState(false);
-    const [harÅpenKjørelisteBehandling, settHarÅpenKjørelisteBehandling] = useState(false);
 
     const harRammevedtak =
         rammevedtakRessurs.status === RessursStatus.SUKSESS &&
@@ -68,21 +62,6 @@ const BehandlingTabsInnhold = () => {
         }
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [behandling.steg, harRammevedtak]);
-
-    useEffect(() => {
-        if (
-            behandling.type === BehandlingType.REVURDERING &&
-            erDagligReise(behandling.stønadstype)
-        ) {
-            request<boolean, null>(
-                `/api/sak/behandling/${behandling.id}/apen-kjorelistebehandling`
-            ).then((res) => {
-                if (res.status === 'SUKSESS') {
-                    settHarÅpenKjørelisteBehandling(res.data);
-                }
-            });
-        }
-    }, [behandling.id, behandling.type, behandling.stønadstype, request]);
 
     const håndterFaneBytte = (nyFane: FanePath) => {
         if (!faneErLåst(behandling, nyFane)) {
@@ -142,7 +121,9 @@ const BehandlingTabsInnhold = () => {
                                 Mulighet for å saksbehandle er skrudd av
                             </Alert>
                         )}
-                        {harÅpenKjørelisteBehandling && <KjørelisteBehandlingPåVentAlert />}
+                        {behandling.harÅpenKjørelistebehandling && (
+                            <KjørelisteBehandlingPåVentAlert />
+                        )}
                         <SettPåVentSak
                             statusPåVentRedigering={statusPåVentRedigering}
                             settStatusPåVentRedigering={settStatusPåVentRedigering}

--- a/src/frontend/Sider/Behandling/Felles/KjørelisteBehandlingPåVentAlert.tsx
+++ b/src/frontend/Sider/Behandling/Felles/KjørelisteBehandlingPåVentAlert.tsx
@@ -4,7 +4,7 @@ import { Alert } from '@navikt/ds-react';
 
 export const KjørelisteBehandlingPåVentAlert: React.FC = () => (
     <Alert variant="warning" size="small">
-        <strong>Det finnes en kjørelistebehandling på vent.</strong> Denne må behandles før det kan
+        <strong>Det finnes en åpen kjørelistebehandling.</strong> Denne må behandles før det kan
         gjøres en revurdering.
     </Alert>
 );

--- a/src/frontend/Sider/Behandling/Felles/KjørelisteBehandlingPåVentAlert.tsx
+++ b/src/frontend/Sider/Behandling/Felles/KjørelisteBehandlingPåVentAlert.tsx
@@ -1,0 +1,10 @@
+import React from 'react';
+
+import { Alert } from '@navikt/ds-react';
+
+export const KjørelisteBehandlingPåVentAlert: React.FC = () => (
+    <Alert variant="warning" size="small">
+        <strong>Det finnes en kjørelistebehandling på vent.</strong> Denne må behandles før det kan
+        gjøres en revurdering.
+    </Alert>
+);

--- a/src/frontend/Sider/Behandling/Totrinnskontroll/typer.ts
+++ b/src/frontend/Sider/Behandling/Totrinnskontroll/typer.ts
@@ -39,6 +39,7 @@ export enum ÅrsakUnderkjent {
     VEDTAKSBREV = 'VEDTAKSBREV',
     FEIL_I_UTGIFTER = 'FEIL_I_UTGIFTER',
     RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER = 'RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER',
+    BEHANDLE_KJØRELISTE_PÅ_VENT = 'BEHANDLE_KJØRELISTE_PÅ_VENT',
 }
 
 export const årsakUnderkjentTilTekst: Record<ÅrsakUnderkjent, string> = {
@@ -47,6 +48,7 @@ export const årsakUnderkjentTilTekst: Record<ÅrsakUnderkjent, string> = {
     VEDTAKSBREV: 'Vedtaksbrev',
     FEIL_I_UTGIFTER: 'Feil i utgifter',
     RETUR_ETTER_ØNSKE_FRA_SAKSBEHANDLER: 'Retur etter ønske fra saksbehandler',
+    BEHANDLE_KJØRELISTE_PÅ_VENT: 'Behandle kjøreliste på vent',
 };
 
 export interface SendTilBeslutterRequest {

--- a/src/frontend/komponenter/SettPåVent/typer.ts
+++ b/src/frontend/komponenter/SettPåVent/typer.ts
@@ -43,6 +43,7 @@ export enum ÅrsakSettPåVent {
     BEKREFTE_DELTAKELSE_KVP = 'BEKREFTE_DELTAKELSE_KVP',
     ANNET = 'ANNET',
     AVVENTER_OPPSTART_TILTAK = 'AVVENTER_OPPSTART_TILTAK',
+    BEHANDLE_KJØRELISTE_PÅ_VENT = 'BEHANDLE_KJØRELISTE_PÅ_VENT',
 }
 
 export const årsakTilTekst: Record<ÅrsakSettPåVent, string> = {
@@ -56,6 +57,7 @@ export const årsakTilTekst: Record<ÅrsakSettPåVent, string> = {
     BEKREFTE_DELTAKELSE_KVP: 'Bekrefte deltakelse KVP',
     ANNET: 'Annet',
     AVVENTER_OPPSTART_TILTAK: 'Avventer oppstart tiltak',
+    BEHANDLE_KJØRELISTE_PÅ_VENT: 'Behandle kjøreliste på vent',
 };
 
 const årsaker: Record<SettPåVentContext, Record<ÅrsakSettPåVent, boolean>> = {
@@ -69,6 +71,7 @@ const årsaker: Record<SettPåVentContext, Record<ÅrsakSettPåVent, boolean>> =
         [ÅrsakSettPåVent.REGISTRERING_AV_UTDANNING]: true,
         [ÅrsakSettPåVent.BEKREFTE_DELTAKELSE_KVP]: false,
         [ÅrsakSettPåVent.AVVENTER_OPPSTART_TILTAK]: false,
+        [ÅrsakSettPåVent.BEHANDLE_KJØRELISTE_PÅ_VENT]: true,
         [ÅrsakSettPåVent.ANNET]: true,
     },
     SAK_TSR: {
@@ -81,6 +84,7 @@ const årsaker: Record<SettPåVentContext, Record<ÅrsakSettPåVent, boolean>> =
         [ÅrsakSettPåVent.REGISTRERING_AV_UTDANNING]: false,
         [ÅrsakSettPåVent.BEKREFTE_DELTAKELSE_KVP]: true,
         [ÅrsakSettPåVent.AVVENTER_OPPSTART_TILTAK]: true,
+        [ÅrsakSettPåVent.BEHANDLE_KJØRELISTE_PÅ_VENT]: true,
         [ÅrsakSettPåVent.ANNET]: true,
     },
     KLAGE: {
@@ -93,6 +97,7 @@ const årsaker: Record<SettPåVentContext, Record<ÅrsakSettPåVent, boolean>> =
         [ÅrsakSettPåVent.REGISTRERING_AV_UTDANNING]: true,
         [ÅrsakSettPåVent.BEKREFTE_DELTAKELSE_KVP]: false,
         [ÅrsakSettPåVent.AVVENTER_OPPSTART_TILTAK]: false,
+        [ÅrsakSettPåVent.BEHANDLE_KJØRELISTE_PÅ_VENT]: false,
         [ÅrsakSettPåVent.ANNET]: true,
     },
 };
@@ -121,6 +126,7 @@ export const årsakTilFrist: Record<ÅrsakSettPåVent, number | undefined> = {
     REGISTRERING_AV_UTDANNING: EN_UKE,
     BEKREFTE_DELTAKELSE_KVP: EN_UKE,
     AVVENTER_OPPSTART_TILTAK: undefined,
+    BEHANDLE_KJØRELISTE_PÅ_VENT: undefined,
     ANNET: undefined,
 };
 

--- a/src/frontend/typer/behandling/behandling.ts
+++ b/src/frontend/typer/behandling/behandling.ts
@@ -24,6 +24,7 @@ export interface Behandling {
     stønadstype: Stønadstype;
     vedtaksdato?: string;
     nyeOpplysningerMetadata?: NyeOpplysningerMetadata;
+    harÅpenKjørelistebehandling: boolean;
     tilordnetSaksbehandler: TilordnetSaksbehandlerDto;
 }
 


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Hvis det er en kjørelistebehandling på vent mens man gjør et opphør klarer vi ikke å behandle denne kjørelista etter på. Vi vil derfor hindre saksbehandler i å gjøre et opphør hvis det er en kjørelistebehandling på vent.

* Hindrer send til beslutter hvis kjørelistebehandling på vent
* Hindrer beslutt vedtak hvis kjørelistebehandling på vent
* Varsler saksbehandler hvis kjørelistebehandling på vent
* Lagt til sett på vent årsak: Behandle kjørelisite
* Lagt til underkjenn årsak: Behandle kjøreliste

<img width="1084" height="347" alt="image" src="https://github.com/user-attachments/assets/0a12ea68-eeb6-479d-bd7e-e5559004ae51" />
<img width="549" height="342" alt="image" src="https://github.com/user-attachments/assets/13d8971d-2677-4e3c-9d68-c6ce593c4841" />
