### PR TITLE
Viser bruker sitt nav-kontor i person-headeren

### DIFF
--- a/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
+++ b/src/frontend/komponenter/PersonHeader/PersonHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 
+import { Buildings3Icon } from '@navikt/aksel-icons';
 import { BodyShort, CopyButton, Heading, HStack, Link } from '@navikt/ds-react';
 
 import styles from './PersonHeader.module.css';
@@ -21,6 +22,18 @@ const PersonHeader: React.FC<{ fagsakPersonId: string }> = ({ fagsakPersonId }) 
                 <Link href={`/person/${fagsakPersonId}`}>{personopplysninger.personIdent}</Link>
                 <CopyButton copyText={personopplysninger.personIdent} size="small" />
             </HStack>
+            {personopplysninger.navKontor && (
+                <>
+                    <BodyShort>|</BodyShort>
+                    <HStack gap="space-4" align="center">
+                        <Buildings3Icon aria-hidden />
+                        <BodyShort>
+                            {personopplysninger.navKontor.enhetId} -{' '}
+                            {personopplysninger.navKontor.navn}
+                        </BodyShort>
+                    </HStack>
+                </>
+            )}
             <BodyShort>|</BodyShort>
             <TagAdressebeskyttelse adressebeskyttelse={personopplysninger.adressebeskyttelse} />
             {personopplysninger.erSkjermet && <SmallWarningTag>Skjermet</SmallWarningTag>}

--- a/src/frontend/typer/personopplysninger.ts
+++ b/src/frontend/typer/personopplysninger.ts
@@ -9,6 +9,12 @@ export interface Personopplysninger {
     vergemål: Vergemål[];
     dødsdato?: string;
     harGeografiskTilknytningUtland: boolean;
+    navKontor?: NavKontor;
+}
+
+export interface NavKontor {
+    enhetId: string;
+    navn: string;
 }
 
 interface Navn {


### PR DESCRIPTION
### Hvorfor er denne endringen nødvendig? ✨

Ønske fra tiltaksenheten. Men legger opp visning for både nay og tiltaksenheten

https://favro.com/organization/98c34fb974ce445eac854de0/4d617346d79341c7fbd9a40a?car

<img width="891" height="146" alt="Skjermbilde 2026-08-13 kl  14 31 29" src="https://github.com/user-attachments/assets/351404cc-788e-4ff2-8ef8-c437908cccc0" />
d=Nav-27705

