### PR TITLE
💬 Gi informasjon til saksbehandler hvis ingen nye kjørelister er beregnet

### DIFF
--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/BeregningFaneDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/BeregningFaneDagligReise.tsx
@@ -1,7 +1,7 @@
 import React, { FC, useState } from 'react';
 
 import { CalculatorIcon } from '@navikt/aksel-icons';
-import { Heading, HStack, Switch, VStack } from '@navikt/ds-react';
+import { BodyShort, Heading, HStack, Switch, VStack } from '@navikt/ds-react';
 
 import { DagligReisePrivatBilBeregningsresultatTabell } from './DagligReisePrivatBilBeregningsresultatTabell';
 import { PrivatBilOppsummertBeregning } from './typer';
@@ -31,6 +31,9 @@ const Beregning: FC<{ oppsummertBeregning: PrivatBilOppsummertBeregning }> = ({
 }) => {
     const [visTidligerePerioder, setVisTidligerePerioder] = useState(false);
 
+    const harNyeKjorelister = oppsummertBeregning.reiser.some((reise) =>
+        reise.perioder.some((periode) => !periode.fraTidligereVedtak)
+    );
     const harPerioderFraTidligereVedtak = oppsummertBeregning.reiser.some((reise) =>
         reise.perioder.some((periode) => periode.fraTidligereVedtak)
     );
@@ -53,27 +56,31 @@ const Beregning: FC<{ oppsummertBeregning: PrivatBilOppsummertBeregning }> = ({
                         </Switch>
                     )}
                 </HStack>
-                {oppsummertBeregning.reiser.map((reise) => {
-                    const relevantePerioder = reise.perioder.filter(
-                        (periode) => visTidligerePerioder || !periode.fraTidligereVedtak
-                    );
-                    if (relevantePerioder.length === 0) {
-                        return null;
-                    }
-                    const totaltStønadsbeløp = visTidligerePerioder
-                        ? reise.totaltStønadsbeløpMedPerioderFraForrigeVedtak
-                        : reise.totaltStønadsbeløpUtenPerioderFraForrigeVedtak;
-                    return (
-                        <DagligReisePrivatBilBeregningsresultatTabell
-                            key={reise.reiseId}
-                            oppsummertBeregning={{
-                                ...reise,
-                                perioder: relevantePerioder,
-                                totaltStønadsbeløp,
-                            }}
-                        />
-                    );
-                })}
+                {!harNyeKjorelister ? (
+                    <BodyShort>Ingen nye kjørelister å beregne</BodyShort>
+                ) : (
+                    oppsummertBeregning.reiser.map((reise) => {
+                        const relevantePerioder = reise.perioder.filter(
+                            (periode) => visTidligerePerioder || !periode.fraTidligereVedtak
+                        );
+                        if (relevantePerioder.length === 0) {
+                            return null;
+                        }
+                        const totaltStønadsbeløp = visTidligerePerioder
+                            ? reise.totaltStønadsbeløpMedPerioderFraForrigeVedtak
+                            : reise.totaltStønadsbeløpUtenPerioderFraForrigeVedtak;
+                        return (
+                            <DagligReisePrivatBilBeregningsresultatTabell
+                                key={reise.reiseId}
+                                oppsummertBeregning={{
+                                    ...reise,
+                                    perioder: relevantePerioder,
+                                    totaltStønadsbeløp,
+                                }}
+                            />
+                        );
+                    })
+                )}
             </VStack>
         </Panel>
     );

--- a/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/BeregningFaneDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/VedtakOgBeregning/DagligReise/BeregningFane/BeregningFaneDagligReise.tsx
@@ -31,9 +31,6 @@ const Beregning: FC<{ oppsummertBeregning: PrivatBilOppsummertBeregning }> = ({
 }) => {
     const [visTidligerePerioder, setVisTidligerePerioder] = useState(false);
 
-    const harNyeKjorelister = oppsummertBeregning.reiser.some((reise) =>
-        reise.perioder.some((periode) => !periode.fraTidligereVedtak)
-    );
     const harPerioderFraTidligereVedtak = oppsummertBeregning.reiser.some((reise) =>
         reise.perioder.some((periode) => periode.fraTidligereVedtak)
     );
@@ -56,7 +53,7 @@ const Beregning: FC<{ oppsummertBeregning: PrivatBilOppsummertBeregning }> = ({
                         </Switch>
                     )}
                 </HStack>
-                {!harNyeKjorelister ? (
+                {!visTidligerePerioder && !harPerioderFraTidligereVedtak ? (
                     <BodyShort>Ingen nye kjørelister å beregne</BodyShort>
                 ) : (
                     oppsummertBeregning.reiser.map((reise) => {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨
Tidligere viste beregningsresultatet i beregning fanen for kjørelister et tomt kort hvis det ikke fantes noen kjørelister som ble beregnet. Dette kunne se ut som en feil. Nå gir vi eksplisitt medling om dette.
