### PR TITLE
Legg til fane for tilbakekrevingshendelser i venstremenyen

### DIFF
--- a/src/frontend/Sider/Behandling/Venstremeny/Tilbakekreving/Tilbakekreving.module.css
+++ b/src/frontend/Sider/Behandling/Venstremeny/Tilbakekreving/Tilbakekreving.module.css
@@ -1,0 +1,4 @@
+.hendelse {
+    border-left: 4px solid var(--ax-border-accent);
+    padding-left: 0.75rem;
+}

--- a/src/frontend/Sider/Behandling/Venstremeny/Tilbakekreving/Tilbakekreving.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Tilbakekreving/Tilbakekreving.tsx
@@ -1,0 +1,81 @@
+import React from 'react';
+
+import { BodyShort, Detail, Label, Link, VStack } from '@navikt/ds-react';
+
+import styles from './Tilbakekreving.module.css';
+import { tilbakekrevingstatusTilTekst } from './typer';
+import { useBehandling } from '../../../../context/BehandlingContext';
+import { useTilbakekrevingHendelser } from '../../../../hooks/useTilbakekrevingHendelser';
+import DataViewer from '../../../../komponenter/DataViewer';
+import {
+    formaterIsoDato,
+    formaterIsoDatoTidKort,
+    formaterIsoPeriode,
+} from '../../../../utils/dato';
+import {
+    kronerMedTusenSkilleEllerStrek,
+    tekstMedFallback,
+} from '../../../../utils/tekstformatering';
+
+const Tilbakekreving: React.FC = () => {
+    const { behandling } = useBehandling();
+    const { tilbakekrevingHendelser } = useTilbakekrevingHendelser(behandling.id);
+
+    return (
+        <DataViewer type={'tilbakekrevingshendelser'} response={{ tilbakekrevingHendelser }}>
+            {({ tilbakekrevingHendelser }) => {
+                if (tilbakekrevingHendelser.length === 0) {
+                    return <BodyShort>Ingen tilbakekrevingshendelser</BodyShort>;
+                }
+
+                const saksbehandlingURL = tilbakekrevingHendelser.find(
+                    (hendelse) => hendelse.saksbehandlingURL
+                )?.saksbehandlingURL;
+
+                return (
+                    <VStack gap="space-16">
+                        {saksbehandlingURL && (
+                            <Link href={saksbehandlingURL} target="_blank">
+                                Gå til tilbakekrevingsbehandling
+                            </Link>
+                        )}
+                        {tilbakekrevingHendelser.map((hendelse, index) => (
+                            <div className={styles.hendelse} key={index}>
+                                <Label size="small">
+                                    {tekstMedFallback(
+                                        tilbakekrevingstatusTilTekst,
+                                        hendelse.behandlingstatus
+                                    )}
+                                </Label>
+                                <Detail>
+                                    {formaterIsoDatoTidKort(hendelse.hendelseOpprettet)}
+                                </Detail>
+                                <BodyShort size="small">
+                                    Feilutbetalt:{' '}
+                                    {kronerMedTusenSkilleEllerStrek(
+                                        hendelse.totaltFeilutbetaltBeløp
+                                    )}
+                                </BodyShort>
+                                <BodyShort size="small">
+                                    Periode:{' '}
+                                    {formaterIsoPeriode(
+                                        hendelse.tilbakekrevingFom,
+                                        hendelse.tilbakekrevingTom
+                                    )}
+                                </BodyShort>
+                                {hendelse.varselSendtTidspunkt && (
+                                    <BodyShort size="small">
+                                        Varsel sendt:{' '}
+                                        {formaterIsoDato(hendelse.varselSendtTidspunkt)}
+                                    </BodyShort>
+                                )}
+                            </div>
+                        ))}
+                    </VStack>
+                );
+            }}
+        </DataViewer>
+    );
+};
+
+export default Tilbakekreving;

--- a/src/frontend/Sider/Behandling/Venstremeny/Tilbakekreving/typer.ts
+++ b/src/frontend/Sider/Behandling/Venstremeny/Tilbakekreving/typer.ts
@@ -1,0 +1,19 @@
+export interface TilbakekrevingHendelse {
+    hendelseOpprettet: string;
+    sakOpprettet: string;
+    varselSendtTidspunkt?: string;
+    behandlingstatus: string;
+    totaltFeilutbetaltBeløp: number;
+    tilbakekrevingFom: string;
+    tilbakekrevingTom: string;
+    tilbakekrevingBehandlingId: string;
+    saksbehandlingURL?: string;
+}
+
+export const tilbakekrevingstatusTilTekst: Record<string, string> = {
+    OPPRETTET: 'Opprettet',
+    TIL_BEHANDLING: 'Til behandling',
+    TIL_FORHÅNDSVARSEL: 'Til forhåndsvarsel',
+    TIL_GODKJENNING: 'Til godkjenning',
+    AVSLUTTET: 'Avsluttet',
+};

