### PR TITLE
Gjør slettede dager om til read-only i redigeringsmodus da det ikke skal være mulig å sende disse inn

### DIFF
--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/RedigerAvklartDag.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/RedigerAvklartDag.tsx
@@ -1,6 +1,6 @@
 import React, { FC } from 'react';
 
-import { Checkbox, CheckboxGroup, Textarea, TextField } from '@navikt/ds-react';
+import { Checkbox, CheckboxGroup, Label, Textarea, TextField } from '@navikt/ds-react';
 
 import { FormErrors } from '../../../../../hooks/felles/useFormState';
 import { GodkjentGjennomførtKjøring, RedigerbarAvklartDag } from '../../../../../typer/kjøreliste';
@@ -40,25 +40,30 @@ export const RedigerAvklartDag: FC<{
 
     return (
         <div className={styles.høyreGridRedigering}>
-            <CheckboxGroup legend="Status" hideLegend error={feil?.godkjentGjennomførtKjøring}>
-                <Checkbox
-                    size="small"
-                    disabled={erSlettetDagFraRammevedtak}
-                    indeterminate={
-                        dag.godkjentGjennomførtKjøring === GodkjentGjennomførtKjøring.IKKE_VURDERT
-                    }
-                    checked={dag.godkjentGjennomførtKjøring === GodkjentGjennomførtKjøring.JA}
-                    data-color={
-                        dag.godkjentGjennomførtKjøring === GodkjentGjennomførtKjøring.IKKE_VURDERT
-                            ? 'neutral'
-                            : undefined
-                    }
-                    onChange={(e) => oppdaterGodkjentGjennomførtKjøring(e.target.checked)}
-                    error={!!feil?.godkjentGjennomførtKjøring}
-                >
-                    {godkjentGjennomførtKjøringTilTekst[dag.godkjentGjennomførtKjøring]}
-                </Checkbox>
-            </CheckboxGroup>
+            {erSlettetDagFraRammevedtak ? (
+                <Label size="small">Slettet</Label>
+            ) : (
+                <CheckboxGroup legend="Status" hideLegend error={feil?.godkjentGjennomførtKjøring}>
+                    <Checkbox
+                        size="small"
+                        indeterminate={
+                            dag.godkjentGjennomførtKjøring ===
+                            GodkjentGjennomførtKjøring.IKKE_VURDERT
+                        }
+                        checked={dag.godkjentGjennomførtKjøring === GodkjentGjennomførtKjøring.JA}
+                        data-color={
+                            dag.godkjentGjennomførtKjøring ===
+                            GodkjentGjennomførtKjøring.IKKE_VURDERT
+                                ? 'neutral'
+                                : undefined
+                        }
+                        onChange={(e) => oppdaterGodkjentGjennomførtKjøring(e.target.checked)}
+                        error={!!feil?.godkjentGjennomførtKjøring}
+                    >
+                        {godkjentGjennomførtKjøringTilTekst[dag.godkjentGjennomførtKjøring]}
+                    </Checkbox>
+                </CheckboxGroup>
+            )}
 
             <TextField
                 label="Parkeringsutgift"

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/RedigerAvklartDag.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/Dag/RedigerAvklartDag.tsx
@@ -11,9 +11,10 @@ import styles from '../UkeInnhold.module.css';
 
 export const RedigerAvklartDag: FC<{
     dag: RedigerbarAvklartDag;
+    erSlettetDagFraRammevedtak: boolean;
     oppdaterDag: (dag: RedigerbarAvklartDag) => void;
     feil: FormErrors<RedigerbarAvklartDag> | undefined;
-}> = ({ dag, oppdaterDag, feil }) => {
+}> = ({ dag, erSlettetDagFraRammevedtak, oppdaterDag, feil }) => {
     const oppdaterParkeringsutgift = (verdi: string) => {
         oppdaterDag({
             ...dag,
@@ -42,6 +43,7 @@ export const RedigerAvklartDag: FC<{
             <CheckboxGroup legend="Status" hideLegend error={feil?.godkjentGjennomførtKjøring}>
                 <Checkbox
                     size="small"
+                    disabled={erSlettetDagFraRammevedtak}
                     indeterminate={
                         dag.godkjentGjennomførtKjøring === GodkjentGjennomførtKjøring.IKKE_VURDERT
                     }
@@ -62,6 +64,7 @@ export const RedigerAvklartDag: FC<{
                 label="Parkeringsutgift"
                 hideLabel
                 size="small"
+                disabled={erSlettetDagFraRammevedtak}
                 value={dag.parkeringsutgift ? tilHeltall(dag.parkeringsutgift) : ''}
                 onChange={(e) => oppdaterParkeringsutgift(e.target.value)}
                 error={feil?.parkeringsutgift}
@@ -71,6 +74,7 @@ export const RedigerAvklartDag: FC<{
                 label="Kommentar"
                 hideLabel
                 size="small"
+                disabled={erSlettetDagFraRammevedtak}
                 resize
                 minRows={1}
                 value={dag.begrunnelse || ''}

--- a/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
+++ b/src/frontend/Sider/Behandling/Kjøreliste/Reisevurdering/UkeInnhold.tsx
@@ -161,6 +161,11 @@ export const UkeInnhold: FC<{
                                         redigerbareDager.find((dag2) => dag2.dato === dag.dato) ||
                                         tomRedigerbarAvklartDag(dag.dato)
                                     }
+                                    erSlettetDagFraRammevedtak={
+                                        dag.erDagSlettet ||
+                                        dag.avklartDag?.avklartKjørtDagStatus ===
+                                            AvklartKjørtDagStatus.SLETTET
+                                    }
                                     oppdaterDag={oppdaterDag}
                                     feil={
                                         valideringsfeilForDager &&


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Her et case hvor bruker tidligere har fått innvilget dager, som nå har blitt opphørt. Dagene som er slettet er da read-only:

<img width="1286" height="523" alt="Skjermbilde 2026-08-06 kl  22 26 00" src="https://github.com/user-attachments/assets/080025ac-0698-4aad-bd22-bda8a5fece6c" />

Bør disse slettede dagene fortsatt være avhuket som at de dekkes? Redd for det blir litt misvisende? 🤷 

Favro: https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?card=Nav-29825