### PR TITLE
legg til varseltekst dersom SH behandler enslig forsørger som målgruppe

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/EndreMålgruppe.tsx
@@ -12,6 +12,7 @@ import {
     resettMålgruppe,
 } from './utils';
 import { MålgruppeValidering, validerMålgruppe } from './valideringMålgruppe';
+import { VarselOvergangsstønad } from './VarselOvergangsstønad';
 import { useBehandling } from '../../../../context/BehandlingContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { FormErrors, isValid } from '../../../../hooks/felles/useFormState';
@@ -160,6 +161,8 @@ const EndreMålgruppe: React.FC<{
 
     const erMålgruppeSomStøttes = form.type !== MålgruppeType.GJENLEVENDE_GAMMELT_REGELVERK;
 
+    const skalViseAdvarselOmRegelendringer = form.type === MålgruppeType.OVERGANGSSTØNAD;
+
     return (
         <ResultatOgStatusKort periode={målgruppe} redigeres>
             <div className={styles.feltContainer}>
@@ -193,6 +196,7 @@ const EndreMålgruppe: React.FC<{
                     feil={vilkårsperiodeFeil?.begrunnelse}
                 />
             )}
+            {skalViseAdvarselOmRegelendringer && <VarselOvergangsstønad />}
             <HStack gap="space-16">
                 {erMålgruppeSomStøttes && (
                     <Button size="xsmall" onClick={lagre}>

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/Målgruppe.tsx
@@ -7,6 +7,7 @@ import EndreMålgruppe from './EndreMålgruppe';
 import { MålgruppeHjelpetekst } from './MålgruppeHjelpetekst';
 import { MålgruppeKort } from './MålgruppeKort';
 import RegisterYtelser from './RegisterYtelser';
+import { VarselOvergangsstønad } from './VarselOvergangsstønad';
 import { useApp } from '../../../../context/AppContext';
 import { useInngangsvilkår } from '../../../../context/InngangsvilkårContext';
 import { useSteg } from '../../../../context/StegContext';
@@ -19,6 +20,7 @@ import {
     lenkerParagrafMålgruppe,
     lenkerRundskrivMålgruppe,
 } from '../../lenker';
+import { MålgruppeType } from '../typer/vilkårperiode/målgruppe';
 import {
     VilkårperioderGrunnlag,
     YtelseGrunnlagPeriode,
@@ -78,6 +80,10 @@ const Målgruppe: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = 
         }
     }, [feilmelding]);
 
+    const skalViseAdvarselOmRegelendringer =
+        målgrupper.some((målgruppe) => målgruppe.type === MålgruppeType.OVERGANGSSTØNAD) &&
+        radSomRedigeres === undefined;
+
     return (
         <VilkårPanel
             ikon={<CardIcon />}
@@ -122,6 +128,8 @@ const Målgruppe: React.FC<{ grunnlag: VilkårperioderGrunnlag | undefined }> = 
                             />
                         </div>
                     )}
+
+                    {skalViseAdvarselOmRegelendringer && <VarselOvergangsstønad />}
 
                     <Feilmelding ref={feilmeldingRef} feil={feilmelding} />
 

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/VarselOvergangsstønad.tsx
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/Målgruppe/VarselOvergangsstønad.tsx
@@ -1,0 +1,22 @@
+import React from 'react';
+
+import { Alert, VStack, BodyShort } from '@navikt/ds-react';
+
+export const VarselOvergangsstønad = () => {
+    return (
+        <Alert variant="info" size="small">
+            <VStack gap="space-8">
+                <BodyShort size="small">
+                    Hvis personen har rett til overgangsstønad etter de nye reglene i ftrl kap. 15
+                    (f.o.m. 1. juli 2026), har personen ikke rett til tilleggsstønader. Se
+                    brukermanualen for informasjon om hvordan sakene skal behandles.
+                </BodyShort>
+                <BodyShort size="small">
+                    Hvis personen har rett til overgangsstønad etter tidligere regler i ftrl kap. 15
+                    (t.o.m. 30. juni 2026), eller etter overgangsreglene, kan personen ha rett til
+                    tilleggsstønader. Disse sakene behandles som tidligere.
+                </BodyShort>
+            </VStack>
+        </Alert>
+    );
+};

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/målgruppe.ts
@@ -31,7 +31,7 @@ export const MålgruppeTypeTilTekst: Record<MålgruppeType, string> = {
     AAP: 'AAP',
     UFØRETRYGD: 'Uføretrygd',
     OMSTILLINGSSTØNAD: 'Omstillingsstønad',
-    OVERGANGSSTØNAD: 'Overgangsstønad',
+    OVERGANGSSTØNAD: 'Overgangsstønad - (tidl. kap. 15/overgangsregler)',
     NEDSATT_ARBEIDSEVNE: 'Nedsatt arbeidsevne',
     SYKEPENGER_100_PROSENT: '100% sykepenger',
     INGEN_MÅLGRUPPE: 'Ingen målgruppe',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Nye lovendringer gjør at overgangsstønader ikke gir rett til støtte, og dette bør gjøres tydelig for saksbehandlere så det ikke gjøres feil ettersom lovendringen er fersk.