--- a/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
+++ b/src/frontend/Sider/Behandling/Venstremeny/Venstremeny.tsx
@@ -6,12 +6,14 @@ import { BehandlingOppsummering } from './BehandlingOppsummering/BehandlingOppsu
 import Dokumentoversikt from './Dokumentoversikt/Dokumentoversikt';
 import Historikk from './Historikk/Historikk';
 import { OppsummeringSøknad } from './Oppsummering/OppsummeringSøknad';
+import Tilbakekreving from './Tilbakekreving/Tilbakekreving';
 import styles from './Venstremeny.module.css';
+import { useBehandling } from '../../../context/BehandlingContext';
 import { TilordnetSaksbehandlerVenstremeny } from '../../../komponenter/TilordnetSaksbehandler/TilordnetSaksbehandlerVenstremeny';
 import { Sticky } from '../../../komponenter/Visningskomponenter/Sticky';
 import Totrinnskontroll from '../Totrinnskontroll/Totrinnskontroll';
 
-const tabs = [
+const standardTabs = [
     {
         value: 'søknaden',
         label: 'Søknaden',
@@ -29,7 +31,19 @@ const tabs = [
     },
 ];
 
+const tilbakekrevingTab = {
+    value: 'tilbakekreving',
+    label: 'Tilbakekreving',
+    komponent: <Tilbakekreving />,
+};
+
 const VenstreMeny: React.FC = () => {
+    const { behandling } = useBehandling();
+
+    const tabs = behandling.harTilbakekrevingSak
+        ? [...standardTabs, tilbakekrevingTab]
+        : standardTabs;
+
     return (
         <div className={styles.container}>
             <VStack padding="space-16" gap={'space-16'}>

--- a/src/frontend/hooks/useTilbakekrevingHendelser.ts
+++ b/src/frontend/hooks/useTilbakekrevingHendelser.ts
@@ -1,0 +1,31 @@
+import { useCallback, useEffect, useState } from 'react';
+
+import { useApp } from '../context/AppContext';
+import { TilbakekrevingHendelse } from '../Sider/Behandling/Venstremeny/Tilbakekreving/typer';
+import { byggTomRessurs, Ressurs } from '../typer/ressurs';
+
+interface UseTilbakekrevingHendelserResponse {
+    tilbakekrevingHendelser: Ressurs<TilbakekrevingHendelse[]>;
+    hentTilbakekrevingHendelser: () => void;
+}
+
+export const useTilbakekrevingHendelser = (
+    behandlingId: string
+): UseTilbakekrevingHendelserResponse => {
+    const { request } = useApp();
+
+    const [tilbakekrevingHendelser, settTilbakekrevingHendelser] =
+        useState<Ressurs<TilbakekrevingHendelse[]>>(byggTomRessurs());
+
+    const hentTilbakekrevingHendelser = useCallback(() => {
+        request<TilbakekrevingHendelse[], null>(
+            `/api/sak/tilbakekreving/${behandlingId}/hendelser`
+        ).then(settTilbakekrevingHendelser);
+    }, [request, behandlingId]);
+
+    useEffect(() => {
+        hentTilbakekrevingHendelser();
+    }, [hentTilbakekrevingHendelser]);
+
+    return { tilbakekrevingHendelser, hentTilbakekrevingHendelser };
+};

--- a/src/frontend/typer/behandling/behandling.ts
+++ b/src/frontend/typer/behandling/behandling.ts
@@ -26,6 +26,7 @@ export interface Behandling {
     nyeOpplysningerMetadata?: NyeOpplysningerMetadata;
     harÅpenKjørelistebehandling: boolean;
     tilordnetSaksbehandler: TilordnetSaksbehandlerDto;
+    harTilbakekrevingSak: boolean;
 }
 
 export interface BehandlingForJournalføring {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Legger til visning av tilbakekrevingshendelser i vesntremenyen. Er i utgangspunktet kun tiltenkt brukt ifbm testing da jeg er blitt ganske lei av å slå opp i databasen for å se hva som finnes av tilbakekrevingshendelser 🙃 

<img width="754" height="768" alt="image" src="https://github.com/user-attachments/assets/d812099f-7d8f-4925-b4e8-b3554e66e25f" />


- Fanen vises kun når behandling.harTilbakekrevingSak er true.
- Ny hook useTilbakekrevingHendelser henter hendelsene fra /api/sak/tilbakekreving/{id}/hendelser (kun når fanen er synlig).
- Hver hendelse viser status, tidspunkt, feilutbetalt beløp, periode og evt. når varsel ble sendt.
- Lenke til tilbakekrevingsbehandlingen (saksbehandlingURL) vises én gang øverst i fanen når den er satt.
- Behandling-typen utvides med harTilbakekrevingSak.
