### PR TITLE
Vis SB varseltekst ved flere reisedager i stønadsvilkår enn aktivitet

### DIFF
--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTso.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTso.ts
@@ -1,9 +1,15 @@
+import { Aktivitet } from './aktivitet';
 import { SvarJaNei, VilkårPeriodeAktivitet, Vurdering } from './vilkårperiode';
 
 export interface AktivitetDagligReiseTso extends VilkårPeriodeAktivitet {
     kildeId?: string;
     faktaOgVurderinger: AktivitetDagligReiseTsoFaktaOgVurderinger;
 }
+
+export const erAktivitetDagligReiseTso = (
+    aktivitet: Aktivitet
+): aktivitet is AktivitetDagligReiseTso =>
+    aktivitet.faktaOgVurderinger['@type'] === 'AKTIVITET_DAGLIG_REISE_TSO';
 
 export interface AktivitetDagligReiseTsoFaktaOgVurderinger {
     '@type': 'AKTIVITET_DAGLIG_REISE_TSO';

--- a/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr.ts
+++ b/src/frontend/Sider/Behandling/Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr.ts
@@ -1,3 +1,4 @@
+import { Aktivitet } from './aktivitet';
 import { SvarJaNei, VilkårPeriodeAktivitet, Vurdering } from './vilkårperiode';
 import { Kodeverk } from '../../../../../typer/kodeverk';
 
@@ -6,6 +7,11 @@ export interface AktivitetDagligReiseTsr extends VilkårPeriodeAktivitet {
     tiltaksvariant?: Kodeverk;
     faktaOgVurderinger: AktivitetDagligReiseTsrFaktaOgVurderinger;
 }
+
+export const erAktivitetDagligReiseTsr = (
+    aktivitet: Aktivitet
+): aktivitet is AktivitetDagligReiseTsr =>
+    aktivitet.faktaOgVurderinger['@type'] === 'AKTIVITET_DAGLIG_REISE_TSR';
 
 export interface AktivitetDagligReiseTsrFaktaOgVurderinger {
     '@type': 'AKTIVITET_DAGLIG_REISE_TSR';

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/EndreVilkår/EndreFakta/EndreFaktaDagligReise.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { EndreFaktaOffentligTransport } from './EndreFaktaOffentligTransport';
 import { EndreFaktaPrivatBil } from './EndreFaktaPrivatBil';
 import { Aktivitet } from '../../../../Inngangsvilkår/typer/vilkårperiode/aktivitet';
-import { AktivitetDagligReiseTsr } from '../../../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr';
+import { erAktivitetDagligReiseTsr } from '../../../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr';
 import {
     FaktaDagligReise,
     FaktaOffentligTransport,
@@ -38,10 +38,7 @@ export const EndreFaktaDagligReise: React.FC<{
     gjelderTsr,
 }) => {
     const tiltaksvarianter = oppfylteAktiviteter
-        .filter(
-            (aktivitet): aktivitet is AktivitetDagligReiseTsr =>
-                aktivitet.faktaOgVurderinger['@type'] === 'AKTIVITET_DAGLIG_REISE_TSR'
-        )
+        .filter(erAktivitetDagligReiseTsr)
         .map((aktivitet) => aktivitet.tiltaksvariant)
         .filter((tiltaksvariant) => tiltaksvariant != null);
 

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/StønadsvilkårDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/StønadsvilkårDagligReise.tsx
@@ -5,7 +5,7 @@ import { Alert, VStack } from '@navikt/ds-react';
 
 import { KopierVilkårDagligReise } from './EndreVilkår/KopierVilkårDagligReise';
 import { NyttVilkårDagligReise } from './EndreVilkår/NyttVilkårDagligReise';
-import { FaktaPrivatBil } from './typer/faktaDagligReise';
+import { erFaktaPrivatBil } from './typer/faktaDagligReise';
 import { VilkårDagligReise } from './typer/vilkårDagligReise';
 import { VisEllerEndreVilkårDagligReise } from './VisEllerEndreVilkårDagligReise';
 import { useApp } from '../../../../context/AppContext';
@@ -21,8 +21,33 @@ import DataViewer from '../../../../komponenter/DataViewer';
 import { StegKnapp } from '../../../../komponenter/Stegflyt/StegKnapp';
 import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
 import { Steg } from '../../../../typer/behandling/steg';
-import { AktivitetDagligReiseTsoFaktaOgVurderinger } from '../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTso';
-import { AktivitetDagligReiseTsrFaktaOgVurderinger } from '../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr';
+import { Aktivitet } from '../../Inngangsvilkår/typer/vilkårperiode/aktivitet';
+import { erAktivitetDagligReiseTso } from '../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTso';
+import { erAktivitetDagligReiseTsr } from '../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr';
+
+function totaltAntallReisedagerIStønadsvilkår(vilkårsett: VilkårDagligReise[]): number {
+    return vilkårsett
+        .map((vilkår) => vilkår.fakta)
+        .filter(erFaktaPrivatBil)
+        .reduce(
+            (acc, fakta) =>
+                acc +
+                fakta.faktaDelperioder.reduce(
+                    (sum, delperiode) => sum + (delperiode?.reisedagerPerUke || 0),
+                    0
+                ),
+            0
+        );
+}
+
+function totaltAntallReisedagerIAktivitetsperioder(aktiviteter: Aktivitet[]): number {
+    return aktiviteter
+        .filter(
+            (aktivitet) =>
+                erAktivitetDagligReiseTso(aktivitet) || erAktivitetDagligReiseTsr(aktivitet)
+        )
+        .reduce((acc, aktivitet) => acc + (aktivitet.faktaOgVurderinger.aktivitetsdager || 0), 0);
+}
 
 export const StønadsvilkårDagligReise = () => {
     const { behandling } = useBehandling();
@@ -73,7 +98,6 @@ const StønadsvilkårInnhold = () => {
         } else {
             nullstillUlagretKomponent(komponentId);
         }
-        // TODO Hvorfor disabler vi denne? Det er da ganske god kotyme å ha exhaustive deps?
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [redigererVilkårId]);
 
@@ -106,38 +130,9 @@ const StønadsvilkårInnhold = () => {
         avsluttRedigering();
     };
 
-    // Bør logikken finnes et annet sted? Utils eller liknende?
-    const totaltAntallReisedagerIStønadsvilkår = vilkårsett
-        .filter((v) => v.fakta.type === 'PRIVAT_BIL')
-        // TODO Jeg vil ikke gjøre dette. Det bør finnes type guards i stedet for at man trenger å caste som dette.
-        .map((v) => v.fakta as FaktaPrivatBil)
-        .reduce(
-            (acc, fakta) =>
-                acc +
-                fakta.faktaDelperioder.reduce(
-                    (sum, delperiode) => sum + (delperiode?.reisedagerPerUke || 0),
-                    0
-                ),
-            0
-        );
-
-    const totaltAntallReisedagerIAktivitetsperioder = aktiviteter
-        .filter((a) =>
-            ['AKTIVITET_DAGLIG_REISE_TSO', 'AKTIVITET_DAGLIG_REISE_TSR'].includes(
-                a.faktaOgVurderinger['@type']
-            )
-        )
-        .map(
-            // TODO Jeg vil ikke gjøre dette. Det bør finnes type guards i stedet for at man trenger å caste som dette.
-            (a) =>
-                a.faktaOgVurderinger as
-                    | AktivitetDagligReiseTsoFaktaOgVurderinger
-                    | AktivitetDagligReiseTsrFaktaOgVurderinger
-        )
-        .reduce((acc, fakta) => acc + (fakta.aktivitetsdager || 0), 0);
-
     const skalViseAdvarselOmAntallReisedager =
-        totaltAntallReisedagerIStønadsvilkår > totaltAntallReisedagerIAktivitetsperioder;
+        totaltAntallReisedagerIStønadsvilkår(vilkårsett) >
+        totaltAntallReisedagerIAktivitetsperioder(aktiviteter);
 
     return (
         <VilkårPanel tittel={'Daglige reiser'} ikon={<BriefcaseIcon />}>
@@ -165,9 +160,7 @@ const StønadsvilkårInnhold = () => {
 
             {skalViseAdvarselOmAntallReisedager && (
                 <Alert variant="warning" size="small">
-                    {/* Potensielt upresist språk her, eller? */}
-                    Antall reisedager i vilkårsvurderingen er høyere enn antall aktivitetsdager i
-                    aktivitetsperiodene. Vurder om vilkårsvurderingen bør justeres.
+                    Antall reisedager er høyere enn antall aktivitetsdager.
                 </Alert>
             )}
             <NyttVilkårDagligReise

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/StønadsvilkårDagligReise.tsx
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/StønadsvilkårDagligReise.tsx
@@ -1,10 +1,11 @@
 import React, { useEffect, useId } from 'react';
 
 import { BriefcaseIcon } from '@navikt/aksel-icons';
-import { VStack } from '@navikt/ds-react';
+import { Alert, VStack } from '@navikt/ds-react';
 
 import { KopierVilkårDagligReise } from './EndreVilkår/KopierVilkårDagligReise';
 import { NyttVilkårDagligReise } from './EndreVilkår/NyttVilkårDagligReise';
+import { FaktaPrivatBil } from './typer/faktaDagligReise';
 import { VilkårDagligReise } from './typer/vilkårDagligReise';
 import { VisEllerEndreVilkårDagligReise } from './VisEllerEndreVilkårDagligReise';
 import { useApp } from '../../../../context/AppContext';
@@ -20,6 +21,8 @@ import DataViewer from '../../../../komponenter/DataViewer';
 import { StegKnapp } from '../../../../komponenter/Stegflyt/StegKnapp';
 import { VilkårPanel } from '../../../../komponenter/VilkårPanel/VilkårPanel';
 import { Steg } from '../../../../typer/behandling/steg';
+import { AktivitetDagligReiseTsoFaktaOgVurderinger } from '../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTso';
+import { AktivitetDagligReiseTsrFaktaOgVurderinger } from '../../Inngangsvilkår/typer/vilkårperiode/aktivitetDagligReiseTsr';
 
 export const StønadsvilkårDagligReise = () => {
     const { behandling } = useBehandling();
@@ -49,7 +52,7 @@ export const StønadsvilkårDagligReise = () => {
 };
 
 const StønadsvilkårInnhold = () => {
-    const { vilkårsett } = useVilkårDagligReise();
+    const { vilkårsett, aktiviteter } = useVilkårDagligReise();
     const { settUlagretKomponent, nullstillUlagretKomponent } = useApp();
 
     const [vilkårSomKopieres, settVilkårSomKopieres] = React.useState<
@@ -70,6 +73,7 @@ const StønadsvilkårInnhold = () => {
         } else {
             nullstillUlagretKomponent(komponentId);
         }
+        // TODO Hvorfor disabler vi denne? Det er da ganske god kotyme å ha exhaustive deps?
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [redigererVilkårId]);
 
@@ -102,6 +106,39 @@ const StønadsvilkårInnhold = () => {
         avsluttRedigering();
     };
 
+    // Bør logikken finnes et annet sted? Utils eller liknende?
+    const totaltAntallReisedagerIStønadsvilkår = vilkårsett
+        .filter((v) => v.fakta.type === 'PRIVAT_BIL')
+        // TODO Jeg vil ikke gjøre dette. Det bør finnes type guards i stedet for at man trenger å caste som dette.
+        .map((v) => v.fakta as FaktaPrivatBil)
+        .reduce(
+            (acc, fakta) =>
+                acc +
+                fakta.faktaDelperioder.reduce(
+                    (sum, delperiode) => sum + (delperiode?.reisedagerPerUke || 0),
+                    0
+                ),
+            0
+        );
+
+    const totaltAntallReisedagerIAktivitetsperioder = aktiviteter
+        .filter((a) =>
+            ['AKTIVITET_DAGLIG_REISE_TSO', 'AKTIVITET_DAGLIG_REISE_TSR'].includes(
+                a.faktaOgVurderinger['@type']
+            )
+        )
+        .map(
+            // TODO Jeg vil ikke gjøre dette. Det bør finnes type guards i stedet for at man trenger å caste som dette.
+            (a) =>
+                a.faktaOgVurderinger as
+                    | AktivitetDagligReiseTsoFaktaOgVurderinger
+                    | AktivitetDagligReiseTsrFaktaOgVurderinger
+        )
+        .reduce((acc, fakta) => acc + (fakta.aktivitetsdager || 0), 0);
+
+    const skalViseAdvarselOmAntallReisedager =
+        totaltAntallReisedagerIStønadsvilkår > totaltAntallReisedagerIAktivitetsperioder;
+
     return (
         <VilkårPanel tittel={'Daglige reiser'} ikon={<BriefcaseIcon />}>
             {vilkårsett.map((vilkår) => (
@@ -125,6 +162,14 @@ const StønadsvilkårInnhold = () => {
                     )}
                 </React.Fragment>
             ))}
+
+            {skalViseAdvarselOmAntallReisedager && (
+                <Alert variant="warning" size="small">
+                    {/* Potensielt upresist språk her, eller? */}
+                    Antall reisedager i vilkårsvurderingen er høyere enn antall aktivitetsdager i
+                    aktivitetsperiodene. Vurder om vilkårsvurderingen bør justeres.
+                </Alert>
+            )}
             <NyttVilkårDagligReise
                 leggerTilNyttVilkår={redigererVilkårId === 'nytt'}
                 startRedigering={() => startRedigering('nytt')}

--- a/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/typer/faktaDagligReise.ts
+++ b/src/frontend/Sider/Behandling/Stønadsvilkår/DagligReise/typer/faktaDagligReise.ts
@@ -30,6 +30,13 @@ export interface FaktaPrivatBil extends FaktaDagligReise {
     aktivitetType: string | undefined;
 }
 
+export const erFaktaOffentligTransport = (
+    fakta: FaktaDagligReise
+): fakta is FaktaOffentligTransport => fakta.type === 'OFFENTLIG_TRANSPORT';
+
+export const erFaktaPrivatBil = (fakta: FaktaDagligReise): fakta is FaktaPrivatBil =>
+    fakta.type === 'PRIVAT_BIL';
+
 export const typeDagligReiseTilTypeVilkårfakta: Record<TypeDagligReise, TypeVilkårFakta> = {
     OFFENTLIG_TRANSPORT: 'DAGLIG_REISE_OFFENTLIG_TRANSPORT',
     PRIVAT_BIL: 'DAGLIG_REISE_PRIVAT_BIL',


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Det er lett å gjøre feil og legge til flere reisedager i stønadsvilkårene for daglig reise enn bruker egentlig har rett til via aktiviteten deres. Dette bør gjøre det tydelig for SB at den feilen blir gjort, selv om vi ikke låser SB fra å gjøre det.